### PR TITLE
Revamp cit traverse for non asta

### DIFF
--- a/.claude/skills/anndata-zarr-summary/run.py
+++ b/.claude/skills/anndata-zarr-summary/run.py
@@ -145,6 +145,44 @@ def zstd_decompress(raw: bytes) -> bytes:
     return zstd.ZstdDecompressor().decompress(raw)
 
 
+def decompress_chunk(raw: bytes, meta: dict) -> bytes:
+    """Decompress a chunk using the compressor recorded in array metadata.
+
+    Handles v2 (`_zarray_raw.compressor`) and v3 (`codecs`). Falls back to
+    auto-detection on raw bytes (blosc/zstd/gzip magic) or passthrough.
+    """
+    compressor = None
+    raw_zarray = meta.get("_zarray_raw") if isinstance(meta, dict) else None
+    if raw_zarray and raw_zarray.get("compressor"):
+        compressor = raw_zarray["compressor"]
+    else:
+        for codec in (meta or {}).get("codecs", []) or []:
+            name = codec.get("name") if isinstance(codec, dict) else None
+            if name and name not in ("bytes", "transpose"):
+                compressor = {"id": name, **(codec.get("configuration") or {})}
+                break
+
+    if compressor:
+        cid = (compressor.get("id") or "").lower()
+        if cid in ("blosc", "blosc2", "zstd", "gzip", "lz4", "zlib"):
+            from numcodecs import get_codec
+            cfg = dict(compressor)
+            if cid == "zstd" and "id" not in cfg:
+                cfg["id"] = "zstd"
+            return bytes(get_codec(cfg).decode(raw))
+
+    # No compressor recorded — try magic-byte sniffing.
+    if _looks_zstd(raw):
+        return zstd_decompress(raw)
+    if len(raw) >= 4 and raw[:4] == b"\x02\x01\x21\x01":  # blosc magic v1 (rough)
+        from numcodecs import Blosc
+        return bytes(Blosc().decode(raw))
+    if raw[:2] == b"\x1f\x8b":
+        import gzip
+        return gzip.decompress(raw)
+    return raw
+
+
 def decode_vlen_utf8(blob: bytes) -> list[str]:
     """AnnData zarr vlen-utf8 encoding for string arrays:
     [4-byte LE count][per item: 4-byte LE length, then UTF-8 bytes].
@@ -183,10 +221,10 @@ def num_chunks(shape: list[int], chunk_shape: list[int]) -> int:
     return math.ceil(shape[0] / chunk_shape[0])
 
 
-def decode_codes(chunks: list[bytes], data_type: str, n_cells: int):
+def decode_codes(chunks: list[bytes], data_type: str, n_cells: int, codes_meta: dict | None = None):
     import numpy as np
 
-    pieces = [zstd_decompress(c) if _looks_zstd(c) else c for c in chunks]
+    pieces = [decompress_chunk(c, codes_meta or {}) for c in chunks]
     blob = b"".join(pieces)
     return np.frombuffer(blob, dtype=numpy_dtype_for(data_type))[:n_cells]
 
@@ -246,6 +284,17 @@ def load_column(
         stats["cache_hit"] = True
         return categories, codes, stats
 
+    cats_meta = read_array_meta(base, f"obs/{col}/categories", is_local, fmt)
+    cats_shape = (cats_meta or {}).get("shape") or [0]
+    if not cats_shape or cats_shape[0] == 0:
+        # Empty categorical — no chunk file exists. Return an empty column.
+        categories: list[str] = []
+        codes = np.zeros(n_cells, dtype="<i1")
+        cats_file.write_text(json.dumps(categories))
+        np.save(codes_file, codes)
+        stats["empty"] = True
+        return categories, codes, stats
+
     # categories — always 1 chunk for string arrays in practice
     cats_raw = fetch_bytes(base, f"obs/{col}/categories/{chunk_path(0, fmt)}", is_local)
     if cats_raw is None:
@@ -253,7 +302,7 @@ def load_column(
         cats_raw = fetch_bytes(base, f"obs/{col}/categories/0", is_local)
     if cats_raw is None:
         raise RuntimeError(f"Could not fetch categories chunk for column {col}")
-    categories = decode_vlen_utf8(zstd_decompress(cats_raw))
+    categories = decode_vlen_utf8(decompress_chunk(cats_raw, cats_meta))
     stats["chunks_downloaded"] += 1
 
     # codes
@@ -276,7 +325,7 @@ def load_column(
             chunks[i] = raw
             stats["chunks_downloaded"] += 1
 
-    codes = decode_codes(chunks, codes_meta["data_type"], n_cells)
+    codes = decode_codes(chunks, codes_meta["data_type"], n_cells, codes_meta)
 
     cats_file.write_text(json.dumps(categories))
     np.save(codes_file, codes)

--- a/.claude/skills/local-paper-index/SKILL.md
+++ b/.claude/skills/local-paper-index/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: local-paper-index
-description: Build and query a local ASTA-shape snippet index for a fresh preprint atlas paper not yet indexed in EuropePMC or Semantic Scholar. Use when ASTA snippet_search returns nothing for the atlas DOI and you need quoted evidence from the paper text. Installs the [local-index] extra (~500 MB of MiniLM + paper-qa).
+description: Build and query a local ASTA-shape snippet index for a fresh preprint atlas paper not yet indexed in EuropePMC or Semantic Scholar. Use when ASTA snippet_search returns nothing for the atlas DOI and you need quoted evidence from the paper text. Installs the [local-index] extra (~500 MB of MiniLM via sentence-transformers).
 ---
 
 # local-paper-index
@@ -61,5 +61,8 @@ No flag or env var needed; existence of `manifest.json` is the gate.
   the gap for indexed references.
 - Image-based supplementary PDFs aren't OCR'd; supplementary text only enters
   the index if the JATS includes structured tables.
-- Heavy ML stack: pulls in `sentence-transformers` + `paper-qa` + torch. Behind
-  the `[local-index]` optional extra to keep default installs lean.
+- Heavy ML stack: pulls in `sentence-transformers` + torch. Behind the
+  `[local-index]` optional extra to keep default installs lean.
+- The JATS parser is vendored at `src/atlas_chat/atlas_chat/services/_jats_parser.py`
+  (source: Cellular-Semantics/paperqa2_cyberian@4d5d153). Re-sync periodically
+  by `cp` if upstream picks up additional JATS dialect support.

--- a/.claude/skills/local-paper-index/SKILL.md
+++ b/.claude/skills/local-paper-index/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: local-paper-index
+description: Build and query a local ASTA-shape snippet index for a fresh preprint atlas paper not yet indexed in EuropePMC or Semantic Scholar. Use when ASTA snippet_search returns nothing for the atlas DOI and you need quoted evidence from the paper text. Installs the [local-index] extra (~500 MB of MiniLM + paper-qa).
+---
+
+# local-paper-index
+
+When the atlas paper is a fresh bioRxiv preprint, ASTA `snippet_search` scoped
+to the paper returns nothing. This skill builds a project-wide local index
+that emits ASTA-shape snippet objects so the existing
+`_summarize_snippets` / `validate_report` machinery works unchanged.
+
+## When to invoke
+
+- `mcp__Asta_semanticscholar__snippet_search` returns no hits for the atlas DOI.
+- The project's `cell_type_annotations.json` has a recent (≤ 6 months) bioRxiv DOI.
+- `atlas_chat.services.local_snippet_index.has_local_index(project_dir)` is False.
+
+## Build
+
+```bash
+uv run python scripts/setup_local_index.py --project <name> [--doi DOI] [--force]
+```
+
+If `--doi` is omitted, the DOI is read from
+`projects/<name>/cell_type_annotations.json`. Output lives under
+`projects/<name>/local_index/`:
+
+```
+local_index/
+  source/paper.jats.xml         # fetched via EuropePMC → curl_cffi → Playwright
+  chunks/{chunks.jsonl, embeddings.npy, chunks.fulltext.txt}
+  citations/{sentences.jsonl, ref_resolution.json}
+  snippet_index/snippets.json   # ASTA-shape snippet objects
+  manifest.json
+```
+
+Build is idempotent — a re-run short-circuits unless `--force` or the JATS
+SHA256 changed.
+
+## Query
+
+```bash
+uv run python -m atlas_chat.services.local_snippet_index search \
+  --project projects/<name> --query "ILC3 CCL1 PTGDS skin inflammation" -k 10
+```
+
+Returns JSON of ASTA-shape dicts (`snippet`, `paper_id`, `title`, `authors`,
+`year`, `corpus_id`, `score`, `annotations.refMentions`).
+
+## Integration
+
+Once built, the report graph picks the local index up automatically via
+`FanOut._citation_traverse` — runs in parallel with ASTA and merges results.
+No flag or env var needed; existence of `manifest.json` is the gate.
+
+## Limitations
+
+- bioRxiv JATS ref-list quality varies; many references lack DOIs and are
+  therefore unresolvable to CorpusIds. Cited-paper traversal via ASTA covers
+  the gap for indexed references.
+- Image-based supplementary PDFs aren't OCR'd; supplementary text only enters
+  the index if the JATS includes structured tables.
+- Heavy ML stack: pulls in `sentence-transformers` + `paper-qa` + torch. Behind
+  the `[local-index]` optional extra to keep default installs lean.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        # Matches `requires-python = ">= 3.13"` in src/atlas_chat/pyproject.toml.
+        python-version: ["3.13"]
 
     steps:
       - name: Checkout
@@ -33,9 +34,9 @@ jobs:
           uv --version
           which uv
 
-      - name: Install dependencies (workspace)
+      - name: Install dependencies (workspace + local-index extra)
         run: |
-          uv sync --dev --all-packages
+          uv sync --dev --all-packages --extra local-index
           uv pip list
 
       - name: Ruff lint
@@ -45,7 +46,9 @@ jobs:
         run: uv run ruff format --check src/ tests/
 
       - name: Unit tests with coverage
-        run: uv run pytest -m unit --cov --cov-fail-under=60 --cov-report=xml
+        # Threshold tracks `[tool.coverage.report] fail_under` in pyproject.toml
+        # (currently 0 per ROADMAP — ratchet up as tests are added).
+        run: uv run pytest -m unit --cov --cov-report=xml
 
       - name: Integration tests (skipped)
         run: |

--- a/AGENT.md
+++ b/AGENT.md
@@ -126,6 +126,13 @@ These two steps are independent after name resolution. Run them in parallel.
 - Query: `"{label} / {resolved_name} in {scope} {tissue}: location, structure, function, markers"`
 - Depth: 1 (default), configurable up to 3
 
+**Local snippet index (fresh preprints):** if
+`projects/{project}/local_index/manifest.json` exists, the graph also calls
+`services.citation_traverser.traverse_local` in parallel with the ASTA path
+and merges results. Snippets carry `source_method: "local_snippet"`. See the
+`local-paper-index` skill (`.claude/skills/local-paper-index/SKILL.md`) for
+how to build the index when ASTA is blind to the atlas paper.
+
 **Output:**
 - `projects/{project}/traversal_output/{cell_type}/all_summaries.json`
 - `projects/{project}/traversal_output/{cell_type}/paper_catalogue.json`

--- a/docs/preprint_citation_options.md
+++ b/docs/preprint_citation_options.md
@@ -1,0 +1,211 @@
+# Citation traversal for fresh preprints — options
+
+**Problem.** atlas_chat's reporting workflow assumes the atlas paper is in EuropePMC / Semantic Scholar. For a fresh bioRxiv preprint (e.g. Steele et al. 2026, used here), neither is true: `get_pmc_supplemental_material` returns nothing, and ASTA `snippet_search` scoped to the atlas paper has no CorpusId to hit. The pilot reports for the spatial skin atlas worked around this by giving each agent the JATS XML directly, but blockquotes are then atlas-only — referenced literature appears as paraphrased inline cites, not as validated quoted evidence.
+
+This doc surveys options for fixing that, both heavy (build a local snippet index) and light (better orchestration). It also notes which pieces already exist in `~/Documents/GitHub/paperqa2_cyberian`.
+
+---
+
+## What ASTA actually does (and why it can't be reproduced trivially)
+
+`mcp__Asta_semanticscholar__snippet_search` returns: snippets of paragraph-length text from indexed papers, each carrying a `paper.corpusId`, `score`, `section`, and crucially **`annotations.refMentions`** — character-offset spans where a snippet cites another paper, resolved to a CorpusId. That's what lets it answer "give me sentences in cited papers that mention X" downstream.
+
+To replicate locally for a fresh preprint we need three things:
+
+1. Text chunked by section, with stable offsets
+2. Inline citations resolved to canonical IDs (DOI → CorpusId / PMID / PMCID)
+3. Per-chunk relevance scoring (BM25, embedding cosine, or LLM rerank)
+
+Semantic Scholar's lag from bioRxiv post to CorpusId assignment varies — Google Scholar reportedly indexes biorxiv within 2 days, Semantic Scholar tends to be slower (~1–4 weeks, anecdotal). So waiting is sometimes acceptable, but for fresh atlases the workflow needs a local path.
+
+---
+
+## Existing tools
+
+### 1. Allen AI `s2orc-doc2json` ([github](https://github.com/allenai/s2orc-doc2json))
+- `jats2json` parses JATS XML to S2ORC schema (sections, body_text with cite_spans, bib_entries with DOIs)
+- `pdf2json` runs PDF → GROBID → S2ORC
+- Output format is exactly what Semantic Scholar consumes
+- Status: maintained but slow-moving; works fine for biorxiv JATS
+
+### 2. GROBID ([kermitt2/grobid](https://github.com/kermitt2/grobid))
+- Heavyweight ML-based PDF → TEI XML
+- ~0.87–0.90 F1 on PMC/bioRxiv reference extraction
+- Needed only when JATS isn't available (biorxiv gives JATS, so we can skip)
+
+### 3. PaperQA2 ([Future-House/paper-qa](https://github.com/Future-House/paper-qa))
+- RAG over local PDFs with Crossref/Semantic Scholar metadata enrichment
+- Three-phase agent: keyword query → candidate retrieval → chunk embed + rank
+- Citation graph traversal built in
+- Heavier than needed if we just want chunked snippets, but a strong reference implementation
+
+### 4. pubmed_parser / lxml (lightweight)
+- Plain JATS → structured dict
+- 100-line job, no ML
+
+### 5. OpenAlex
+- Citation graph, free API, often picks up biorxiv preprints faster than Semantic Scholar (because it ingests biorxiv directly)
+- Doesn't give snippets, only metadata + references
+- Useful for the "expand from atlas → cited papers" step even when ASTA is blind to the atlas itself
+
+### 6. Crossref
+- DOI → metadata + references (when publishers deposit them, which biorxiv does)
+- Free, no auth, fast
+
+---
+
+## What `paperqa2_cyberian` already has
+
+Located at `/Users/do12/Documents/GitHub/paperqa2_cyberian/paperqa2_cyberian/`:
+
+| File | LOC | Purpose |
+|---|---|---|
+| `parse_jats_citations.py` | 553 | JATS → sentence-level citation associations, resolved to DOI/PMID/PMCID. **This is the missing piece for our preprint problem.** |
+| `extract_asta_refs.py` | 197 | Pull `refMentions` out of ASTA snippet_search responses with sentence context |
+| `retrieve_chunks.py` | 144 | Local sentence-transformer embedding retrieval over chunked papers |
+| `cyberian_llm.py` | 226 | LLM wrapper used for chunk reranking |
+| `cache.py` | 42 | Disk cache layer |
+| `.claude/skills/paperqa/SKILL.md` | — | Three-step skill: embed retrieve → Haiku rerank → synthesize cited answer |
+
+Planning docs in `paperqa2_cyberian/planning/` already cover the relevant territory: `citation_traversal.md`, `contextual_retrieval.md`, `embedding_skill.md`, `query_decomposition.md`.
+
+So **the engineering largely exists** — what's missing is integration into `atlas_chat` and a clean handoff: a way for the report-synthesis subagent to query a locally-indexed atlas paper the same way it queries ASTA.
+
+---
+
+## Options
+
+### Option A — Lightweight orchestration (no new infrastructure)
+
+For each fresh-preprint atlas:
+
+1. Manual / scripted pre-step: download JATS + supp via the playwright path already proven on Steele 2026.
+2. Run `parse_jats_citations.py` from `paperqa2_cyberian` once at project setup → emit `projects/{name}/source/citations.json` (sentences with ref_ids + resolved DOIs).
+3. Synthesize-report subagent: prompt it to use the citations JSON as its evidence corpus. Blockquotes drawn from JATS sentences; "(Author, Year)" citations resolved via the citations JSON.
+4. Validation hook updated to accept blockquotes from `citations.json` sentences (not just `atlas_full_text.txt`).
+
+**Pros:** ~half a day of work; reuses what exists; preserves the existing report-validation contract.
+**Cons:** No retrieval — agent has to grep the JATS itself; no quoted evidence from *referenced* papers, only from the atlas paper itself.
+
+### Option B — Local ASTA-style snippet index (per project)
+
+Add a skill `local-paper-index <jats-path>` that:
+
+1. Parses JATS → S2ORC-shape JSON (using `s2orc-doc2json` or the existing parser)
+2. Splits body into ~paragraph-sized chunks; embeds with sentence-transformers (already in `retrieve_chunks.py`)
+3. Resolves every inline citation's DOI → CorpusId via the Semantic Scholar /paper API (this still works — only the atlas itself is missing, not the references)
+4. Emits a JSON store with the same shape as a serialised ASTA response: `{paper, snippet:{text, section, annotations:{refMentions:[{corpusId, char_start, char_end}]}}}[]`
+
+The synthesize-report agent then has *two* retrieval tools: ASTA for indexed literature and `local_snippet_search(atlas_id, query)` for the fresh preprint, returning identically-shaped objects.
+
+**Pros:** Clean parity between fresh and indexed papers; downstream prompts don't change; reference-paper quotes become possible because each refMention's CorpusId can be passed to ASTA `get_paper`.
+**Cons:** Real engineering — a new skill plus a query API. ~2–3 days.
+
+### Option C — Just use PaperQA2 directly
+
+Wrap PaperQA2 as a subagent. Index the JATS + any cited papers that have open-access PDFs (via OpenAlex / Crossref → unpaywall). Let PaperQA2 do retrieval + citation tracking. Report-synthesis becomes "ask PaperQA2 for the markers / location / function of cell type X, with citations".
+
+**Pros:** Strongest off-the-shelf RAG; handles citation graph natively; the user already has paperqa2_cyberian wiring.
+**Cons:** Less control over the report format and validation contract; PaperQA2's answer style is conversational, not template-locked; another moving piece in the stack. Also blockquote validation gets harder because PaperQA2 paraphrases.
+
+### Option D — Push ingestion to OpenAlex / Crossref and wait
+
+Submit the atlas DOI to OpenAlex (they accept biorxiv DOIs ~immediately); use OpenAlex + Crossref for the citation graph and identifier resolution. Don't index the atlas paper text locally — leave that to the manual JATS read. Use ASTA only for the cited *references*, which are presumably older and indexed.
+
+**Pros:** Smallest delta from current workflow.
+**Cons:** Still no quoted evidence from references, only the atlas; same shape of output as the pilot run.
+
+### Option E — "Just better instructions" (the simple option)
+
+You raised this yourself. Rework the report-synthesizer prompt to:
+
+1. Treat the JATS XML as the primary corpus, but explicitly require the agent to traverse Steele's reference list (which is in the JATS) and run ASTA `get_paper` or `snippet_search` on each referenced DOI to gather quotable text from those cited papers.
+2. Stage the resulting external snippets as a second `all_summaries.json` evidence file (alongside `atlas_full_text.txt`).
+3. Allow blockquotes from either file in validation.
+
+No new infrastructure. Just a tightened orchestration loop with the agent doing the equivalent of citation traversal manually via the existing MCP tools. Each report would do ~5–15 extra MCP calls.
+
+**Pros:** Probably the right "ship it" answer for the spatial skin atlas pilot. Zero new code.
+**Cons:** Doesn't scale: 107 cell types × 10 ref-papers × 1 MCP call each = ~1000 calls; rate limits and cost. Also doesn't fix the underlying gap for future atlases.
+
+---
+
+## Recommendation
+
+For the **spatial skin atlas right now**: Option E — adjust the synthesizer prompt to require post-hoc reference traversal via ASTA `get_paper` on each referenced DOI in Steele's JATS, and to capture quotable evidence from those into `all_summaries.json`. That gets us validated cross-paper blockquotes for the remaining 97 reports without new infrastructure.
+
+For the **general atlas_chat improvement**: Option A as a fast win, then Option B if the team plans to ingest more fresh preprints (HDCA, BICAN, etc. will keep hitting this). Option B mostly means lifting `paperqa2_cyberian` into a callable skill — the JATS parser, embeddings, and refMention extractor are already written.
+
+PaperQA2 directly (Option C) is heavier than needed unless atlas_chat moves toward more open-ended literature Q&A.
+
+---
+
+## Open questions before committing
+
+1. ~~Do we want blockquotes from *referenced* papers~~ **— Resolved: yes.** The validation contract — every blockquote must be an exact substring of the evidence corpus — is retained, and the corpus grows to include chunks from cited papers (not just the atlas). PaperQA2-style chunks are larger (paragraph- to section-sized, ~2–3k chars) but a quoted sentence is still a substring of its containing chunk, so `report_checker.py`'s substring check still works without modification. Implication: the local snippet store must persist **full chunk text**, not just metadata or hashed embeddings — otherwise validation has nothing to scan.
+2. How much should atlas_chat depend on `paperqa2_cyberian`? **— Held over.** Leaning toward centralised (single library install, atlas_chat calls into it as a dependency) rather than copying files, but the decision can wait until the integration work starts. Either path keeps `paperqa2_cyberian` as the source of truth for the parser, embeddings, and chunker.
+3. ~~Validation corpus location~~ **— Resolved: project-wide chunk store.** All chunks live under `projects/{name}/chunks/` (or similar single location) — shared across cell types, no duplication. **Refinement:** when a report is actually written, the specific chunks the report blockquotes can be extracted/copied into `traversal_output/{cell_type}/` so each report's validation corpus is self-contained (cheap substring scan over a small file, rerunnable in isolation). The master store is the canonical source; the per-cell-type extract is a derived artefact, written at report-synthesis time. This keeps both properties: one shared chunk index for retrieval, and self-contained validation per report.
+
+### Implications for Option B design
+
+The substring-validation requirement constrains the local snippet store shape:
+
+- Each chunk is stored as plain text on disk (not just an embedding vector). Embeddings sit alongside for retrieval.
+- Chunks should be **whole paragraphs or whole sections**, not sentence-fragments. A larger chunk window means a quoted sentence from the chunk is still trivially a substring, and chunk boundaries don't accidentally cut a quotable sentence in half. PaperQA2's default chunk size (~3000 chars with 100-char overlap) is in the right ballpark.
+- When `report_checker.py` runs, it concatenates all chunk-text files in the evidence corpus and does the same `quote in text` check it does today — no schema change needed.
+- The ASTA-shape wrapper (snippet object with `paper`, `score`, `section`, `annotations.refMentions`) is only needed for the *retrieval API* shape, not for the validation corpus. The two can be the same file (chunks-with-metadata) or split (chunks for validation + index for retrieval).
+
+This means Option B is even smaller than first sketched: build a chunker that emits paragraph-sized snippets-with-metadata, embed them with the existing `retrieve_chunks.py` machinery, expose `local_snippet_search(paper_id, query) → snippets[]` returning ASTA-shaped objects, and let `report_checker.py` scan the same chunk files. No fork of the validation logic.
+
+---
+
+## Appendix — bioRxiv programmatic access (why we used Playwright)
+
+We used Playwright to download `paper.jats.xml` and `supp.pdf` because `curl` got blocked by Cloudflare. The intent here is *not* an excuse for keeping Playwright — it's the wrong tool if there's a real API. Here's the actual landscape.
+
+### What bioRxiv exposes
+
+| Endpoint | What it returns | CF-gated? |
+|---|---|---|
+| `api.biorxiv.org/details/biorxiv/{doi}/na/json` | Metadata (title, authors, abstract, jatsxml URL) | **No** — works via curl. We already used this. |
+| `api.biorxiv.org/pubs/biorxiv/{interval}/{cursor}` | Listings, OAI-PMH style harvesting | No |
+| `www.biorxiv.org/content/early/.../<id>.source.xml` | JATS XML (full text) | **Yes** — served via Highwire behind CF |
+| `www.biorxiv.org/content/.../v1.full.pdf` | Main PDF | Yes |
+| `www.biorxiv.org/content/biorxiv/.../DC1/embed/media-N.pdf` | Supplementary files | Yes |
+| `s3://biorxiv-src-monthly/` | Monthly TDM dump of all JATS + PDFs | No (S3 auth, requester-pays) |
+
+So: **the metadata API is free and uncomplicated, but the actual full-text URLs the metadata returns are CF-protected**. The bioRxiv "TDM" page is honest about this — for programmatic bulk access they direct you to S3.
+
+### Realistic options for atlas_chat
+
+1. **`curl_cffi` / `cloudscraper` with browser TLS fingerprint.** A 10-line Python function: hit `api.biorxiv.org/details/...` for metadata + JATS URL, then fetch the JATS URL via `curl_cffi` (which impersonates Chrome's TLS stack). For Steele 2026 this would have worked without a real browser. Caveat: brittle if CF tightens. `cloudscraper` has gone in and out of working over the years.
+2. **EuropePMC mirror, when available.** EuropePMC ingests many bioRxiv preprints (with lag). When indexed, `mcp__artl-mcp__get_europepmc_full_text` returns clean Markdown — no CF, no parsing, MCP-native. Worth checking *first* even for fresh-ish preprints. Steele 2026 isn't there yet but a 2-month-old preprint usually is.
+3. **AWS `s3://biorxiv-src-monthly` (requester-pays).** ~6 TB total, monthly snapshots; ~$0.09/GB egress. Overkill for single-paper fetch but the right answer if atlas_chat starts ingesting many preprints — a single monthly sync, then everything is local. Probably impractical for routine use.
+4. **Playwright (what we did).** Works, but pulls in a headless browser dependency. Fine as a fallback when the other methods fail; bad as the default.
+
+### Recommendation for the workflow
+
+A small helper `fetch_preprint(doi)` that tries, in order:
+1. EuropePMC via existing MCP (`get_europepmc_full_text`) — preferred when available
+2. bioRxiv metadata API → JATS URL → fetch with `curl_cffi`
+3. Playwright fallback only if the above fail
+
+This keeps Playwright as a safety net rather than the primary path. Worth a half-day if Option A/B above gets built — it's the natural source step that feeds the local JATS parser.
+
+---
+
+## Sources
+
+- [allenai/s2orc-doc2json](https://github.com/allenai/s2orc-doc2json) — JATS/PDF → S2ORC JSON
+- [Future-House/paper-qa](https://github.com/Future-House/paper-qa) — PaperQA2 RAG library
+- [PaperQA2 cookbook](https://futurehouse.gitbook.io/futurehouse-cookbook/paperqa)
+- [grobid](https://github.com/kermitt2/grobid) — PDF → TEI XML
+- [GROBID benchmark on bioRxiv ~0.90 F1](https://grobid.readthedocs.io/en/latest/End-to-end-evaluation/)
+- Local: `paperqa2_cyberian/paperqa2_cyberian/parse_jats_citations.py`, `extract_asta_refs.py`, `retrieve_chunks.py`
+- Local: `paperqa2_cyberian/.claude/skills/paperqa/SKILL.md`
+- [bioRxiv machine access / TDM page](https://www.biorxiv.org/tdm) — describes API + S3 bucket
+- [bioRxiv API root](https://api.biorxiv.org/) — metadata endpoints (no CF)
+- [bioRxiv S3 TDM announcement (2020)](https://connect.biorxiv.org/news/2020/04/18/tdm)
+- [curl_cffi](https://github.com/lexiforest/curl_cffi) — TLS-fingerprint-impersonating HTTP client
+- [VeNoMouS/cloudscraper](https://github.com/venomous/cloudscraper) — Cloudflare bypass library (works intermittently)
+- ["How to download bioRxiv on a budget"](https://sitlabs.org/writing/biorxiv.html) — community write-up on practical access

--- a/docs/preprint_citation_options.md
+++ b/docs/preprint_citation_options.md
@@ -1,5 +1,14 @@
 # Citation traversal for fresh preprints — options
 
+> **Implementation note (resolved).** Option B was implemented in
+> `src/atlas_chat/atlas_chat/services/local_snippet_index.py`. The required
+> JATS parser was **vendored** into `services/_jats_parser.py` from
+> Cellular-Semantics/paperqa2_cyberian@4d5d153 rather than pulled as a git
+> dependency — paperqa2_cyberian is experimental, lacks a release line, and
+> would have constrained atlas_chat to its Python pin. The rest of this doc
+> is preserved as historical context for the design decision; the references
+> to "paperqa2_cyberian as a dependency" no longer apply.
+
 **Problem.** atlas_chat's reporting workflow assumes the atlas paper is in EuropePMC / Semantic Scholar. For a fresh bioRxiv preprint (e.g. Steele et al. 2026, used here), neither is true: `get_pmc_supplemental_material` returns nothing, and ASTA `snippet_search` scoped to the atlas paper has no CorpusId to hit. The pilot reports for the spatial skin atlas worked around this by giving each agent the JATS XML directly, but blockquotes are then atlas-only — referenced literature appears as paraphrased inline cites, not as validated quoted evidence.
 
 This doc surveys options for fixing that, both heavy (build a local snippet index) and light (better orchestration). It also notes which pieces already exist in `~/Documents/GitHub/paperqa2_cyberian`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,10 @@ members = [
 [tool.uv.sources]
 atlas_chat = { workspace = true }
 github_app_posting = { workspace = true }
+# Dev-time override: resolve paperqa2-cyberian from the local checkout until
+# the relaxed Python pin (>=3.13) is pushed to origin/main. Switch back to
+# the git+https form in src/atlas_chat/pyproject.toml once published.
+paperqa2-cyberian = { path = "../paperqa2_cyberian", editable = true }
 
 [tool.uv]
 managed = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,10 +8,6 @@ members = [
 [tool.uv.sources]
 atlas_chat = { workspace = true }
 github_app_posting = { workspace = true }
-# Dev-time override: resolve paperqa2-cyberian from the local checkout until
-# the relaxed Python pin (>=3.13) is pushed to origin/main. Switch back to
-# the git+https form in src/atlas_chat/pyproject.toml once published.
-paperqa2-cyberian = { path = "../paperqa2_cyberian", editable = true }
 
 [tool.uv]
 managed = true

--- a/scripts/setup_local_index.py
+++ b/scripts/setup_local_index.py
@@ -1,0 +1,86 @@
+"""Project-setup CLI: build the local snippet index for a fresh-preprint atlas.
+
+Wraps `atlas_chat.services.local_snippet_index.build_local_index` with project
+discovery (reads DOI from cell_type_annotations.json if --doi isn't passed).
+
+Example:
+    uv run python scripts/setup_local_index.py --project spatial_skin_atlas
+    uv run python scripts/setup_local_index.py --project some_atlas --doi 10.1101/... --force
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import sys
+from pathlib import Path
+
+
+def _resolve_project_dir(project_arg: str) -> Path:
+    p = Path(project_arg)
+    if p.is_dir():
+        return p.resolve()
+    # Try projects/<name>
+    candidate = Path.cwd() / "projects" / project_arg
+    if candidate.is_dir():
+        return candidate.resolve()
+    raise FileNotFoundError(f"Project not found: {project_arg}")
+
+
+def _doi_from_config(project_dir: Path) -> str | None:
+    cfg = project_dir / "cell_type_annotations.json"
+    if not cfg.exists():
+        return None
+    try:
+        return json.loads(cfg.read_text()).get("source", {}).get("doi")
+    except Exception:
+        return None
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n", maxsplit=1)[0])
+    parser.add_argument(
+        "--project",
+        required=True,
+        help="Project directory or name (under projects/)",
+    )
+    parser.add_argument(
+        "--doi",
+        default=None,
+        help="DOI of the preprint. Read from cell_type_annotations.json if omitted.",
+    )
+    parser.add_argument(
+        "--jats",
+        type=Path,
+        default=None,
+        help="Path to an existing JATS XML; skip fetch step.",
+    )
+    parser.add_argument("--force", action="store_true", help="Rebuild even if up to date")
+    parser.add_argument("-v", "--verbose", action="store_true")
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(
+        level=logging.INFO if args.verbose else logging.WARNING,
+        format="%(levelname)s: %(message)s",
+    )
+
+    project_dir = _resolve_project_dir(args.project)
+    doi = args.doi or _doi_from_config(project_dir)
+    if not doi:
+        print(
+            "ERROR: no DOI supplied and none found in cell_type_annotations.json",
+            file=sys.stderr,
+        )
+        return 1
+
+    # Lazy import — keeps `--help` snappy when the heavy ML stack isn't installed.
+    from atlas_chat.services.local_snippet_index import build_local_index
+
+    manifest = build_local_index(project_dir, doi, args.jats, args.force)
+    print(json.dumps(manifest, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/atlas_chat/atlas_chat/graphs/report_graph.py
+++ b/src/atlas_chat/atlas_chat/graphs/report_graph.py
@@ -275,15 +275,64 @@ class FanOut(BaseNode[ReportState, ReportDeps, str]):
         seed_id = config.corpus_id or f"DOI:{config.doi}"
 
         raw_snippets: list[dict[str, Any]] = []
+        catalogue: dict[str, dict[str, Any]] = {}
         try:
             from atlas_chat.services import citation_traverser
 
-            raw_snippets, catalogue = await citation_traverser.traverse(
+            asta_task = citation_traverser.traverse(
                 query=query,
                 seed_ids=[seed_id],
                 depth=state.depth,
                 output_dir=ctx.deps.traversal_dir,
             )
+            # Run ASTA + local index in parallel when the project has a local
+            # snippet index (built via `setup_local_index.py`). Falls through
+            # to ASTA-only when no manifest.json is present.
+            local_task = None
+            try:
+                from atlas_chat.services import local_snippet_index
+
+                if local_snippet_index.has_local_index(config.project_dir):
+                    local_task = citation_traverser.traverse_local(
+                        query=query,
+                        project_dir=config.project_dir,
+                        k=20,
+                    )
+            except ImportError:
+                logger.info("local_snippet_index unavailable; ASTA-only")
+
+            if local_task is not None:
+                (asta_snips, asta_cat), (local_snips, local_cat) = await asyncio.gather(
+                    asta_task, local_task
+                )
+                # Tag source_method; ASTA snippets fall through with default
+                for s in asta_snips:
+                    s.setdefault("source_method", "asta")
+                # Merge: local first (more specific to the atlas), then ASTA.
+                # Deduplicate on (corpus_id, chunk_id or snippet text)
+                seen: set[tuple[str, str]] = set()
+                merged: list[dict[str, Any]] = []
+                for s in local_snips + asta_snips:
+                    key = (
+                        s.get("corpus_id", ""),
+                        str(s.get("chunk_id", s.get("snippet", "")[:120])),
+                    )
+                    if key in seen:
+                        continue
+                    seen.add(key)
+                    merged.append(s)
+                raw_snippets = merged
+                catalogue = {**asta_cat, **local_cat}
+                logger.info(
+                    "Merged %d ASTA + %d local snippets (catalogue: %d entries)",
+                    len(asta_snips),
+                    len(local_snips),
+                    len(catalogue),
+                )
+            else:
+                raw_snippets, catalogue = await asta_task
+                for s in raw_snippets:
+                    s.setdefault("source_method", "asta")
             state.paper_catalogue = catalogue
         except (ImportError, Exception) as exc:
             logger.warning("Citation traversal failed: %s", exc)
@@ -366,7 +415,8 @@ class FanOut(BaseNode[ReportState, ReportDeps, str]):
                         idx = ev.get("snippet_index", 0)
                         # Map back to the raw snippet
                         if 0 <= idx < len(raw_snippets):
-                            src_text = raw_snippets[idx].get("snippet", "")
+                            src = raw_snippets[idx]
+                            src_text = src.get("snippet", "")
                             verified_quotes = [
                                 q
                                 for q in ev.get("quotes", [])
@@ -375,6 +425,8 @@ class FanOut(BaseNode[ReportState, ReportDeps, str]):
                             ev["quotes"] = verified_quotes
                             # Also carry forward the raw snippet for validation
                             ev["snippet"] = src_text
+                            # Propagate provenance for downstream filtering
+                            ev["source_method"] = src.get("source_method", "asta")
                         all_evidence.append(ev)
             except (json.JSONDecodeError, Exception) as exc:
                 logger.warning("Snippet summarization failed for batch %d: %s", i, exc)

--- a/src/atlas_chat/atlas_chat/services/_jats_parser.py
+++ b/src/atlas_chat/atlas_chat/services/_jats_parser.py
@@ -1,0 +1,583 @@
+"""Parse JATS XML from EuropePMC to extract sentence-level citation associations.
+
+JATS XML preserves inline citations (<xref ref-type="bibr"> or <xref ref-type="ref">)
+cross-referenced to a structured <ref-list> with DOIs, PMIDs, and PMCIDs. This module
+extracts that structure into dataclasses suitable for citation traversal pipelines.
+
+Dependencies: stdlib only.
+
+----------------------------------------------------------------------------
+Vendored from Cellular-Semantics/paperqa2_cyberian @ 4d5d153 (Mar 2026).
+
+paperqa2_cyberian is an experimental repo with no formal release line and
+no LICENSE file. Rather than pin atlas_chat to a moving experimental
+dependency (which also forces Python 3.13+ on a 3.10-3.12 CI matrix), the
+parser is vendored here. Stdlib-only — re-syncing is a straight `cp` if the
+upstream picks up new JATS dialect support.
+----------------------------------------------------------------------------
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import re
+import urllib.request
+import xml.etree.ElementTree as ET
+from dataclasses import asdict, dataclass, field
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Data structures
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ResolvedRef:
+    ref_id: str  # e.g. "CR1"
+    doi: str | None = None
+    pmid: str | None = None
+    pmcid: str | None = None
+    title: str | None = None
+    year: int | None = None
+    first_author: str | None = None
+
+
+@dataclass
+class CitedSentence:
+    text: str  # sentence with citation markers like [1-3]
+    section: str  # section title
+    ref_ids: list[str] = field(default_factory=list)  # ordered, deduplicated
+    resolved_refs: list[ResolvedRef] = field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# XML cleanup
+# ---------------------------------------------------------------------------
+
+
+def _clean_xml(xml_string: str) -> str:
+    """Strip DOCTYPE declarations that cause ET to choke on external entities."""
+    return re.sub(r"<!DOCTYPE[^>]*>", "", xml_string, count=1)
+
+
+def _strip_namespace_from_tree(root: ET.Element) -> None:
+    """Remove xmlns prefixes in-place so we can use plain tag names."""
+    for elem in root.iter():
+        if "}" in elem.tag:
+            elem.tag = elem.tag.split("}", 1)[1]
+        for key in list(elem.attrib):
+            if "}" in key:
+                new_key = key.split("}", 1)[1]
+                elem.attrib[new_key] = elem.attrib.pop(key)
+
+
+# ---------------------------------------------------------------------------
+# Reference list parsing
+# ---------------------------------------------------------------------------
+
+
+def _parse_single_ref(ref_elem: ET.Element) -> ResolvedRef:
+    """Extract identifiers and metadata from one <ref> element."""
+    ref_id = ref_elem.get("id", "")
+
+    doi = pmid = pmcid = title = first_author = None
+    year: int | None = None
+
+    # Look in both element-citation and mixed-citation
+    citation = ref_elem.find(".//element-citation")
+    if citation is None:
+        citation = ref_elem.find(".//mixed-citation")
+
+    if citation is not None:
+        # DOI / PMID / PMCID from pub-id elements
+        for pub_id in citation.findall(".//pub-id"):
+            pub_type = pub_id.get("pub-id-type", "")
+            val = (pub_id.text or "").strip()
+            if pub_type == "doi":
+                doi = val
+            elif pub_type == "pmid":
+                pmid = val
+            elif pub_type == "pmcid":
+                pmcid = val
+
+        # Title — article-title or chapter-title
+        title_elem = citation.find("article-title")
+        if title_elem is None:
+            title_elem = citation.find("chapter-title")
+        if title_elem is not None:
+            title = "".join(title_elem.itertext()).strip()
+
+        # Year
+        year_elem = citation.find("year")
+        if year_elem is not None:
+            year_text = (year_elem.text or "").strip()
+            m = re.search(r"\d{4}", year_text)
+            if m:
+                year = int(m.group())
+
+        # First author
+        name_elem = citation.find(".//name")
+        if name_elem is not None:
+            surname = name_elem.find("surname")
+            if surname is not None:
+                first_author = (surname.text or "").strip()
+
+    return ResolvedRef(
+        ref_id=ref_id,
+        doi=doi,
+        pmid=pmid,
+        pmcid=pmcid,
+        title=title,
+        year=year,
+        first_author=first_author,
+    )
+
+
+def _parse_ref_list(root: ET.Element) -> dict[str, ResolvedRef]:
+    """Parse all <ref> elements into a lookup dict keyed by ref id."""
+    refs: dict[str, ResolvedRef] = {}
+    for ref_elem in root.iter("ref"):
+        parsed = _parse_single_ref(ref_elem)
+        if parsed.ref_id:
+            refs[parsed.ref_id] = parsed
+    return refs
+
+
+# ---------------------------------------------------------------------------
+# Range expansion
+# ---------------------------------------------------------------------------
+
+
+def _expand_ref_range(rid_start: str, rid_end: str) -> list[str]:
+    """Expand "CR1"-"CR3" → ["CR1","CR2","CR3"].
+
+    Works for any common prefix + numeric suffix pattern.
+    """
+    m_start = re.match(r"^(.*?)(\d+)$", rid_start)
+    m_end = re.match(r"^(.*?)(\d+)$", rid_end)
+    if not m_start or not m_end or m_start.group(1) != m_end.group(1):
+        return [rid_start, rid_end]
+    prefix = m_start.group(1)
+    lo, hi = int(m_start.group(2)), int(m_end.group(2))
+    if hi < lo:
+        return [rid_start, rid_end]
+    return [f"{prefix}{i}" for i in range(lo, hi + 1)]
+
+
+# ---------------------------------------------------------------------------
+# Text reconstruction with citation tracking
+# ---------------------------------------------------------------------------
+
+# ref-type values that indicate a bibliography citation
+_BIBR_REF_TYPES = {"bibr", "ref"}
+
+# Type alias: list of (character_position, list_of_ref_ids)
+CitationPositions = list[tuple[int, list[str]]]
+
+
+def _walk_node(
+    node: ET.Element,
+    parts: list[str],
+    citations: CitationPositions,
+    *,
+    inside_sup: bool = False,
+) -> None:
+    """Recursively walk an element tree, rebuilding text and tracking citations.
+
+    ``parts`` accumulates text fragments; ``citations`` accumulates
+    (char_offset, [ref_ids]) pairs where char_offset is computed from
+    the *current* length of the joined parts.
+    """
+
+    def _current_pos() -> int:
+        return sum(len(p) for p in parts)
+
+    if node.tag == "xref" and node.get("ref-type") in _BIBR_REF_TYPES:
+        rid = node.get("rid", "")
+        display = "".join(node.itertext()).strip()
+        pos = _current_pos()
+        if rid:
+            citations.append((pos, [rid]))
+        if display:
+            parts.append(display)
+        # tail handled by caller
+    elif node.tag == "sup":
+        # Collect all bibr xrefs in this <sup>, detect ranges
+        bibr_children = [
+            ch for ch in node if ch.tag == "xref" and ch.get("ref-type") in _BIBR_REF_TYPES
+        ]
+        all_children_are_bibr = len(bibr_children) == len(list(node))
+
+        if bibr_children and all_children_are_bibr:
+            parts.append("[")
+            _process_sup_bibr(node, parts, citations)
+            parts.append("]")
+        else:
+            # Mixed content <sup> — recurse normally
+            if node.text:
+                parts.append(node.text)
+            for child in node:
+                _walk_node(child, parts, citations, inside_sup=True)
+                if child.tail:
+                    parts.append(child.tail)
+    elif node.tag == "xref":
+        # Non-bibr xref (fig, table, etc.) — just include display text
+        display = "".join(node.itertext()).strip()
+        if display:
+            parts.append(display)
+    else:
+        # Generic element (<italic>, <bold>, <ext-link>, etc.) — recurse
+        if node.text:
+            parts.append(node.text)
+        for child in node:
+            _walk_node(child, parts, citations, inside_sup=inside_sup)
+            if child.tail:
+                parts.append(child.tail)
+
+
+def _process_sup_bibr(
+    sup: ET.Element,
+    parts: list[str],
+    citations: CitationPositions,
+) -> None:
+    """Handle a <sup> that contains only bibr xrefs (possibly with range separators)."""
+    children = list(sup)
+    prev_rid: str | None = None
+
+    for i, child in enumerate(children):
+        if child.tag != "xref" or child.get("ref-type") not in _BIBR_REF_TYPES:
+            continue
+
+        rid = child.get("rid", "")
+        display = "".join(child.itertext()).strip()
+
+        # Check for range separator between this xref and the previous one
+        separator = ""
+        if i > 0:
+            # Separator is the tail of the previous child, or text between
+            prev = children[i - 1]
+            sep_text = (prev.tail or "").strip()
+            if not sep_text and i == 1:
+                sep_text = (sup.text or "").strip()
+            separator = sep_text
+
+        is_range = separator in ("-", "\u2013", "\u2014")
+
+        if is_range and prev_rid and rid:
+            expanded = _expand_ref_range(prev_rid, rid)
+            # The first ref was already recorded; record intermediate + last
+            for expanded_rid in expanded[1:]:
+                pos = sum(len(p) for p in parts)
+                citations.append((pos, [expanded_rid]))
+            parts.append("\u2013")
+            parts.append(display)
+        else:
+            if prev_rid is not None:
+                parts.append(",")
+            pos = sum(len(p) for p in parts)
+            if rid:
+                citations.append((pos, [rid]))
+            if display:
+                parts.append(display)
+
+        prev_rid = rid
+
+
+def _reconstruct_paragraph(
+    p_elem: ET.Element,
+) -> tuple[str, CitationPositions]:
+    """Reconstruct text from a <p> element, tracking citation positions."""
+    parts: list[str] = []
+    citations: CitationPositions = []
+
+    if p_elem.text:
+        parts.append(p_elem.text)
+
+    for child in p_elem:
+        _walk_node(child, parts, citations)
+        if child.tail:
+            parts.append(child.tail)
+
+    text = "".join(parts).strip()
+    return text, citations
+
+
+# ---------------------------------------------------------------------------
+# Sentence splitting
+# ---------------------------------------------------------------------------
+
+# Abbreviations that should not trigger sentence breaks
+_ABBREV_SET = {
+    "et al",
+    "Fig",
+    "Figs",
+    "Ref",
+    "Refs",
+    "Eq",
+    "Eqs",
+    "vs",
+    "i.e",
+    "e.g",
+    "Dr",
+    "Mr",
+    "Mrs",
+    "Ms",
+    "Prof",
+    "Jr",
+    "Sr",
+    "St",
+    "vol",
+    "no",
+    "approx",
+}
+
+
+def _split_sentences(text: str) -> list[tuple[str, int]]:
+    """Split text into sentences, returning (sentence, start_offset) pairs.
+
+    Uses a conservative approach: splits on sentence-ending punctuation
+    followed by whitespace and an uppercase letter, but protects common
+    abbreviations.
+    """
+    if not text:
+        return []
+
+    # Find candidate split points: ". X" / "? X" / "! X" where X is uppercase
+    candidates: list[int] = []
+    for m in re.finditer(r'[.?!]\s+(?=[A-Z\[\("\'"\u201c])', text):
+        # Check if the period belongs to a known abbreviation
+        end_pos = m.start()  # position of the punctuation
+        # Look back up to 10 chars for an abbreviation
+        prefix = text[max(0, end_pos - 10) : end_pos + 1]
+        is_abbrev = False
+        for ab in _ABBREV_SET:
+            if prefix.endswith(ab + ".") or prefix.endswith(ab):
+                is_abbrev = True
+                break
+        if not is_abbrev:
+            # split at the start of the whitespace gap
+            candidates.append(m.start() + 1)
+
+    if not candidates:
+        return [(text.strip(), 0)]
+
+    result: list[tuple[str, int]] = []
+    prev = 0
+    for sp in candidates:
+        chunk = text[prev:sp].strip()
+        if chunk:
+            idx = text.find(chunk, prev)
+            result.append((chunk, idx if idx >= 0 else prev))
+        prev = sp
+    # Last segment
+    chunk = text[prev:].strip()
+    if chunk:
+        idx = text.find(chunk, prev)
+        result.append((chunk, idx if idx >= 0 else prev))
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Citation → sentence mapping
+# ---------------------------------------------------------------------------
+
+
+def _assign_citations_to_sentences(
+    sentences: list[tuple[str, int]],
+    citations: CitationPositions,
+    section: str,
+    ref_lookup: dict[str, ResolvedRef],
+) -> list[CitedSentence]:
+    """Map citation positions to the sentence they fall within."""
+    if not sentences or not citations:
+        return []
+
+    result: list[CitedSentence] = []
+
+    for sent_text, sent_start in sentences:
+        sent_end = sent_start + len(sent_text)
+        ref_ids: list[str] = []
+        for cit_pos, cit_rids in citations:
+            if sent_start <= cit_pos <= sent_end:
+                for rid in cit_rids:
+                    if rid not in ref_ids:
+                        ref_ids.append(rid)
+
+        if ref_ids:
+            resolved = [ref_lookup[rid] for rid in ref_ids if rid in ref_lookup]
+            result.append(
+                CitedSentence(
+                    text=sent_text,
+                    section=section,
+                    ref_ids=ref_ids,
+                    resolved_refs=resolved,
+                )
+            )
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Section walking
+# ---------------------------------------------------------------------------
+
+
+def _get_section_title(sec_elem: ET.Element) -> str:
+    """Extract section title from a <sec> element."""
+    title_elem = sec_elem.find("title")
+    if title_elem is not None:
+        return "".join(title_elem.itertext()).strip()
+    return ""
+
+
+def _walk_sections(
+    elem: ET.Element,
+    ref_lookup: dict[str, ResolvedRef],
+    section_title: str = "Main",
+) -> list[CitedSentence]:
+    """Recursively walk <sec> and <body> elements, extracting cited sentences."""
+    results: list[CitedSentence] = []
+
+    for child in elem:
+        if child.tag == "sec":
+            sub_title = _get_section_title(child) or section_title
+            results.extend(_walk_sections(child, ref_lookup, sub_title))
+        elif child.tag == "p":
+            text, citations = _reconstruct_paragraph(child)
+            if not citations:
+                continue
+            sentences = _split_sentences(text)
+            results.extend(
+                _assign_citations_to_sentences(sentences, citations, section_title, ref_lookup)
+            )
+
+    return results
+
+
+def _extract_cited_sentences(
+    root: ET.Element,
+    ref_lookup: dict[str, ResolvedRef],
+) -> list[CitedSentence]:
+    """Extract all cited sentences from the document body and back matter."""
+    results: list[CitedSentence] = []
+
+    # Body
+    body = root.find(".//body")
+    if body is not None:
+        results.extend(_walk_sections(body, ref_lookup))
+
+    # Abstract (sometimes has citations)
+    for abstract in root.iter("abstract"):
+        results.extend(_walk_sections(abstract, ref_lookup, "Abstract"))
+
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def parse_jats_citations(
+    xml_string: str,
+) -> tuple[list[CitedSentence], dict[str, ResolvedRef]]:
+    """Parse JATS XML and extract sentence-level citation associations.
+
+    Args:
+        xml_string: Raw JATS XML content.
+
+    Returns:
+        Tuple of (cited_sentences, ref_lookup) where ref_lookup maps ref_id
+        to ResolvedRef.
+    """
+    cleaned = _clean_xml(xml_string)
+    root = ET.fromstring(cleaned)
+    _strip_namespace_from_tree(root)
+
+    ref_lookup = _parse_ref_list(root)
+    logger.info("Parsed %d references from ref-list", len(ref_lookup))
+
+    cited_sentences = _extract_cited_sentences(root, ref_lookup)
+    logger.info("Extracted %d cited sentences", len(cited_sentences))
+
+    return cited_sentences, ref_lookup
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _fetch_jats_xml(pmcid: str) -> str:
+    """Fetch JATS XML from EuropePMC for a given PMCID."""
+    # Normalise: ensure PMC prefix
+    if not pmcid.upper().startswith("PMC"):
+        pmcid = f"PMC{pmcid}"
+
+    url = f"https://www.ebi.ac.uk/europepmc/webservices/rest/{pmcid}/fullTextXML"
+    logger.info("Fetching %s", url)
+
+    req = urllib.request.Request(url)
+    with urllib.request.urlopen(req, timeout=30) as resp:
+        return resp.read().decode("utf-8")
+
+
+def cli_main() -> None:
+    """CLI entry point: fetch JATS XML for a PMCID and output structured JSON."""
+    parser = argparse.ArgumentParser(description="Parse JATS XML citations from EuropePMC")
+    parser.add_argument("pmcid", help="PubMed Central ID (e.g. PMC10719114)")
+    parser.add_argument(
+        "--from-file",
+        help="Read XML from a local file instead of fetching",
+    )
+    parser.add_argument("--pretty", action="store_true", help="Pretty-print JSON output")
+    parser.add_argument("-v", "--verbose", action="store_true", help="Enable debug logging")
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="%(levelname)s: %(message)s",
+    )
+
+    if args.from_file:
+        with open(args.from_file) as f:
+            xml_string = f.read()
+    else:
+        xml_string = _fetch_jats_xml(args.pmcid)
+
+    cited_sentences, ref_lookup = parse_jats_citations(xml_string)
+
+    # Normalise PMCID for output
+    pmcid = args.pmcid.upper()
+    if not pmcid.startswith("PMC"):
+        pmcid = f"PMC{pmcid}"
+
+    # Build stats
+    refs_with_doi = sum(1 for r in ref_lookup.values() if r.doi)
+    refs_with_pmid = sum(1 for r in ref_lookup.values() if r.pmid)
+
+    output = {
+        "pmcid": pmcid,
+        "refs": {k: asdict(v) for k, v in ref_lookup.items()},
+        "cited_sentences": [
+            {
+                "text": cs.text,
+                "section": cs.section,
+                "ref_ids": cs.ref_ids,
+            }
+            for cs in cited_sentences
+        ],
+        "stats": {
+            "total_refs": len(ref_lookup),
+            "refs_with_doi": refs_with_doi,
+            "refs_with_pmid": refs_with_pmid,
+            "sentences_with_citations": len(cited_sentences),
+        },
+    }
+
+    indent = 2 if args.pretty else None
+    print(json.dumps(output, indent=indent, ensure_ascii=False))

--- a/src/atlas_chat/atlas_chat/services/citation_traverser.py
+++ b/src/atlas_chat/atlas_chat/services/citation_traverser.py
@@ -185,3 +185,38 @@ async def traverse(
     """
     provider = _make_provider()
     return await _search_depth(provider, query, seed_ids, depth)
+
+
+async def traverse_local(
+    query: str,
+    project_dir: Path,
+    k: int = 20,
+) -> tuple[list[dict[str, Any]], dict[str, dict[str, Any]]]:
+    """Local-snippet-index counterpart of `traverse()`.
+
+    Returns the same (raw_snippets, catalogue) shape as the ASTA path so the
+    caller can merge them. Snippets are tagged with `source_method: "local_snippet"`.
+    The catalogue carries one entry — the atlas paper itself — keyed by
+    `CorpusId:local_<hash>`.
+    """
+    import asyncio
+
+    from atlas_chat.services import local_snippet_index
+
+    raw_snippets = await asyncio.to_thread(local_snippet_index.search, project_dir, query, k)
+    if not raw_snippets:
+        return [], {}
+
+    paper = raw_snippets[0]
+    catalogue = {
+        paper["corpus_id"]: {
+            "title": paper.get("title", ""),
+            "authors": paper.get("authors", ""),
+            "year": paper.get("year"),
+            "venue": "bioRxiv",
+            "doi": paper.get("doi", ""),
+            "url": paper.get("url", ""),
+            "abstract": "",
+        }
+    }
+    return raw_snippets, catalogue

--- a/src/atlas_chat/atlas_chat/services/fetch_preprint.py
+++ b/src/atlas_chat/atlas_chat/services/fetch_preprint.py
@@ -1,0 +1,259 @@
+"""Resolve a DOI to a local JATS XML file for fresh preprints.
+
+Tries three paths in order: EuropePMC full text → bioRxiv JATS via curl_cffi
+(Cloudflare-friendly TLS impersonation) → Playwright fallback. Returns a
+FetchedPreprint dataclass identifying the source used.
+
+This sits in front of the local snippet index (services/local_snippet_index.py)
+so the rest of the pipeline doesn't care how the JATS arrived.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import re
+import sys
+import urllib.request
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+EUROPEPMC_BASE = "https://www.ebi.ac.uk/europepmc/webservices/rest"
+BIORXIV_API = "https://api.biorxiv.org/details/biorxiv"
+
+
+class PreprintFetchError(RuntimeError):
+    """Raised when every fetch path fails. Carries which paths were tried."""
+
+    def __init__(self, doi: str, attempts: list[tuple[str, str]]):
+        self.doi = doi
+        self.attempts = attempts
+        msg = f"Could not fetch JATS for {doi}. Attempts:\n" + "\n".join(
+            f"  - {src}: {reason}" for src, reason in attempts
+        )
+        super().__init__(msg)
+
+
+@dataclass
+class FetchedPreprint:
+    doi: str
+    jats_path: Path
+    source_used: str  # "europepmc" | "biorxiv_curlcffi" | "biorxiv_playwright"
+    title: str | None = None
+    authors: str | None = None
+    year: int | None = None
+
+
+# ------------------------------------------------------------------
+# Path 1: EuropePMC
+# ------------------------------------------------------------------
+
+
+def _try_europepmc(doi: str, out_path: Path) -> tuple[bool, str]:
+    try:
+        with httpx.Client(timeout=30) as client:
+            resp = client.get(
+                f"{EUROPEPMC_BASE}/search",
+                params={
+                    "query": f'DOI:"{doi}"',
+                    "format": "json",
+                    "pageSize": 1,
+                    "resultType": "core",
+                },
+            )
+            resp.raise_for_status()
+            results = resp.json().get("resultList", {}).get("result", [])
+            if not results:
+                return False, "DOI not found in EuropePMC search"
+            pmcid = results[0].get("pmcid")
+            if not pmcid:
+                return False, "no PMCID in EuropePMC record"
+            xml_resp = client.get(f"{EUROPEPMC_BASE}/{pmcid}/fullTextXML", timeout=60)
+            if xml_resp.status_code != 200:
+                return False, f"fullTextXML returned {xml_resp.status_code}"
+            out_path.write_text(xml_resp.text)
+            return True, f"fetched from EuropePMC PMC {pmcid}"
+    except Exception as exc:
+        return False, f"exception: {exc}"
+
+
+# ------------------------------------------------------------------
+# Path 2: bioRxiv API → JATS URL → curl_cffi
+# ------------------------------------------------------------------
+
+
+def _biorxiv_metadata(doi: str) -> dict | None:
+    """Hit api.biorxiv.org/details (no CF) for the JATS URL + metadata."""
+    url = f"{BIORXIV_API}/{doi}/na/json"
+    try:
+        with urllib.request.urlopen(url, timeout=20) as fh:
+            data = json.load(fh)
+        if data.get("messages", [{}])[0].get("status") != "ok":
+            return None
+        coll = data.get("collection", [])
+        return coll[0] if coll else None
+    except Exception as exc:
+        logger.warning("biorxiv metadata fetch failed: %s", exc)
+        return None
+
+
+def _normalize_jats_url(url: str) -> str:
+    """bioRxiv's API sometimes returns paths with a doubled slash (e.g.
+    `early/2026/03/23//2026.03.20.713219.source.xml`). Highwire returns 404
+    for those literal paths but accepts the collapsed form."""
+    scheme, _, rest = url.partition("://")
+    return scheme + "://" + re.sub(r"/{2,}", "/", rest)
+
+
+def _try_biorxiv_curlcffi(meta: dict, out_path: Path) -> tuple[bool, str]:
+    jats_url = meta.get("jatsxml")
+    if not jats_url:
+        return False, "no jatsxml URL in bioRxiv metadata"
+    jats_url = _normalize_jats_url(jats_url)
+    try:
+        from curl_cffi import requests as cf_requests  # type: ignore[import-not-found]
+    except ImportError:
+        return False, "curl_cffi not installed (pip install atlas_chat[local-index])"
+    try:
+        resp = cf_requests.get(jats_url, impersonate="chrome120", timeout=60)
+        if resp.status_code != 200:
+            return False, f"jatsxml returned {resp.status_code}"
+        text = resp.text
+        if "<article" not in text[:2000]:
+            return False, "response is not a JATS article (likely CF challenge)"
+        out_path.write_text(text)
+        return True, "fetched via curl_cffi (chrome120 impersonation)"
+    except Exception as exc:
+        return False, f"curl_cffi exception: {exc}"
+
+
+# ------------------------------------------------------------------
+# Path 3: Playwright fallback
+# ------------------------------------------------------------------
+
+
+def _try_playwright(meta: dict, out_path: Path) -> tuple[bool, str]:
+    jats_url = meta.get("jatsxml")
+    if not jats_url:
+        return False, "no jatsxml URL"
+    jats_url = _normalize_jats_url(jats_url)
+    try:
+        from playwright.sync_api import sync_playwright  # type: ignore[import-not-found]
+    except ImportError:
+        return False, "playwright not installed"
+    try:
+        # Need to navigate to a biorxiv page first to get CF cookies, then
+        # use the in-browser fetch with credentials.
+        doi = meta.get("doi", "")
+        seed_url = f"https://www.biorxiv.org/content/{doi}v{meta.get('version', 1)}"
+        with sync_playwright() as pw:
+            browser = pw.chromium.launch()
+            ctx = browser.new_context()
+            page = ctx.new_page()
+            page.goto(seed_url, timeout=30000)
+            text = page.evaluate(
+                "async (url) => {"
+                " const r = await fetch(url, {credentials: 'include'});"
+                " return r.ok ? await r.text() : null;"
+                "}",
+                jats_url,
+            )
+            browser.close()
+        if not text or "<article" not in text[:2000]:
+            return False, "Playwright fetched but content not a JATS article"
+        out_path.write_text(text)
+        return True, "fetched via Playwright fallback"
+    except Exception as exc:
+        return False, f"Playwright exception: {exc}"
+
+
+# ------------------------------------------------------------------
+# Entry point
+# ------------------------------------------------------------------
+
+
+def fetch_preprint(doi: str, out_dir: Path) -> FetchedPreprint:
+    """Fetch JATS XML for a preprint, trying EuropePMC then bioRxiv paths.
+
+    Writes `paper.jats.xml` inside out_dir. Raises PreprintFetchError if
+    every path fails.
+    """
+    out_dir.mkdir(parents=True, exist_ok=True)
+    jats_path = out_dir / "paper.jats.xml"
+    attempts: list[tuple[str, str]] = []
+
+    # Path 1: EuropePMC
+    ok, reason = _try_europepmc(doi, jats_path)
+    attempts.append(("europepmc", reason))
+    if ok:
+        logger.info("fetch_preprint(%s): %s", doi, reason)
+        return FetchedPreprint(doi=doi, jats_path=jats_path, source_used="europepmc")
+
+    # Paths 2 + 3 need bioRxiv metadata first
+    meta = _biorxiv_metadata(doi)
+    if not meta:
+        attempts.append(("biorxiv_api", "metadata lookup failed"))
+        raise PreprintFetchError(doi, attempts)
+
+    # Path 2: curl_cffi
+    ok, reason = _try_biorxiv_curlcffi(meta, jats_path)
+    attempts.append(("biorxiv_curlcffi", reason))
+    if ok:
+        logger.info("fetch_preprint(%s): %s", doi, reason)
+        return _populate(doi, jats_path, "biorxiv_curlcffi", meta)
+
+    # Path 3: Playwright
+    ok, reason = _try_playwright(meta, jats_path)
+    attempts.append(("biorxiv_playwright", reason))
+    if ok:
+        logger.info("fetch_preprint(%s): %s", doi, reason)
+        return _populate(doi, jats_path, "biorxiv_playwright", meta)
+
+    raise PreprintFetchError(doi, attempts)
+
+
+def _populate(doi: str, jats_path: Path, source: str, meta: dict) -> FetchedPreprint:
+    year_match = re.match(r"(\d{4})", meta.get("date", ""))
+    return FetchedPreprint(
+        doi=doi,
+        jats_path=jats_path,
+        source_used=source,
+        title=meta.get("title"),
+        authors=meta.get("authors"),
+        year=int(year_match.group(1)) if year_match else None,
+    )
+
+
+# ------------------------------------------------------------------
+# CLI
+# ------------------------------------------------------------------
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n", maxsplit=1)[0])
+    parser.add_argument("doi", help="Preprint DOI, e.g. 10.1101/2026.03.20.713219")
+    parser.add_argument("--out", required=True, type=Path, help="Output directory")
+    parser.add_argument("-v", "--verbose", action="store_true")
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(
+        level=logging.INFO if args.verbose else logging.WARNING,
+        format="%(levelname)s: %(message)s",
+    )
+
+    try:
+        result = fetch_preprint(args.doi, args.out)
+    except PreprintFetchError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+    print(json.dumps(asdict(result), default=str, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/atlas_chat/atlas_chat/services/local_snippet_index.py
+++ b/src/atlas_chat/atlas_chat/services/local_snippet_index.py
@@ -64,7 +64,7 @@ class SentenceRow:
 
 
 def _normalize_biorxiv_jats(xml: str) -> str:
-    """Make bioRxiv JATS digestible by paperqa2_cyberian.parse_jats_citations.
+    """Make bioRxiv JATS digestible by `_jats_parser.parse_jats_citations`.
 
     Two fixes:
       1. Strip `hwp:*` namespaced attributes that get aliased to `id` after
@@ -261,14 +261,14 @@ def build_sentence_rows(
     xml: str,
     fulltext: str,
 ) -> tuple[list[SentenceRow], dict[str, Any]]:
-    """Run paperqa2_cyberian.parse_jats_citations and align each cited sentence
+    """Run the vendored `_jats_parser.parse_jats_citations` and align each cited sentence
     to a char offset in `fulltext`. Returns (rows, refs_dict).
 
     `refs_dict` is the full {ref_id → ResolvedRef} mapping from the parser —
     callers can read `.doi`, `.title`, `.year`, `.first_author` for downstream
     resolution (DOI batch + title-match fallback).
     """
-    from paperqa2_cyberian.parse_jats_citations import parse_jats_citations
+    from atlas_chat.services._jats_parser import parse_jats_citations
 
     cited, refs = parse_jats_citations(xml)
 

--- a/src/atlas_chat/atlas_chat/services/local_snippet_index.py
+++ b/src/atlas_chat/atlas_chat/services/local_snippet_index.py
@@ -1,0 +1,806 @@
+"""Local snippet index for fresh-preprint atlases.
+
+Builds a project-wide chunk store + sentence-citation graph + ASTA-shape
+snippet index from a single JATS XML file. The `search()` API returns dicts
+shaped like `citation_traverser._snippet_to_dict(AstaSnippet(...))` so the
+downstream `_summarize_snippets` / `validate_report` machinery consumes them
+unchanged.
+
+The index is gated by `local_index/manifest.json` — if absent, the pipeline
+falls through to ASTA-only.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import logging
+import re
+import sys
+import urllib.request
+import xml.etree.ElementTree as ET
+from dataclasses import asdict, dataclass, field
+from functools import lru_cache
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+EMBED_MODEL = "sentence-transformers/all-MiniLM-L6-v2"
+CHUNK_TARGET_CHARS = 2800
+CHUNK_OVERLAP_CHARS = 200
+MANIFEST_VERSION = 1
+
+
+# ------------------------------------------------------------------
+# Data classes (on-disk shape)
+# ------------------------------------------------------------------
+
+
+@dataclass
+class Chunk:
+    chunk_id: int
+    section: str
+    char_start: int
+    char_end: int
+    text: str
+
+
+@dataclass
+class SentenceRow:
+    text: str
+    section: str
+    char_start: int  # offset in the cleaned full-text
+    char_end: int
+    ref_ids: list[str]
+    # resolved at build time:
+    doi_list: list[str] = field(default_factory=list)
+
+
+# ------------------------------------------------------------------
+# JATS normalisation (bioRxiv quirks)
+# ------------------------------------------------------------------
+
+
+def _normalize_biorxiv_jats(xml: str) -> str:
+    """Make bioRxiv JATS digestible by paperqa2_cyberian.parse_jats_citations.
+
+    Two fixes:
+      1. Strip `hwp:*` namespaced attributes that get aliased to `id` after
+         namespace strip, overwriting the real `<ref id="cNN">` value.
+      2. Rename `<citation>` (Highwire convention) to `<element-citation>`
+         (JATS standard) so the parser's ref-detail extractor matches.
+    """
+    # Remove hwp:* attributes from any element. Match on attribute name to
+    # avoid pulling in unrelated namespaces.
+    xml = re.sub(r'\s+hwp:[\w:-]+="[^"]*"', "", xml)
+    xml = re.sub(r'\s+xmlns:hw="[^"]*"', "", xml)
+    # Rename <citation ...> → <element-citation ...> only when it carries
+    # publication-type (the JATS-ish citation, not other uses of <citation>).
+    xml = re.sub(
+        r"<citation(\s+[^>]*publication-type=)",
+        r"<element-citation\1",
+        xml,
+    )
+    xml = xml.replace("</citation>", "</element-citation>")
+    return xml
+
+
+# ------------------------------------------------------------------
+# JATS → plain text + sections
+# ------------------------------------------------------------------
+
+
+@dataclass
+class _BodySegment:
+    section: str
+    text: str  # paragraph text (whitespace collapsed)
+
+
+def _strip_ns(root: ET.Element) -> None:
+    for el in root.iter():
+        if "}" in el.tag:
+            el.tag = el.tag.split("}", 1)[1]
+
+
+def _text_of(el: ET.Element) -> str:
+    """Concatenate all descendant text, skipping ref-list and tables."""
+    parts: list[str] = []
+    if el.text:
+        parts.append(el.text)
+    for child in el:
+        if child.tag in {"ref-list", "table-wrap"}:
+            continue
+        parts.append(_text_of(child))
+        if child.tail:
+            parts.append(child.tail)
+    return "".join(parts)
+
+
+def extract_body_segments(xml: str) -> list[_BodySegment]:
+    """Walk JATS body, return ordered paragraph segments with section labels."""
+    root = ET.fromstring(xml)
+    _strip_ns(root)
+
+    segments: list[_BodySegment] = []
+
+    # Abstract first
+    for abs_el in root.iter("abstract"):
+        for p in abs_el.iter("p"):
+            txt = re.sub(r"\s+", " ", _text_of(p)).strip()
+            if txt:
+                segments.append(_BodySegment("ABSTRACT", txt))
+
+    # Body sections (recursive)
+    body = root.find(".//body")
+    if body is None:
+        return segments
+
+    def walk(sec_el: ET.Element, parent_title: str) -> None:
+        title_el = sec_el.find("title")
+        title = (
+            re.sub(r"\s+", " ", _text_of(title_el)).strip()
+            if title_el is not None
+            else parent_title
+        )
+        for child in sec_el:
+            if child.tag == "sec":
+                walk(child, title)
+            elif child.tag == "p":
+                txt = re.sub(r"\s+", " ", _text_of(child)).strip()
+                if txt:
+                    segments.append(_BodySegment(title, txt))
+
+    for sec in body.findall("sec"):
+        walk(sec, "BODY")
+    # Top-level <p> inside body (no sec wrapper)
+    for p in body.findall("p"):
+        txt = re.sub(r"\s+", " ", _text_of(p)).strip()
+        if txt:
+            segments.append(_BodySegment("BODY", txt))
+
+    return segments
+
+
+# ------------------------------------------------------------------
+# Chunking
+# ------------------------------------------------------------------
+
+
+def chunk_segments(
+    segments: list[_BodySegment],
+    target_chars: int = CHUNK_TARGET_CHARS,
+    overlap_chars: int = CHUNK_OVERLAP_CHARS,
+) -> tuple[str, list[Chunk]]:
+    """Build paragraph-aware chunks. Returns (concatenated_fulltext, chunks).
+
+    Adjacent paragraphs from the same section are concatenated up to target
+    size. Section boundaries flush the current chunk. Overlap is added by
+    re-emitting the tail of the previous chunk if the next paragraph would
+    otherwise start a fresh chunk.
+    """
+    fulltext_parts: list[str] = []
+    chunks: list[Chunk] = []
+    cursor = 0
+    cur_section = ""
+    cur_text = ""
+    cur_start = 0
+
+    def flush() -> None:
+        nonlocal cur_text, cur_start
+        if not cur_text:
+            return
+        chunk = Chunk(
+            chunk_id=len(chunks),
+            section=cur_section,
+            char_start=cur_start,
+            char_end=cur_start + len(cur_text),
+            text=cur_text,
+        )
+        chunks.append(chunk)
+        cur_text = ""
+
+    for seg in segments:
+        para = seg.text + "\n\n"
+        para_start = cursor
+        fulltext_parts.append(para)
+        cursor += len(para)
+
+        # New section → flush current
+        if cur_section and seg.section != cur_section:
+            flush()
+        if not cur_text:
+            cur_section = seg.section
+            cur_start = para_start
+            cur_text = para
+        elif len(cur_text) + len(para) <= target_chars:
+            cur_text += para
+        else:
+            flush()
+            # Carry overlap from end of the previous chunk
+            if chunks and overlap_chars > 0:
+                tail = chunks[-1].text[-overlap_chars:]
+                cur_text = tail + para
+                cur_start = chunks[-1].char_end - len(tail)
+            else:
+                cur_text = para
+                cur_start = para_start
+            cur_section = seg.section
+    flush()
+
+    fulltext = "".join(fulltext_parts)
+    return fulltext, chunks
+
+
+# ------------------------------------------------------------------
+# Sentence-level citation graph
+# ------------------------------------------------------------------
+
+
+def build_sentence_rows(
+    xml: str,
+    fulltext: str,
+) -> tuple[list[SentenceRow], dict[str, Any]]:
+    """Run paperqa2_cyberian.parse_jats_citations and align each cited sentence
+    to a char offset in `fulltext`. Returns (rows, refs_dict).
+
+    `refs_dict` is the full {ref_id → ResolvedRef} mapping from the parser —
+    callers can read `.doi`, `.title`, `.year`, `.first_author` for downstream
+    resolution (DOI batch + title-match fallback).
+    """
+    from paperqa2_cyberian.parse_jats_citations import parse_jats_citations
+
+    cited, refs = parse_jats_citations(xml)
+
+    ref_id_to_doi = {rid: r.doi for rid, r in refs.items() if r.doi}
+
+    rows: list[SentenceRow] = []
+    for cs in cited:
+        # Try to locate the cited sentence in fulltext. parse_jats_citations
+        # emits sentence text WITH citation markers like [12-15]. Strip those
+        # to find the underlying text in our cleaned fulltext.
+        needle = re.sub(r"\[[^\]]{1,40}\]", "", cs.text).strip()
+        if not needle:
+            continue
+        # Pick the first 80 chars as a search anchor (longer = more unique).
+        anchor = needle[:80]
+        pos = fulltext.find(anchor)
+        if pos < 0:
+            # Try without internal whitespace collapses
+            anchor_loose = re.sub(r"\s+", " ", anchor)
+            pos = fulltext.find(anchor_loose)
+        if pos < 0:
+            continue
+        doi_list = [ref_id_to_doi[rid] for rid in cs.ref_ids if rid in ref_id_to_doi]
+        rows.append(
+            SentenceRow(
+                text=cs.text,
+                section=cs.section,
+                char_start=pos,
+                char_end=pos + len(needle),
+                ref_ids=cs.ref_ids,
+                doi_list=doi_list,
+            )
+        )
+    return rows, refs
+
+
+# ------------------------------------------------------------------
+# DOI → CorpusId resolution via Semantic Scholar (batch)
+# ------------------------------------------------------------------
+
+
+def _resolve_dois_to_corpus_ids(dois: list[str]) -> dict[str, str]:
+    """Batch-resolve DOIs to Semantic Scholar CorpusIds.
+
+    Retries on 429 with exponential backoff (3 attempts, 2-4-8 second sleeps)."""
+    import time
+
+    import httpx
+
+    if not dois:
+        return {}
+    unique = list({d for d in dois if d})
+    out: dict[str, str] = {}
+    batch_size = 100
+    api = "https://api.semanticscholar.org/graph/v1/paper/batch"
+    fields = "externalIds,title,authors,year"
+    with httpx.Client(timeout=60) as client:
+        for i in range(0, len(unique), batch_size):
+            batch = unique[i : i + batch_size]
+            for attempt in range(3):
+                try:
+                    resp = client.post(
+                        api,
+                        params={"fields": fields},
+                        json={"ids": [f"DOI:{d}" for d in batch]},
+                    )
+                    if resp.status_code == 429:
+                        sleep = 2 ** (attempt + 1)
+                        logger.warning("S2 429, sleeping %ds (attempt %d)", sleep, attempt + 1)
+                        time.sleep(sleep)
+                        continue
+                    if resp.status_code != 200:
+                        logger.warning("S2 batch returned %d", resp.status_code)
+                        break
+                    for d, paper in zip(batch, resp.json(), strict=False):
+                        if not paper:
+                            continue
+                        cid = paper.get("externalIds", {}).get("CorpusId")
+                        if cid:
+                            out[d] = str(cid)
+                    break
+                except Exception as exc:
+                    logger.warning("S2 batch attempt %d failed: %s", attempt + 1, exc)
+                    if attempt == 2:
+                        break
+                    time.sleep(2 ** (attempt + 1))
+    logger.info("Resolved %d/%d DOIs to CorpusIds", len(out), len(unique))
+    return out
+
+
+def _resolve_title_to_corpus_id(
+    title: str,
+    year: int | None,
+    first_author: str | None,
+    client: Any,
+) -> tuple[str | None, str | None]:
+    """Single-paper title-match via Semantic Scholar.
+
+    Returns (corpus_id, doi) — both None if no confident match. Uses S2's
+    /paper/search/match endpoint, which returns the single best title match
+    (or empty data if confidence is too low). Retries once on 429.
+    """
+    import time
+
+    api = "https://api.semanticscholar.org/graph/v1/paper/search/match"
+    params = {"query": title[:300], "fields": "externalIds,title,year,authors"}
+    for attempt in range(3):
+        try:
+            resp = client.get(api, params=params)
+            if resp.status_code == 429:
+                time.sleep(2 ** (attempt + 1))
+                continue
+            if resp.status_code == 404:
+                return None, None  # no match
+            if resp.status_code != 200:
+                return None, None
+            data = resp.json().get("data", [])
+            if not data:
+                return None, None
+            best = data[0]
+            # Year guard: discard matches more than 2 years off if year was supplied.
+            if year and best.get("year") and abs(int(best["year"]) - year) > 2:
+                return None, None
+            # Author guard: require first-author surname appears in the matched
+            # author list when both are present.
+            if first_author and best.get("authors"):
+                au_text = " ".join(a.get("name", "") for a in best["authors"]).lower()
+                if first_author.lower() not in au_text:
+                    return None, None
+            ext = best.get("externalIds") or {}
+            cid = ext.get("CorpusId")
+            doi = ext.get("DOI")
+            return (str(cid) if cid else None), doi
+        except Exception as exc:
+            logger.debug("title-match attempt %d failed: %s", attempt + 1, exc)
+            time.sleep(2 ** (attempt + 1))
+    return None, None
+
+
+def _resolve_refs_to_corpus_ids(refs: dict[str, Any]) -> dict[str, dict[str, str | None]]:
+    """Resolve every ref to a CorpusId, using DOI batch first then title-match.
+
+    Returns a dict keyed by ref_id with shape:
+        {"corpus_id": str | None, "doi": str | None,
+         "method": "doi" | "title" | "none"}
+
+    `refs` is the dict returned by `parse_jats_citations` — values have `.doi`,
+    `.title`, `.year`, `.first_author` attributes (ResolvedRef dataclass)."""
+    import httpx
+
+    out: dict[str, dict[str, str | None]] = {}
+
+    # Phase 1: DOI batch resolution for refs that carry a DOI.
+    dois_to_lookup = [r.doi for r in refs.values() if r.doi]
+    doi_to_corpus = _resolve_dois_to_corpus_ids(dois_to_lookup)
+    for ref_id, r in refs.items():
+        if r.doi:
+            cid = doi_to_corpus.get(r.doi)
+            out[ref_id] = {
+                "corpus_id": cid,
+                "doi": r.doi,
+                "method": "doi" if cid else "doi_unmatched",
+            }
+
+    # Phase 2: title-match for refs without DOIs (or whose DOI didn't resolve).
+    title_candidates = [
+        (rid, r) for rid, r in refs.items() if r.title and not out.get(rid, {}).get("corpus_id")
+    ]
+    if not title_candidates:
+        logger.info("DOI-only resolution covered all refs (%d)", len(out))
+        return out
+
+    logger.info(
+        "Title-matching %d refs without resolved DOI via S2 /paper/search/match",
+        len(title_candidates),
+    )
+    resolved_via_title = 0
+    with httpx.Client(timeout=30) as client:
+        for ref_id, r in title_candidates:
+            cid, doi = _resolve_title_to_corpus_id(r.title, r.year, r.first_author, client)
+            entry = out.get(ref_id, {"corpus_id": None, "doi": r.doi, "method": "title_unmatched"})
+            if cid:
+                entry = {
+                    "corpus_id": cid,
+                    "doi": doi or r.doi,
+                    "method": "title",
+                }
+                resolved_via_title += 1
+            else:
+                entry["method"] = "title_unmatched"
+            out[ref_id] = entry
+
+    total_resolved = sum(1 for v in out.values() if v["corpus_id"])
+    logger.info(
+        "Resolved %d/%d refs to CorpusIds (%d via DOI, %d via title-match)",
+        total_resolved,
+        len(refs),
+        len(doi_to_corpus),
+        resolved_via_title,
+    )
+    return out
+
+
+# ------------------------------------------------------------------
+# bioRxiv metadata
+# ------------------------------------------------------------------
+
+
+def _biorxiv_meta(doi: str) -> dict | None:
+    url = f"https://api.biorxiv.org/details/biorxiv/{doi}/na/json"
+    try:
+        with urllib.request.urlopen(url, timeout=20) as fh:
+            data = json.load(fh)
+        if data.get("messages", [{}])[0].get("status") != "ok":
+            return None
+        coll = data.get("collection", [])
+        return coll[0] if coll else None
+    except Exception:
+        return None
+
+
+# ------------------------------------------------------------------
+# Build orchestrator
+# ------------------------------------------------------------------
+
+
+def _local_corpus_id(doi: str) -> str:
+    """Stable atlas CorpusId for an unindexed preprint.
+
+    Format `CorpusId:local_<sha1[:10]>` — the `local_` token has no digits so
+    it sidesteps the legacy `CorpusId:\\d+` validation regex in
+    `report_checker.py::check_references` while preserving shape parity."""
+    h = hashlib.sha1(doi.encode("utf-8")).hexdigest()[:10]
+    return f"CorpusId:local_{h}"
+
+
+def _manifest_hash(xml_bytes: bytes, parser_version: int = 1) -> str:
+    h = hashlib.sha256()
+    h.update(xml_bytes)
+    h.update(f"|emb={EMBED_MODEL}|p={parser_version}|m={MANIFEST_VERSION}".encode())
+    return h.hexdigest()
+
+
+def build_local_index(
+    project_dir: Path,
+    doi: str,
+    jats_path: Path | None = None,
+    force: bool = False,
+) -> dict[str, Any]:
+    """Build (or refresh) the local snippet index for a project.
+
+    If `jats_path` is None, `services.fetch_preprint.fetch_preprint` is called
+    to populate it. Otherwise the existing JATS file is used as-is.
+    Idempotent: a re-run with unchanged JATS short-circuits unless force=True.
+    Returns the manifest dict.
+    """
+    project_dir = Path(project_dir)
+    idx_dir = project_dir / "local_index"
+    source_dir = idx_dir / "source"
+    chunks_dir = idx_dir / "chunks"
+    citations_dir = idx_dir / "citations"
+    snippet_dir = idx_dir / "snippet_index"
+    for d in (idx_dir, source_dir, chunks_dir, citations_dir, snippet_dir):
+        d.mkdir(parents=True, exist_ok=True)
+
+    # 1. Resolve JATS path
+    if jats_path is None:
+        jats_path = source_dir / "paper.jats.xml"
+        if not jats_path.exists() or force:
+            from atlas_chat.services.fetch_preprint import fetch_preprint
+
+            fetched = fetch_preprint(doi, source_dir)
+            jats_path = fetched.jats_path
+    else:
+        # Copy / link into source dir for self-containment
+        target = source_dir / "paper.jats.xml"
+        if jats_path.resolve() != target.resolve():
+            target.write_bytes(jats_path.read_bytes())
+            jats_path = target
+
+    raw_xml_bytes = jats_path.read_bytes()
+    manifest_path = idx_dir / "manifest.json"
+    expected_hash = _manifest_hash(raw_xml_bytes)
+    if manifest_path.exists() and not force:
+        try:
+            existing = json.loads(manifest_path.read_text())
+            if existing.get("hash") == expected_hash:
+                logger.info("Local index already up to date (manifest hash match).")
+                return existing
+        except Exception:
+            pass
+
+    xml = raw_xml_bytes.decode("utf-8")
+    normalized = _normalize_biorxiv_jats(xml)
+
+    # 2. Body text + paragraph segments → chunks
+    segments = extract_body_segments(normalized)
+    fulltext, chunks = chunk_segments(segments)
+    (chunks_dir / "chunks.fulltext.txt").write_text(fulltext)
+    with (chunks_dir / "chunks.jsonl").open("w") as fh:
+        for c in chunks:
+            fh.write(json.dumps(asdict(c)) + "\n")
+
+    # 3. Embeddings
+    embeddings_path = chunks_dir / "embeddings.npy"
+    _embed_and_save([c.text for c in chunks], embeddings_path)
+
+    # 4. Sentence-level citation graph (and full refs dict)
+    sent_rows, refs_full = build_sentence_rows(normalized, fulltext)
+    with (citations_dir / "sentences.jsonl").open("w") as fh:
+        for r in sent_rows:
+            fh.write(json.dumps(asdict(r)) + "\n")
+
+    # 5. Resolve EVERY cited ref to a CorpusId — DOI batch first, then title-match
+    #    for refs without a DOI (or whose DOI didn't resolve).
+    ref_resolution = _resolve_refs_to_corpus_ids(refs_full)
+    (citations_dir / "ref_resolution.json").write_text(json.dumps(ref_resolution, indent=2))
+    ref_id_to_corpus = {
+        rid: entry["corpus_id"] for rid, entry in ref_resolution.items() if entry["corpus_id"]
+    }
+
+    # 6. Atlas-paper metadata (for ASTA-shape paper field)
+    meta = _biorxiv_meta(doi) or {}
+    paper_meta = {
+        "title": meta.get("title", ""),
+        "authors": meta.get("authors", ""),
+        "year": int(re.match(r"(\d{4})", meta.get("date", "") or "").group(1))
+        if re.match(r"(\d{4})", meta.get("date", "") or "")
+        else None,
+        "doi": doi,
+        "corpus_id": _local_corpus_id(doi),
+        "url": f"https://www.biorxiv.org/content/{doi}v{meta.get('version', 1)}",
+    }
+
+    # 7. Merge chunks ↔ sentences → ASTA-shape snippet index
+    snippets = _merge_snippets(chunks, sent_rows, ref_id_to_corpus, paper_meta)
+    (snippet_dir / "snippets.json").write_text(json.dumps(snippets, indent=2))
+
+    manifest = {
+        "version": MANIFEST_VERSION,
+        "doi": doi,
+        "hash": expected_hash,
+        "embedding_model": EMBED_MODEL,
+        "n_chunks": len(chunks),
+        "n_sentences": len(sent_rows),
+        "n_refs": len(refs_full),
+        "n_corpus_ids_resolved": len(ref_id_to_corpus),
+        "resolution_methods": _resolution_breakdown(ref_resolution),
+        "paper": paper_meta,
+    }
+    manifest_path.write_text(json.dumps(manifest, indent=2))
+    logger.info(
+        "Built local_index: %d chunks, %d cited sentences, %d/%d refs resolved (%s)",
+        len(chunks),
+        len(sent_rows),
+        len(ref_id_to_corpus),
+        len(refs_full),
+        manifest["resolution_methods"],
+    )
+    return manifest
+
+
+def _embed_and_save(texts: list[str], out_path: Path) -> None:
+    import numpy as np
+    from sentence_transformers import SentenceTransformer
+
+    model = SentenceTransformer(EMBED_MODEL)
+    vecs = model.encode(texts, convert_to_numpy=True, show_progress_bar=False)
+    # Normalise for cosine similarity at search time
+    norms = np.linalg.norm(vecs, axis=1, keepdims=True)
+    norms[norms == 0] = 1.0
+    vecs = vecs / norms
+    np.save(out_path, vecs)
+
+
+def _resolution_breakdown(ref_resolution: dict[str, dict[str, str | None]]) -> dict[str, int]:
+    """Count refs by resolution method for the manifest."""
+    counts: dict[str, int] = {}
+    for entry in ref_resolution.values():
+        m = entry.get("method") or "none"
+        counts[m] = counts.get(m, 0) + 1
+    return counts
+
+
+def _merge_snippets(
+    chunks: list[Chunk],
+    sent_rows: list[SentenceRow],
+    ref_id_to_corpus: dict[str, str],
+    paper_meta: dict,
+) -> list[dict]:
+    """Emit one ASTA-shape snippet per chunk with refMentions baked in.
+
+    refMentions are emitted per `ref_id` (not per DOI), so refs resolved via
+    title-match (no DOI) still produce mentions."""
+    # Index sentences by char_start for fast lookup
+    sent_rows_sorted = sorted(sent_rows, key=lambda r: r.char_start)
+    snippets: list[dict] = []
+    for c in chunks:
+        ref_mentions: list[dict] = []
+        for r in sent_rows_sorted:
+            if r.char_start >= c.char_end:
+                break
+            if r.char_end <= c.char_start:
+                continue
+            # Only keep sentences fully inside the chunk (loss-tolerant)
+            if r.char_start < c.char_start or r.char_end > c.char_end:
+                continue
+            for ref_id in r.ref_ids:
+                cid = ref_id_to_corpus.get(ref_id)
+                if not cid:
+                    continue
+                ref_mentions.append(
+                    {
+                        "matchedPaperCorpusId": cid,
+                        "ref_id": ref_id,
+                        "start": r.char_start - c.char_start,
+                        "end": r.char_end - c.char_start,
+                    }
+                )
+        snippets.append(
+            {
+                "chunk_id": c.chunk_id,
+                "paper": {
+                    "corpusId": paper_meta["corpus_id"],
+                    "title": paper_meta["title"],
+                    "authors": paper_meta["authors"],
+                    "year": paper_meta["year"],
+                    "doi": paper_meta["doi"],
+                },
+                "snippet": {
+                    "text": c.text,
+                    "section": c.section,
+                    "annotations": {"refMentions": ref_mentions},
+                },
+            }
+        )
+    return snippets
+
+
+# ------------------------------------------------------------------
+# Retrieval API (Phase 3)
+# ------------------------------------------------------------------
+
+
+@lru_cache(maxsize=8)
+def _load_index(project_dir_str: str) -> dict[str, Any]:
+    project_dir = Path(project_dir_str)
+    idx_dir = project_dir / "local_index"
+    manifest = json.loads((idx_dir / "manifest.json").read_text())
+    chunks: list[dict] = []
+    with (idx_dir / "chunks" / "chunks.jsonl").open() as fh:
+        for line in fh:
+            chunks.append(json.loads(line))
+    snippets = json.loads((idx_dir / "snippet_index" / "snippets.json").read_text())
+    snippet_by_chunk = {s["chunk_id"]: s for s in snippets}
+
+    import numpy as np
+
+    embeddings = np.load(idx_dir / "chunks" / "embeddings.npy")
+    return {
+        "manifest": manifest,
+        "chunks": chunks,
+        "snippets_by_chunk": snippet_by_chunk,
+        "embeddings": embeddings,
+    }
+
+
+def search(project_dir: Path, query: str, k: int = 20) -> list[dict[str, Any]]:
+    """Local snippet search returning ASTA-shape dicts compatible with
+    `_summarize_snippets` and `_snippet_to_dict(AstaSnippet)`.
+    """
+    import numpy as np
+    from sentence_transformers import SentenceTransformer
+
+    state = _load_index(str(Path(project_dir).resolve()))
+    embeddings = state["embeddings"]
+    manifest = state["manifest"]
+
+    model = SentenceTransformer(EMBED_MODEL)
+    q_vec = model.encode([query], convert_to_numpy=True)[0]
+    q_vec = q_vec / max(np.linalg.norm(q_vec), 1e-9)
+    scores = embeddings @ q_vec
+    top_idx = np.argsort(-scores)[:k].tolist()
+
+    paper_meta = manifest["paper"]
+    out: list[dict[str, Any]] = []
+    for i in top_idx:
+        chunk = state["chunks"][i]
+        snippet_entry = state["snippets_by_chunk"].get(chunk["chunk_id"], {})
+        ref_mentions = (
+            snippet_entry.get("snippet", {}).get("annotations", {}).get("refMentions", [])
+        )
+        out.append(
+            {
+                # Fields required by _snippet_to_dict + snippet_summarizer prompt:
+                "snippet": chunk["text"],
+                "paper_id": paper_meta["corpus_id"],
+                "corpus_id": paper_meta["corpus_id"],
+                "title": paper_meta["title"],
+                "authors": paper_meta["authors"],
+                "year": paper_meta["year"],
+                "url": paper_meta["url"],
+                "score": float(scores[i]),
+                # Extras for downstream / debugging:
+                "doi": paper_meta.get("doi", ""),
+                "section": chunk["section"],
+                "chunk_id": chunk["chunk_id"],
+                "annotations": {"refMentions": ref_mentions},
+                "source_method": "local_snippet",
+            }
+        )
+    return out
+
+
+def has_local_index(project_dir: Path) -> bool:
+    return (Path(project_dir) / "local_index" / "manifest.json").exists()
+
+
+# ------------------------------------------------------------------
+# CLI
+# ------------------------------------------------------------------
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n", maxsplit=1)[0])
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    p_build = sub.add_parser("build", help="Build / refresh the local index")
+    p_build.add_argument("--project", required=True, type=Path)
+    p_build.add_argument("--doi", required=True)
+    p_build.add_argument("--jats", type=Path, default=None, help="Use existing JATS XML")
+    p_build.add_argument("--force", action="store_true")
+
+    p_search = sub.add_parser("search", help="Query the local index")
+    p_search.add_argument("--project", required=True, type=Path)
+    p_search.add_argument("--query", required=True)
+    p_search.add_argument("-k", type=int, default=10)
+
+    args = parser.parse_args(argv)
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+
+    if args.cmd == "build":
+        manifest = build_local_index(args.project, args.doi, args.jats, args.force)
+        print(json.dumps(manifest, indent=2))
+        return 0
+    if args.cmd == "search":
+        results = search(args.project, args.query, k=args.k)
+        print(json.dumps(results, indent=2))
+        return 0
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/atlas_chat/atlas_chat/services/local_snippet_index.py
+++ b/src/atlas_chat/atlas_chat/services/local_snippet_index.py
@@ -104,15 +104,34 @@ def _strip_ns(root: ET.Element) -> None:
             el.tag = el.tag.split("}", 1)[1]
 
 
-def _text_of(el: ET.Element) -> str:
-    """Concatenate all descendant text, skipping ref-list and tables."""
+def _is_bibr_xref(el: ET.Element) -> bool:
+    return el.tag == "xref" and el.get("ref-type") == "bibr"
+
+
+def _contains_bibr(el: ET.Element) -> bool:
+    return any(_is_bibr_xref(g) for g in el.iter())
+
+
+def _text_of(el: ET.Element, in_citation: bool = False) -> str:
+    """Concatenate all descendant text, skipping ref-list and tables.
+
+    Wraps citation markers in brackets so the rendered text shows e.g.
+    ``[12-15]`` rather than a bare ``12-15`` run (which would otherwise
+    appear glued to surrounding words and make blockquote validation
+    against `parse_jats_citations`'s sentence output — which already
+    bracket-wraps — impossible).
+    """
     parts: list[str] = []
     if el.text:
         parts.append(el.text)
     for child in el:
         if child.tag in {"ref-list", "table-wrap"}:
             continue
-        parts.append(_text_of(child))
+        is_citation_block = (child.tag == "sup" and _contains_bibr(child)) or _is_bibr_xref(child)
+        if is_citation_block and not in_citation:
+            parts.append("[" + _text_of(child, in_citation=True) + "]")
+        else:
+            parts.append(_text_of(child, in_citation=in_citation))
         if child.tail:
             parts.append(child.tail)
     return "".join(parts)
@@ -257,21 +276,20 @@ def build_sentence_rows(
 
     rows: list[SentenceRow] = []
     for cs in cited:
-        # Try to locate the cited sentence in fulltext. parse_jats_citations
-        # emits sentence text WITH citation markers like [12-15]. Strip those
-        # to find the underlying text in our cleaned fulltext.
-        needle = re.sub(r"\[[^\]]{1,40}\]", "", cs.text).strip()
-        if not needle:
-            continue
-        # Pick the first 80 chars as a search anchor (longer = more unique).
-        anchor = needle[:80]
+        # parse_jats_citations emits sentence text with bracketed citation
+        # markers like [12-15]. The body chunker now also bracket-wraps
+        # bibr xrefs, so the sentence text should match the fulltext
+        # directly. Fall back to a bracket-stripped form for any cases the
+        # two extractors render differently.
+        anchor = cs.text[:80]
         pos = fulltext.find(anchor)
         if pos < 0:
-            # Try without internal whitespace collapses
-            anchor_loose = re.sub(r"\s+", " ", anchor)
-            pos = fulltext.find(anchor_loose)
+            stripped = re.sub(r"\[[^\]]{1,40}\]", "", cs.text).strip()
+            if stripped:
+                pos = fulltext.find(stripped[:80])
         if pos < 0:
             continue
+        needle = cs.text
         doi_list = [ref_id_to_doi[rid] for rid in cs.ref_ids if rid in ref_id_to_doi]
         rows.append(
             SentenceRow(

--- a/src/atlas_chat/pyproject.toml
+++ b/src/atlas_chat/pyproject.toml
@@ -22,9 +22,10 @@ dev = [
     "mypy>=1.10.0",
 ]
 # Local snippet index for fresh preprints (not yet indexed by ASTA / EuropePMC).
-# Pulls in sentence-transformers + paper-qa (~500 MB) — keep optional.
+# Pulls in sentence-transformers (~500 MB) — keep optional.
 local-index = [
-    "paperqa2-cyberian @ git+https://github.com/Cellular-Semantics/paperqa2_cyberian.git@main",
+    "sentence-transformers>=5.0",
+    "numpy>=1.26",
     "curl-cffi>=0.7.0",
 ]
 

--- a/src/atlas_chat/pyproject.toml
+++ b/src/atlas_chat/pyproject.toml
@@ -21,6 +21,12 @@ dev = [
     "ruff>=0.5.0",
     "mypy>=1.10.0",
 ]
+# Local snippet index for fresh preprints (not yet indexed by ASTA / EuropePMC).
+# Pulls in sentence-transformers + paper-qa (~500 MB) — keep optional.
+local-index = [
+    "paperqa2-cyberian @ git+https://github.com/Cellular-Semantics/paperqa2_cyberian.git@main",
+    "curl-cffi>=0.7.0",
+]
 
 [project.scripts]
 atlas-report = "atlas_chat.cli:main"

--- a/tests/unit/test_local_snippet_index.py
+++ b/tests/unit/test_local_snippet_index.py
@@ -39,8 +39,8 @@ JATS_FIXTURE = dedent("""\
       <body>
         <sec>
           <title>Introduction</title>
-          <p>Prior work showed marker expression in skin
-            <xref ref-type="bibr" rid="c1">1</xref>.</p>
+          <p>Prior work showed marker expression in skin<sup><xref
+              ref-type="bibr" rid="c1">1</xref></sup>.</p>
           <p>Another paragraph without citations describing methods.</p>
         </sec>
         <sec>

--- a/tests/unit/test_local_snippet_index.py
+++ b/tests/unit/test_local_snippet_index.py
@@ -1,0 +1,184 @@
+"""Unit tests for the local snippet index.
+
+Driven by a tiny synthetic JATS fixture so the test runs without network
+and without the heavy ML stack — only the parser + chunker + merge layer
+are exercised. The embedding step is bypassed via direct chunk inspection.
+"""
+
+from __future__ import annotations
+
+from textwrap import dedent
+
+import pytest
+from atlas_chat.services.local_snippet_index import (
+    _local_corpus_id,
+    _merge_snippets,
+    _normalize_biorxiv_jats,
+    build_sentence_rows,
+    chunk_segments,
+    extract_body_segments,
+    has_local_index,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+# Minimal bioRxiv-flavoured JATS: uses <citation> + hwp:id (the two quirks the
+# normaliser handles), one cited sentence, one ref-list entry with a DOI.
+JATS_FIXTURE = dedent("""\
+    <?xml version="1.0"?>
+    <article xmlns:hw="org.highwire.hpp">
+      <front>
+        <article-meta>
+          <abstract>
+            <p>Abstract paragraph mentioning ILC3 cells in skin.</p>
+          </abstract>
+        </article-meta>
+      </front>
+      <body>
+        <sec>
+          <title>Introduction</title>
+          <p>Prior work showed marker expression in skin
+            <xref ref-type="bibr" rid="c1">1</xref>.</p>
+          <p>Another paragraph without citations describing methods.</p>
+        </sec>
+        <sec>
+          <title>Results</title>
+          <p>We identified ILC3_CCL1+PTGDS+ cells localised to the superficial dermis.</p>
+        </sec>
+      </body>
+      <back>
+        <ref-list>
+          <ref id="c1" hwp:id="ref-1">
+            <citation publication-type="journal">
+              <article-title>Reference paper title</article-title>
+              <year>2021</year>
+              <pub-id pub-id-type="doi">10.1234/example</pub-id>
+            </citation>
+          </ref>
+        </ref-list>
+      </back>
+    </article>
+""")
+
+
+# ---------------------------------------------------------------------------
+# _normalize_biorxiv_jats
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_normalize_strips_hwp_and_renames_citation() -> None:
+    out = _normalize_biorxiv_jats(JATS_FIXTURE)
+    assert "hwp:id" not in out
+    assert "xmlns:hw=" not in out
+    assert "<element-citation" in out
+    # Plain <citation> on its own (without publication-type) is unchanged
+    assert "<citation publication-type=" not in out
+
+
+# ---------------------------------------------------------------------------
+# extract_body_segments + chunk_segments
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_body_extraction_includes_sections() -> None:
+    normalized = _normalize_biorxiv_jats(JATS_FIXTURE)
+    segments = extract_body_segments(normalized)
+    sections = {s.section for s in segments}
+    assert "ABSTRACT" in sections
+    assert "Introduction" in sections
+    assert "Results" in sections
+    # ref-list text should not appear in body extraction
+    assert not any("Reference paper title" in s.text for s in segments)
+
+
+@pytest.mark.unit
+def test_chunking_produces_fulltext_with_consistent_offsets() -> None:
+    normalized = _normalize_biorxiv_jats(JATS_FIXTURE)
+    segments = extract_body_segments(normalized)
+    fulltext, chunks = chunk_segments(segments)
+    assert chunks, "expected at least one chunk"
+    # Each chunk's slice of fulltext must equal its stored text
+    for c in chunks:
+        # Allow loose offsets when overlap is added, but text must be a
+        # substring of fulltext.
+        assert c.text in fulltext
+        assert c.section
+    # Re-assemble cleanly
+    assert "ILC3_CCL1+PTGDS+" in fulltext
+
+
+# ---------------------------------------------------------------------------
+# build_sentence_rows
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_sentence_rows_resolve_doi() -> None:
+    normalized = _normalize_biorxiv_jats(JATS_FIXTURE)
+    segments = extract_body_segments(normalized)
+    fulltext, _ = chunk_segments(segments)
+    rows, refs = build_sentence_rows(normalized, fulltext)
+    # The single cited sentence references c1 → 10.1234/example
+    assert "c1" in refs
+    assert refs["c1"].doi == "10.1234/example"
+    cited = [r for r in rows if "c1" in r.ref_ids]
+    assert cited, "expected at least one cited sentence"
+    assert all("10.1234/example" in r.doi_list for r in cited)
+
+
+# ---------------------------------------------------------------------------
+# _merge_snippets — ASTA-shape parity
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_merge_emits_asta_shape() -> None:
+    normalized = _normalize_biorxiv_jats(JATS_FIXTURE)
+    segments = extract_body_segments(normalized)
+    fulltext, chunks = chunk_segments(segments)
+    rows, _refs = build_sentence_rows(normalized, fulltext)
+    paper_meta = {
+        "corpus_id": "CorpusId:local_abc123",
+        "title": "Test",
+        "authors": "Test, A.",
+        "year": 2026,
+        "doi": "10.0000/test",
+    }
+    # Caller now supplies a ref_id → corpus_id map directly (supports refs
+    # resolved via title-match as well as via DOI).
+    ref_id_to_corpus = {"c1": "999999"}
+    snippets = _merge_snippets(chunks, rows, ref_id_to_corpus, paper_meta)
+    assert snippets
+    s0 = snippets[0]
+    # Top-level shape
+    assert {"chunk_id", "paper", "snippet"} <= set(s0.keys())
+    assert s0["paper"]["corpusId"] == "CorpusId:local_abc123"
+    # snippet shape
+    assert {"text", "section", "annotations"} <= set(s0["snippet"].keys())
+    # At least one refMention with the resolved corpus_id
+    all_refs = [rm for s in snippets for rm in s["snippet"]["annotations"]["refMentions"]]
+    assert any(rm["matchedPaperCorpusId"] == "999999" for rm in all_refs)
+
+
+# ---------------------------------------------------------------------------
+# Misc
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_local_corpus_id_format() -> None:
+    cid = _local_corpus_id("10.1101/foo")
+    assert cid.startswith("CorpusId:local_")
+    # Has no digits-only suffix → won't false-match the legacy `\d+` regex
+    import re
+
+    assert not re.match(r"^CorpusId:\d+$", cid)
+
+
+@pytest.mark.unit
+def test_has_local_index_false_for_missing(tmp_path) -> None:
+    assert not has_local_index(tmp_path)

--- a/uv.lock
+++ b/uv.lock
@@ -250,7 +250,8 @@ dev = [
 ]
 local-index = [
     { name = "curl-cffi" },
-    { name = "paperqa2-cyberian" },
+    { name = "numpy" },
+    { name = "sentence-transformers" },
 ]
 
 [package.metadata]
@@ -260,7 +261,7 @@ requires-dist = [
     { name = "deep-research-client", git = "https://github.com/monarch-initiative/deep-research-client.git?rev=main" },
     { name = "jsonschema", specifier = ">=4.22.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.10.0" },
-    { name = "paperqa2-cyberian", marker = "extra == 'local-index'", editable = "../paperqa2_cyberian" },
+    { name = "numpy", marker = "extra == 'local-index'", specifier = ">=1.26" },
     { name = "pydantic", specifier = ">=2.7.0" },
     { name = "pydantic-ai", specifier = ">=1.16.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0.0" },
@@ -268,6 +269,7 @@ requires-dist = [
     { name = "python-dotenv", specifier = ">=1.0.1" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.5.0" },
+    { name = "sentence-transformers", marker = "extra == 'local-index'", specifier = ">=5.0" },
 ]
 provides-extras = ["dev", "local-index"]
 
@@ -1139,13 +1141,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/0f/3e/b63f18349a0a266dd23453497f24202786f4a0d3f12b5554e385906f94a8/fhaviary-0.35.0-py3-none-any.whl", hash = "sha256:4637fdd58374bac3b0892d3cdf604f1b66ebffea64aacfbc8d639f1452d30e2f", size = 61677, upload-time = "2026-04-16T23:07:50.545Z" },
 ]
 
-[package.optional-dependencies]
-llm = [
-    { name = "fhlmi" },
-    { name = "litellm" },
-    { name = "packaging" },
-]
-
 [[package]]
 name = "fhlmi"
 version = "0.45.1"
@@ -1517,15 +1512,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/54/75/07f6aa680575d9646c4167db6407c41340cbe2357f5654c4e72a1b01ca14/hf_xet-1.4.2-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:6b0932eb8b10317ea78b7da6bab172b17be03bbcd7809383d8d5abd6a2233e04", size = 4432751, upload-time = "2026-03-13T06:58:46.533Z" },
     { url = "https://files.pythonhosted.org/packages/cd/71/193eabd7e7d4b903c4aa983a215509c6114915a5a237525ec562baddb868/hf_xet-1.4.2-cp37-abi3-win_amd64.whl", hash = "sha256:ad185719fb2e8ac26f88c8100562dbf9dbdcc3d9d2add00faa94b5f106aea53f", size = 3671149, upload-time = "2026-03-13T06:58:57.07Z" },
     { url = "https://files.pythonhosted.org/packages/b4/7e/ccf239da366b37ba7f0b36095450efae4a64980bdc7ec2f51354205fdf39/hf_xet-1.4.2-cp37-abi3-win_arm64.whl", hash = "sha256:32c012286b581f783653e718c1862aea5b9eb140631685bb0c5e7012c8719a87", size = 3533426, upload-time = "2026-03-13T06:58:55.46Z" },
-]
-
-[[package]]
-name = "html2text"
-version = "2025.4.15"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f8/27/e158d86ba1e82967cc2f790b0cb02030d4a8bef58e0c79a8590e9678107f/html2text-2025.4.15.tar.gz", hash = "sha256:948a645f8f0bc3abe7fd587019a2197a12436cd73d0d4908af95bfc8da337588", size = 64316, upload-time = "2025-04-15T04:02:30.045Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/1d/84/1a0f9555fd5f2b1c924ff932d99b40a0f8a6b12f6dd625e2a47f415b00ea/html2text-2025.4.15-py3-none-any.whl", hash = "sha256:00569167ffdab3d7767a4cdf589b7f57e777a5ed28d12907d8c58769ec734acc", size = 34656, upload-time = "2025-04-15T04:02:28.44Z" },
 ]
 
 [[package]]
@@ -1926,15 +1912,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/07/18/43a5f24608d8c313dd189cf838c8e68d75b115567c6279de7796197cfb6a/kiwisolver-1.5.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:e7a116ae737f0000343218c4edf5bd45893bfeaff0993c0b215d7124c9f77646", size = 2394403, upload-time = "2026-03-09T13:15:31.517Z" },
     { url = "https://files.pythonhosted.org/packages/3b/b5/98222136d839b8afabcaa943b09bd05888c2d36355b7e448550211d1fca4/kiwisolver-1.5.0-cp314-cp314t-win_amd64.whl", hash = "sha256:1dd9b0b119a350976a6d781e7278ec7aca0b201e1a9e2d23d9804afecb6ca681", size = 79687, upload-time = "2026-03-09T13:15:33.204Z" },
     { url = "https://files.pythonhosted.org/packages/99/a2/ca7dc962848040befed12732dff6acae7fb3c4f6fc4272b3f6c9a30b8713/kiwisolver-1.5.0-cp314-cp314t-win_arm64.whl", hash = "sha256:58f812017cd2985c21fbffb4864d59174d4903dd66fa23815e74bbc7a0e2dd57", size = 70032, upload-time = "2026-03-09T13:15:34.411Z" },
-]
-
-[[package]]
-name = "latexcodec"
-version = "3.0.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/27/dd/4270b2c5e2ee49316c3859e62293bd2ea8e382339d63ab7bbe9f39c0ec3b/latexcodec-3.0.1.tar.gz", hash = "sha256:e78a6911cd72f9dec35031c6ec23584de6842bfbc4610a9678868d14cdfb0357", size = 31222, upload-time = "2025-06-17T18:47:34.051Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b5/40/23569737873cc9637fd488606347e9dd92b9fa37ba4fcda1f98ee5219a97/latexcodec-3.0.1-py3-none-any.whl", hash = "sha256:a9eb8200bff693f0437a69581f7579eb6bca25c4193515c09900ce76451e452e", size = 18532, upload-time = "2025-06-17T18:47:30.726Z" },
 ]
 
 [[package]]
@@ -2868,67 +2845,6 @@ wheels = [
 ]
 
 [[package]]
-name = "paper-qa"
-version = "2026.3.18"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "anyio" },
-    { name = "fhaviary", extra = ["llm"] },
-    { name = "fhlmi" },
-    { name = "html2text" },
-    { name = "httpx" },
-    { name = "httpx-aiohttp" },
-    { name = "numpy" },
-    { name = "paper-qa-pypdf" },
-    { name = "pybtex" },
-    { name = "pydantic" },
-    { name = "pydantic-settings" },
-    { name = "rich" },
-    { name = "setuptools" },
-    { name = "tantivy" },
-    { name = "tenacity" },
-    { name = "tiktoken" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/f5/3e/fc064437bd881a2686eea9e76beb1760f181517aa5ebb42497cda7f450cb/paper_qa-2026.3.18.tar.gz", hash = "sha256:e036802bb794b6b16b682b047a5ad1413ca653370452ead3d0a9a83a66fb9761", size = 27570424, upload-time = "2026-03-18T18:57:04.072Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/be/ab/9dc635e0ea42ecb6a384b9f2b5da72a5f6b513814e158810859dffdb2999/paper_qa-2026.3.18-py3-none-any.whl", hash = "sha256:c4a37457f4a6ac1e6d02187345db0ede8b0a07f31b39014ceecdbdbc8145a162", size = 536506, upload-time = "2026-03-18T18:56:57.055Z" },
-]
-
-[[package]]
-name = "paper-qa-pypdf"
-version = "2026.3.18"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "paper-qa" },
-    { name = "pypdf" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/4e/80/54d499171a0708d70ad9c688ffc5167254db6f20d4c5d6b9e0f1e73c6960/paper_qa_pypdf-2026.3.18.tar.gz", hash = "sha256:0c112cd3b92be7a1d3012ccbc768e7e5ea77fc788d17c17ea8e8ea35580b8d98", size = 18022, upload-time = "2026-03-18T18:57:09.885Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/02/4b/b69dd0f328fc9b925e8b146e43c7989421095e12d8949448814446e80486/paper_qa_pypdf-2026.3.18-py3-none-any.whl", hash = "sha256:b08ed0a1d12bfcdf32106f28ecad12e155b66f0b1b2ce04e83658f5bc5de0174", size = 16292, upload-time = "2026-03-18T18:57:02.004Z" },
-]
-
-[[package]]
-name = "paperqa2-cyberian"
-version = "0.1.0"
-source = { editable = "../paperqa2_cyberian" }
-dependencies = [
-    { name = "httpx" },
-    { name = "paper-qa" },
-    { name = "pypdf", extra = ["image"] },
-    { name = "sentence-transformers" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "httpx", specifier = ">=0.28" },
-    { name = "paper-qa", specifier = ">=2026.2.16" },
-    { name = "pypdf", extras = ["image"], specifier = ">=6.7.1" },
-    { name = "pytest", marker = "extra == 'test'", specifier = ">=8" },
-    { name = "sentence-transformers", specifier = ">=5.2.3" },
-]
-provides-extras = ["test"]
-
-[[package]]
 name = "pathable"
 version = "0.5.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3209,19 +3125,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pybtex"
-version = "0.26.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "latexcodec" },
-    { name = "pyyaml" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/4d/f5/f30da9c93f0fa6d619332b2f69597219b625f35780473a05164a9981fd9a/pybtex-0.26.1.tar.gz", hash = "sha256:2e5543bea424e60e9e42eef70bff597be48649d8f68ba061a7a092b2477d5464", size = 692991, upload-time = "2026-04-03T13:05:39.014Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/44/f6/775eb92e865b28cdb4ad1f2bed7a5446197516f76b58a950faa3be3fd08d/pybtex-0.26.1-py3-none-any.whl", hash = "sha256:e26c0412cc54f5f21b2a6d9d175762a2d2af9ccf3a8f651cdb89ec035db77aa1", size = 126134, upload-time = "2026-04-03T13:05:40.623Z" },
-]
-
-[[package]]
 name = "pycparser"
 version = "3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3486,20 +3389,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f3/91/9c6ee907786a473bf81c5f53cf703ba0957b23ab84c264080fb5a450416f/pyparsing-3.3.2.tar.gz", hash = "sha256:c777f4d763f140633dcb6d8a3eda953bf7a214dc4eff598413c070bcdc117cbc", size = 6851574, upload-time = "2026-01-21T03:57:59.36Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl", hash = "sha256:850ba148bd908d7e2411587e247a1e4f0327839c40e2e5e6d05a007ecc69911d", size = 122781, upload-time = "2026-01-21T03:57:55.912Z" },
-]
-
-[[package]]
-name = "pypdf"
-version = "6.12.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0a/6d/20879428577c1e57ecd41b69dc86beabf43db9287ad2e702207f8b48c751/pypdf-6.12.2.tar.gz", hash = "sha256:111669eb6680c04495ae0c113a1476e3bf93a95761d23c7406b591c80a6490b1", size = 6468184, upload-time = "2026-05-26T13:31:26.911Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/9e/44/fee070a16639d9869bb6a7e0f3a1b3946da1d66f32b9260b4d19cb90d7b2/pypdf-6.12.2-py3-none-any.whl", hash = "sha256:67b2699357a1f3f4c945940ea80826349ee507c9e2577724a14b4941982c104d", size = 343865, upload-time = "2026-05-26T13:31:25.068Z" },
-]
-
-[package.optional-dependencies]
-image = [
-    { name = "pillow" },
 ]
 
 [[package]]
@@ -4232,29 +4121,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/83/d3/803453b36afefb7c2bb238361cd4ae6125a569b4db67cd9e79846ba2d68c/sympy-1.14.0.tar.gz", hash = "sha256:d3d3fe8df1e5a0b42f0e7bdf50541697dbe7d23746e894990c030e2b05e72517", size = 7793921, upload-time = "2025-04-27T18:05:01.611Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a2/09/77d55d46fd61b4a135c444fc97158ef34a095e5681d0a6c10b75bf356191/sympy-1.14.0-py3-none-any.whl", hash = "sha256:e091cc3e99d2141a0ba2847328f5479b05d94a6635cb96148ccb3f34671bd8f5", size = 6299353, upload-time = "2025-04-27T18:04:59.103Z" },
-]
-
-[[package]]
-name = "tantivy"
-version = "0.26.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/57/74/ec8c3f7bb3599af86c19f1a774c37e36a6e7524d3563f3aeb99220981f6f/tantivy-0.26.0.tar.gz", hash = "sha256:7c9507fcc62bac4ef1d40b1ed37ff7fa07e44b5043b30288f63bcf4fdc62644a", size = 93615, upload-time = "2026-04-29T11:51:31.115Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/fb/56/aef45e8ec7fddbca4885516bc1d8cc61950f666ba8b44ef9e50b8db51f91/tantivy-0.26.0-cp313-cp313-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:7509b06fab07d4209bf37759e3c0c407f6c53fa3184d694ec82416fc8d189e7d", size = 8301236, upload-time = "2026-04-29T11:50:59.299Z" },
-    { url = "https://files.pythonhosted.org/packages/ef/3b/8ce1a1662e6e6c303a65055a42206853adfeaa14596e62b6f218b5af5526/tantivy-0.26.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:0c77962afc03f8a7081991fee088d09891acaa3401cdf882b1cc40d9d839a683", size = 4284342, upload-time = "2026-04-29T11:51:01.626Z" },
-    { url = "https://files.pythonhosted.org/packages/32/15/4f4e74669bdc26e7508d527f27be1a12d249e1d9ab6bba05f47ba1cdedfa/tantivy-0.26.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9f017f6991752da8092c46c670e0eae349a1266d2315720ff5b252ed1ea4acd4", size = 4610161, upload-time = "2026-04-29T11:51:03.966Z" },
-    { url = "https://files.pythonhosted.org/packages/50/3e/4648f7fc34834f3f4c99465111f50add73f0517f21ceae7c81771942c99b/tantivy-0.26.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bb7df28cc98497c767b86ebc5f167e3f2552739f748a1c28c10e14e7db726cd1", size = 4571125, upload-time = "2026-04-29T11:51:06.162Z" },
-    { url = "https://files.pythonhosted.org/packages/2e/04/1fcf362fbe115c1dde654727cd24ae55888ca66d1dfcbe70b75b347a4d58/tantivy-0.26.0-cp313-cp313-win_amd64.whl", hash = "sha256:9d4278d25df78ebd71dcf5510273fa0f4c552e1eed1b6e35a8f2d00b2003b2d7", size = 3759480, upload-time = "2026-04-29T11:51:08.365Z" },
-    { url = "https://files.pythonhosted.org/packages/59/3d/a85ffd178a6b00813cd144e4af2db100023a5a7cd9cae3a5f998e74d5cbd/tantivy-0.26.0-cp313-cp313t-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:7b9a350e59513e330fbcb0930ef2f574d86a8aa46047a1ad1c5b4c91838e3aec", size = 8296228, upload-time = "2026-04-29T11:51:10.844Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/81/c78c3ae37c52e1244da340139e11cca0d44ee742e227bba19ecefbbf54b5/tantivy-0.26.0-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:e1bdf6dcbd25fdc3244e6b09f5114253a81ec533ad5346eff135ee98668f04c7", size = 4279507, upload-time = "2026-04-29T11:51:13.065Z" },
-    { url = "https://files.pythonhosted.org/packages/39/df/a409dad06800793d7dd2cc831aeb46b808b4ce00df7d506e6760acee2cc2/tantivy-0.26.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a9450186861d6f350ec5969ff2e349377d2ed5617f084a8ad0f303ed7a91a2e3", size = 4605550, upload-time = "2026-04-29T11:51:15.289Z" },
-    { url = "https://files.pythonhosted.org/packages/bf/24/68245511021df5b19879d262ef2b1adf214ec67cc69761e1a83fd28571b1/tantivy-0.26.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e69569ec68c0e8d1c3aa3cf52423ced6b9b9b5bb0156e8b32088390919d41964", size = 4566249, upload-time = "2026-04-29T11:51:17.398Z" },
-    { url = "https://files.pythonhosted.org/packages/15/73/8c6e544358d45b863b64645b5cd88374279d13cfcdea1b4a9c7554fce0ec/tantivy-0.26.0-cp313-cp313t-win_amd64.whl", hash = "sha256:2064dd212455666b0f212d832bed38cc5b2de6c5f8069009926ad103bc2eb428", size = 3756762, upload-time = "2026-04-29T11:51:19.278Z" },
-    { url = "https://files.pythonhosted.org/packages/98/53/0c9ec136930dad07c8f24cd31210181e7ba2228aeea9fd75d751b9d716e5/tantivy-0.26.0-cp314-cp314-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:7983206d75c7334fdcb1c49372adf6afe8aeb89ad2abfc7a5fd9701254735134", size = 8319819, upload-time = "2026-04-29T11:51:21.451Z" },
-    { url = "https://files.pythonhosted.org/packages/10/5b/35b7f2af5101883dde8f0523a69944bd5b2471ce399339e97e2e3775a227/tantivy-0.26.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:4a970d35402612208b077de5feb9da978380c173e7835335c50d15d0f13cbaba", size = 4289015, upload-time = "2026-04-29T11:51:23.435Z" },
-    { url = "https://files.pythonhosted.org/packages/ef/4b/fbc1293fc8108eaa2f11718d77070e09cefe4aac4055fd2036548a776946/tantivy-0.26.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:22f6acf0c4d9dff2aecb161071db921c9a0bd3e2485dbc8304fd4561fe50c6a7", size = 4622332, upload-time = "2026-04-29T11:51:25.483Z" },
-    { url = "https://files.pythonhosted.org/packages/86/68/d1ae76c42b523b076434a357b675c37fd9684ac0fc6e0e63f703a1f1014a/tantivy-0.26.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a92825f3215fc4b5ef55da8a577eb9ad30c7ee5c7371daea82329e67aa4c7d12", size = 4573494, upload-time = "2026-04-29T11:51:27.512Z" },
-    { url = "https://files.pythonhosted.org/packages/be/3b/6f1ababc26839b3baa0299da2319567ffbecfe0c1b295de1e75e605d98e4/tantivy-0.26.0-cp314-cp314-win_amd64.whl", hash = "sha256:0c9ce6c5a04c4a18244f38601ea18a94044c07f8e713894d456dcbfccd3fa0f5", size = 3761380, upload-time = "2026-04-29T11:51:29.546Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -248,13 +248,19 @@ dev = [
     { name = "pytest-cov" },
     { name = "ruff" },
 ]
+local-index = [
+    { name = "curl-cffi" },
+    { name = "paperqa2-cyberian" },
+]
 
 [package.metadata]
 requires-dist = [
     { name = "cellsem-llm-client", git = "https://github.com/Cellular-Semantics/cellsem_llm_client.git?rev=main" },
+    { name = "curl-cffi", marker = "extra == 'local-index'", specifier = ">=0.7.0" },
     { name = "deep-research-client", git = "https://github.com/monarch-initiative/deep-research-client.git?rev=main" },
     { name = "jsonschema", specifier = ">=4.22.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.10.0" },
+    { name = "paperqa2-cyberian", marker = "extra == 'local-index'", editable = "../paperqa2_cyberian" },
     { name = "pydantic", specifier = ">=2.7.0" },
     { name = "pydantic-ai", specifier = ">=1.16.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0.0" },
@@ -263,7 +269,7 @@ requires-dist = [
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.5.0" },
 ]
-provides-extras = ["dev"]
+provides-extras = ["dev", "local-index"]
 
 [[package]]
 name = "atlas-chat-validation-tools"
@@ -780,6 +786,28 @@ wheels = [
 ]
 
 [[package]]
+name = "cuda-bindings"
+version = "12.9.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cuda-pathfinder", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/63/56/e465c31dc9111be3441a9ba7df1941fe98f4aa6e71e8788a3fb4534ce24d/cuda_bindings-12.9.4-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:32bdc5a76906be4c61eb98f546a6786c5773a881f3b166486449b5d141e4a39f", size = 11906628, upload-time = "2025-10-21T14:51:49.905Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/84/1e6be415e37478070aeeee5884c2022713c1ecc735e6d82d744de0252eee/cuda_bindings-12.9.4-cp313-cp313t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:56e0043c457a99ac473ddc926fe0dc4046694d99caef633e92601ab52cbe17eb", size = 11925991, upload-time = "2025-10-21T14:51:56.535Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/af/6dfd8f2ed90b1d4719bc053ff8940e494640fe4212dc3dd72f383e4992da/cuda_bindings-12.9.4-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8b72ee72a9cc1b531db31eebaaee5c69a8ec3500e32c6933f2d3b15297b53686", size = 11922703, upload-time = "2025-10-21T14:52:03.585Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/19/90ac264acc00f6df8a49378eedec9fd2db3061bf9263bf9f39fd3d8377c3/cuda_bindings-12.9.4-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d80bffc357df9988dca279734bc9674c3934a654cab10cadeed27ce17d8635ee", size = 11924658, upload-time = "2025-10-21T14:52:10.411Z" },
+]
+
+[[package]]
+name = "cuda-pathfinder"
+version = "1.5.5"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/11/c8/26f2e4aae92f11522a96043892ba39a90eac610d5242523aa863212bc1c7/cuda_pathfinder-1.5.5-py3-none-any.whl", hash = "sha256:0228c023f95d1480f143ef5c8922d27a2ab052087a942e81dc289c9eb8f91689", size = 51671, upload-time = "2026-05-27T01:21:25.413Z" },
+]
+
+[[package]]
 name = "curies"
 version = "0.12.10"
 source = { registry = "https://pypi.org/simple" }
@@ -790,6 +818,39 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/1d/30/24ee7cef5e2c0cc9c70bc50a0929014e22d31ca5ebeebf806a276053c378/curies-0.12.10.tar.gz", hash = "sha256:5bad4111b719ff79a84bc362fab9cbc992325e2bc6dfeca249813d0c5c2ba6c5", size = 375216, upload-time = "2026-03-16T08:27:03.644Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9e/7d/7363c69b8609ad14c333eca693a55bd0cfc11f218c5e71d6b1ce948d2c0d/curies-0.12.10-py3-none-any.whl", hash = "sha256:b7177d1ee9dfd5257fb8dfbe8dea5e3c43507b36e0ebf0bcc01e8fdd5d5ed221", size = 70370, upload-time = "2026-03-16T08:27:04.999Z" },
+]
+
+[[package]]
+name = "curl-cffi"
+version = "0.15.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "cffi" },
+    { name = "rich" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/48/5b/89fcfebd3e5e85134147ac99e9f2b2271165fd4d71984fc65da5f17819b7/curl_cffi-0.15.0.tar.gz", hash = "sha256:ea0c67652bf6893d34ee0f82c944f37e488f6147e9421bef1771cc6545b02ded", size = 196437, upload-time = "2026-04-03T11:12:31.525Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5e/42/54ddd442c795f30ce5dd4e49f87ce77505958d3777cd96a91567a3975d2a/curl_cffi-0.15.0-cp310-abi3-macosx_10_9_x86_64.whl", hash = "sha256:bda66404010e9ed743b1b83c20c86f24fe21a9a6873e17479d6e67e29d8ded28", size = 2795267, upload-time = "2026-04-03T11:11:46.48Z" },
+    { url = "https://files.pythonhosted.org/packages/83/2d/3915e238579b3c5a92cead5c79130c3b8d20caaba7616cc4d894650e1d6b/curl_cffi-0.15.0-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:a25620d9bf989c9c029a7d1642999c4c265abb0bad811deb2f77b0b5b2b12e5b", size = 2573544, upload-time = "2026-04-03T11:11:47.951Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/b3/9d2f1057749a1b07ba1989db3c1503ce8bed998310bae9aea2c43aa64f20/curl_cffi-0.15.0-cp310-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:582e570aa2586b96ed47cf4a17586b9a3c462cbe43f780487c3dc245c6ef1527", size = 10515369, upload-time = "2026-04-03T11:11:50.126Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/1d/6d10dded5ce3fd8157e558ebd97d09e551b77a62cdc1c31e93d0a633cee5/curl_cffi-0.15.0-cp310-abi3-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:838e48212447d9c81364b04707a5c861daf08f8320f9ecb3406a8919d1d5c3b3", size = 10160045, upload-time = "2026-04-03T11:11:52.664Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/12/c70b835487ace3b9ba1502631912e3440082b8ae3a162f60b59cb0b6444d/curl_cffi-0.15.0-cp310-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2b6c847d86283b07ae69bb72c82eb8a59242277142aa35b89850f89e792a02fc", size = 11090433, upload-time = "2026-04-03T11:11:55.049Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/0d/78edcc4f71934225db99df68197a107386d59080742fc7bf6bb4d007924f/curl_cffi-0.15.0-cp310-abi3-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:9e5e69eee735f659287e2c84444319d68a1fa68dd37abf228943a4074864283a", size = 10479178, upload-time = "2026-04-03T11:11:57.685Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/84/1e101c1acb1ea2f0b4992f5c3024f596d8e21db0d53540b9d583f673c4e7/curl_cffi-0.15.0-cp310-abi3-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:aa1323950224db24f4c510d010b3affa02196ca853fb424191fa917a513d3f4b", size = 10317051, upload-time = "2026-04-03T11:12:00.295Z" },
+    { url = "https://files.pythonhosted.org/packages/28/42/8ef236b22a6c23d096c85a1dc507efe37bfdfc7a2f8a4b34efb590197369/curl_cffi-0.15.0-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:41f80170ba844009273b2660da1964ec31e99e5719d16b3422ada87177e32e13", size = 11299660, upload-time = "2026-04-03T11:12:02.791Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/01/56aeb055d962da87a1be0d74c6c644e251c7e88129b5471dc44ac724e678/curl_cffi-0.15.0-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:1977e1e12cfb5c11352cbb74acef1bed24eb7d226dab61ca57c168c21acd4d61", size = 11945049, upload-time = "2026-04-03T11:12:05.912Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/8c/2abf99a38d6340d66cf0557e0c750ef3f8883dfc5d450087e01c85861343/curl_cffi-0.15.0-cp310-abi3-win_amd64.whl", hash = "sha256:5a0c1896a0d5a5ac1eb89cd24b008d2b718dd1df6fd2f75451b59ca66e49e572", size = 1661649, upload-time = "2026-04-03T11:12:07.948Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/39/dfd54f2240d3a9b96d77bacc62b97813b35e2aa8ecf5cd5013c683f1ba96/curl_cffi-0.15.0-cp310-abi3-win_arm64.whl", hash = "sha256:a6d57f8389273a3a1f94370473c74897467bcc36af0a17336989780c507fa43d", size = 1410741, upload-time = "2026-04-03T11:12:10.073Z" },
+    { url = "https://files.pythonhosted.org/packages/19/6a/c24df8a4fc22fa84070dcd94abeba43c15e08cc09e35869565c0bad196fd/curl_cffi-0.15.0-cp313-abi3-android_24_arm64_v8a.whl", hash = "sha256:4682dc38d4336e0eb0b185374db90a760efde63cbea994b4e63f3521d44c4c92", size = 7190427, upload-time = "2026-04-03T11:12:12.142Z" },
+    { url = "https://files.pythonhosted.org/packages/11/56/132225cb3491d07cc6adcce5fe395e059bde87c68cff1ef87a31c88c7819/curl_cffi-0.15.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:967ad7355bd8e9586f8c2d02eaa99953747549e7ea4a9b25cd53353e6b67fe6d", size = 2795723, upload-time = "2026-04-03T11:12:13.668Z" },
+    { url = "https://files.pythonhosted.org/packages/07/8f/f4f83cd303bef7e8f1749512e5dd157e7e5d08b0a36c8211f9640a2757bf/curl_cffi-0.15.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7e63539d0d839d0a8c5eacf86229bc68c57803547f35e0db7ee0986328b478c3", size = 2573739, upload-time = "2026-04-03T11:12:15.08Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/5c/643d65c7fc9acd742876aa55c2d7823c438cb7665810acd2e66c9976c4d9/curl_cffi-0.15.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:08c799b89740b9bc49c09fbc3d5907f13ac1f845ca52620507ef9466d4639dd5", size = 10521046, upload-time = "2026-04-03T11:12:17.034Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/0b/9b8037113c93f4c5323096163471fa7c35c7676c3f608eeaf1287cd99d58/curl_cffi-0.15.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7b7a92767a888ee90147e18964b396d8435ff42737030d6fb00824ffd6094805", size = 11096115, upload-time = "2026-04-03T11:12:19.694Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/96/fff2fcbd924ef4042e0d67379f751a8a4e3186a91e75e35a4cf218b306ee/curl_cffi-0.15.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:829cc357061ecb99cc2d406301f609a039e05665322f5c025ec67c38b0dc49ce", size = 11305346, upload-time = "2026-04-03T11:12:22.151Z" },
+    { url = "https://files.pythonhosted.org/packages/53/1b/304b253a45ab28691c8c5e8cca1e6cbb9cf8e46dfceae4648dd536f75e73/curl_cffi-0.15.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:408d6f14e346841cd889c2e0962832bb235ba3b6749ebf609f347f747da5e60f", size = 11949834, upload-time = "2026-04-03T11:12:24.986Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/ff/4723d92f08259c707a974aba27a08d0a822b9555e35ca581bf18d055a364/curl_cffi-0.15.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b624c7ce087bfda967a013ed0a64702a525444e5b6e97d23534d567ccc6525aa", size = 1702771, upload-time = "2026-04-03T11:12:28.201Z" },
+    { url = "https://files.pythonhosted.org/packages/59/8c/36bbe06d66fa2b765e4a07199f643a59a9cd1a754207a96335402a9520f4/curl_cffi-0.15.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0b6c0543b993996670e9e4b78e305a2d60809d5681903ffb5568e21a387434d3", size = 1466312, upload-time = "2026-04-03T11:12:30.054Z" },
 ]
 
 [[package]]
@@ -1064,22 +1125,30 @@ wheels = [
 
 [[package]]
 name = "fhaviary"
-version = "0.33.0"
+version = "0.35.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "docstring-parser" },
     { name = "httpx" },
     { name = "httpx-aiohttp" },
     { name = "pydantic" },
+    { name = "pydantic-core" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0b/c3/513f3ca1e70c6965d4b5604c62b035a482015004d8655891ea6b867831dd/fhaviary-0.33.0.tar.gz", hash = "sha256:442b7844c4d78080c0de8857372ba3d2f4d9ec608baa41f737e1ae14c8706cf6", size = 5868495, upload-time = "2026-02-18T23:12:51.777Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ed/e7/7fc0cb7ec77f3a4eed6935439c6a334b75cdc90e0a80ac31b98fa95db610/fhaviary-0.35.0.tar.gz", hash = "sha256:d13debda9ea898fb4c7bebb8d592c5e9838f6d167e13da31e0b9b55b5f0c0f17", size = 5887281, upload-time = "2026-04-16T23:07:56.634Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/36/39/b9ae1cd70695859ee3998416af74eb1d046d03d61c9ff5eece868d3bc597/fhaviary-0.33.0-py3-none-any.whl", hash = "sha256:b4c88b2a4c2a8e6877dfd2c67a5944406a9442af3e3b25db61ef1a8f15f6cec6", size = 60872, upload-time = "2026-02-18T23:12:45.739Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/3e/b63f18349a0a266dd23453497f24202786f4a0d3f12b5554e385906f94a8/fhaviary-0.35.0-py3-none-any.whl", hash = "sha256:4637fdd58374bac3b0892d3cdf604f1b66ebffea64aacfbc8d639f1452d30e2f", size = 61677, upload-time = "2026-04-16T23:07:50.545Z" },
+]
+
+[package.optional-dependencies]
+llm = [
+    { name = "fhlmi" },
+    { name = "litellm" },
+    { name = "packaging" },
 ]
 
 [[package]]
 name = "fhlmi"
-version = "0.44.1"
+version = "0.45.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "coredis" },
@@ -1089,9 +1158,9 @@ dependencies = [
     { name = "pydantic" },
     { name = "tiktoken" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f7/ca/2501ac02388fa5152b957121f2b5ad908bc65adc68b43ae748fb2b73b9eb/fhlmi-0.44.1.tar.gz", hash = "sha256:3538242e77535bcb93b05d97c5aa79a74cb6e1344e46012bf13f38aff03d0b9e", size = 484116, upload-time = "2026-03-02T20:58:24.152Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ab/32/30daf289d6b78b4142ba782b9590d83db693d42153f1176e90d569228cf3/fhlmi-0.45.1.tar.gz", hash = "sha256:793fae4776fbed3aea8ad26f33b8ff37399fdddf64151976c01f3749553898a9", size = 488023, upload-time = "2026-03-23T17:44:35.354Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/62/c6/9318697b3d7cc351f861cc41e991e0d8e27a919d7b7b820d70cbcc7a2de4/fhlmi-0.44.1-py3-none-any.whl", hash = "sha256:11258ffe154ed7d2a0117f52ae47c33bb54cfc7ff8010fa45e98b4a767b7079b", size = 45304, upload-time = "2026-03-02T20:58:22.672Z" },
+    { url = "https://files.pythonhosted.org/packages/37/07/bcacf6032fe4a7afbda1331d01f455cb6bbb1ff4aeee60eacda524de40c2/fhlmi-0.45.1-py3-none-any.whl", hash = "sha256:dded9284de1d8d58f3aa3404defa62fafdeb11c0b4af61bdcbe6e65179d6adc5", size = 47725, upload-time = "2026-03-23T17:44:34.006Z" },
 ]
 
 [[package]]
@@ -1448,6 +1517,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/54/75/07f6aa680575d9646c4167db6407c41340cbe2357f5654c4e72a1b01ca14/hf_xet-1.4.2-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:6b0932eb8b10317ea78b7da6bab172b17be03bbcd7809383d8d5abd6a2233e04", size = 4432751, upload-time = "2026-03-13T06:58:46.533Z" },
     { url = "https://files.pythonhosted.org/packages/cd/71/193eabd7e7d4b903c4aa983a215509c6114915a5a237525ec562baddb868/hf_xet-1.4.2-cp37-abi3-win_amd64.whl", hash = "sha256:ad185719fb2e8ac26f88c8100562dbf9dbdcc3d9d2add00faa94b5f106aea53f", size = 3671149, upload-time = "2026-03-13T06:58:57.07Z" },
     { url = "https://files.pythonhosted.org/packages/b4/7e/ccf239da366b37ba7f0b36095450efae4a64980bdc7ec2f51354205fdf39/hf_xet-1.4.2-cp37-abi3-win_arm64.whl", hash = "sha256:32c012286b581f783653e718c1862aea5b9eb140631685bb0c5e7012c8719a87", size = 3533426, upload-time = "2026-03-13T06:58:55.46Z" },
+]
+
+[[package]]
+name = "html2text"
+version = "2025.4.15"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f8/27/e158d86ba1e82967cc2f790b0cb02030d4a8bef58e0c79a8590e9678107f/html2text-2025.4.15.tar.gz", hash = "sha256:948a645f8f0bc3abe7fd587019a2197a12436cd73d0d4908af95bfc8da337588", size = 64316, upload-time = "2025-04-15T04:02:30.045Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1d/84/1a0f9555fd5f2b1c924ff932d99b40a0f8a6b12f6dd625e2a47f415b00ea/html2text-2025.4.15-py3-none-any.whl", hash = "sha256:00569167ffdab3d7767a4cdf589b7f57e777a5ed28d12907d8c58769ec734acc", size = 34656, upload-time = "2025-04-15T04:02:28.44Z" },
 ]
 
 [[package]]
@@ -1851,6 +1929,15 @@ wheels = [
 ]
 
 [[package]]
+name = "latexcodec"
+version = "3.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/27/dd/4270b2c5e2ee49316c3859e62293bd2ea8e382339d63ab7bbe9f39c0ec3b/latexcodec-3.0.1.tar.gz", hash = "sha256:e78a6911cd72f9dec35031c6ec23584de6842bfbc4610a9678868d14cdfb0357", size = 31222, upload-time = "2025-06-17T18:47:34.051Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b5/40/23569737873cc9637fd488606347e9dd92b9fa37ba4fcda1f98ee5219a97/latexcodec-3.0.1-py3-none-any.whl", hash = "sha256:a9eb8200bff693f0437a69581f7579eb6bca25c4193515c09900ce76451e452e", size = 18532, upload-time = "2025-06-17T18:47:30.726Z" },
+]
+
+[[package]]
 name = "ldp"
 version = "0.44.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2200,6 +2287,15 @@ wheels = [
 ]
 
 [[package]]
+name = "mpmath"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/47/dd32fa426cc72114383ac549964eecb20ecfd886d1e5ccf5340b55b02f57/mpmath-1.3.0.tar.gz", hash = "sha256:7a28eb2a9774d00c7bc92411c19a89209d5da7c4c9a9e227be8330a23a25b91f", size = 508106, upload-time = "2023-03-07T16:47:11.061Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/43/e3/7d92a15f894aa0c9c4b49b8ee9ac9850d6e63b03c9c32c0367a13ae62209/mpmath-1.3.0-py3-none-any.whl", hash = "sha256:a0b2b9fe80bbcd81a6647ff13108738cfb482d481d826cc0e02f5b35e5c88d2c", size = 536198, upload-time = "2023-03-07T16:47:09.197Z" },
+]
+
+[[package]]
 name = "multidict"
 version = "6.7.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2334,6 +2430,15 @@ wheels = [
 ]
 
 [[package]]
+name = "networkx"
+version = "3.6.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6a/51/63fe664f3908c97be9d2e4f1158eb633317598cfa6e1fc14af5383f17512/networkx-3.6.1.tar.gz", hash = "sha256:26b7c357accc0c8cde558ad486283728b65b6a95d85ee1cd66bafab4c8168509", size = 2517025, upload-time = "2025-12-08T17:02:39.908Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/c9/b2622292ea83fbb4ec318f5b9ab867d0a28ab43c5717bb85b0a5f6b3b0a4/networkx-3.6.1-py3-none-any.whl", hash = "sha256:d47fbf302e7d9cbbb9e2555a0d267983d2aa476bac30e90dfbe5669bd57f3762", size = 2068504, upload-time = "2025-12-08T17:02:38.159Z" },
+]
+
+[[package]]
 name = "nexus-rpc"
 version = "1.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2402,6 +2507,140 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/07/12/8160bea39da3335737b10308df4f484235fd297f556745f13092aa039d3b/numpy-2.4.3-cp314-cp314t-win32.whl", hash = "sha256:5e10da9e93247e554bb1d22f8edc51847ddd7dde52d85ce31024c1b4312bfba0", size = 6154547, upload-time = "2026-03-09T07:58:28.289Z" },
     { url = "https://files.pythonhosted.org/packages/42/f3/76534f61f80d74cc9cdf2e570d3d4eeb92c2280a27c39b0aaf471eda7b48/numpy-2.4.3-cp314-cp314t-win_amd64.whl", hash = "sha256:45f003dbdffb997a03da2d1d0cb41fbd24a87507fb41605c0420a3db5bd4667b", size = 12633645, upload-time = "2026-03-09T07:58:30.384Z" },
     { url = "https://files.pythonhosted.org/packages/1f/b6/7c0d4334c15983cec7f92a69e8ce9b1e6f31857e5ee3a413ac424e6bd63d/numpy-2.4.3-cp314-cp314t-win_arm64.whl", hash = "sha256:4d382735cecd7bcf090172489a525cd7d4087bc331f7df9f60ddc9a296cf208e", size = 10565454, upload-time = "2026-03-09T07:58:33.031Z" },
+]
+
+[[package]]
+name = "nvidia-cublas-cu12"
+version = "12.8.4.1"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/61/e24b560ab2e2eaeb3c839129175fb330dfcfc29e5203196e5541a4c44682/nvidia_cublas_cu12-12.8.4.1-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:8ac4e771d5a348c551b2a426eda6193c19aa630236b418086020df5ba9667142", size = 594346921, upload-time = "2025-03-07T01:44:31.254Z" },
+]
+
+[[package]]
+name = "nvidia-cuda-cupti-cu12"
+version = "12.8.90"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f8/02/2adcaa145158bf1a8295d83591d22e4103dbfd821bcaf6f3f53151ca4ffa/nvidia_cuda_cupti_cu12-12.8.90-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ea0cb07ebda26bb9b29ba82cda34849e73c166c18162d3913575b0c9db9a6182", size = 10248621, upload-time = "2025-03-07T01:40:21.213Z" },
+]
+
+[[package]]
+name = "nvidia-cuda-nvrtc-cu12"
+version = "12.8.93"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/05/6b/32f747947df2da6994e999492ab306a903659555dddc0fbdeb9d71f75e52/nvidia_cuda_nvrtc_cu12-12.8.93-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:a7756528852ef889772a84c6cd89d41dfa74667e24cca16bb31f8f061e3e9994", size = 88040029, upload-time = "2025-03-07T01:42:13.562Z" },
+]
+
+[[package]]
+name = "nvidia-cuda-runtime-cu12"
+version = "12.8.90"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0d/9b/a997b638fcd068ad6e4d53b8551a7d30fe8b404d6f1804abf1df69838932/nvidia_cuda_runtime_cu12-12.8.90-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:adade8dcbd0edf427b7204d480d6066d33902cab2a4707dcfc48a2d0fd44ab90", size = 954765, upload-time = "2025-03-07T01:40:01.615Z" },
+]
+
+[[package]]
+name = "nvidia-cudnn-cu12"
+version = "9.10.2.21"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-cublas-cu12", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ba/51/e123d997aa098c61d029f76663dedbfb9bc8dcf8c60cbd6adbe42f76d049/nvidia_cudnn_cu12-9.10.2.21-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:949452be657fa16687d0930933f032835951ef0892b37d2d53824d1a84dc97a8", size = 706758467, upload-time = "2025-06-06T21:54:08.597Z" },
+]
+
+[[package]]
+name = "nvidia-cufft-cu12"
+version = "11.3.3.83"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1f/13/ee4e00f30e676b66ae65b4f08cb5bcbb8392c03f54f2d5413ea99a5d1c80/nvidia_cufft_cu12-11.3.3.83-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4d2dd21ec0b88cf61b62e6b43564355e5222e4a3fb394cac0db101f2dd0d4f74", size = 193118695, upload-time = "2025-03-07T01:45:27.821Z" },
+]
+
+[[package]]
+name = "nvidia-cufile-cu12"
+version = "1.13.1.3"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bb/fe/1bcba1dfbfb8d01be8d93f07bfc502c93fa23afa6fd5ab3fc7c1df71038a/nvidia_cufile_cu12-1.13.1.3-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1d069003be650e131b21c932ec3d8969c1715379251f8d23a1860554b1cb24fc", size = 1197834, upload-time = "2025-03-07T01:45:50.723Z" },
+]
+
+[[package]]
+name = "nvidia-curand-cu12"
+version = "10.3.9.90"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/aa/6584b56dc84ebe9cf93226a5cde4d99080c8e90ab40f0c27bda7a0f29aa1/nvidia_curand_cu12-10.3.9.90-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:b32331d4f4df5d6eefa0554c565b626c7216f87a06a4f56fab27c3b68a830ec9", size = 63619976, upload-time = "2025-03-07T01:46:23.323Z" },
+]
+
+[[package]]
+name = "nvidia-cusolver-cu12"
+version = "11.7.3.90"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-cublas-cu12", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "nvidia-cusparse-cu12", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/85/48/9a13d2975803e8cf2777d5ed57b87a0b6ca2cc795f9a4f59796a910bfb80/nvidia_cusolver_cu12-11.7.3.90-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:4376c11ad263152bd50ea295c05370360776f8c3427b30991df774f9fb26c450", size = 267506905, upload-time = "2025-03-07T01:47:16.273Z" },
+]
+
+[[package]]
+name = "nvidia-cusparse-cu12"
+version = "12.5.8.93"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/f5/e1854cb2f2bcd4280c44736c93550cc300ff4b8c95ebe370d0aa7d2b473d/nvidia_cusparse_cu12-12.5.8.93-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1ec05d76bbbd8b61b06a80e1eaf8cf4959c3d4ce8e711b65ebd0443bb0ebb13b", size = 288216466, upload-time = "2025-03-07T01:48:13.779Z" },
+]
+
+[[package]]
+name = "nvidia-cusparselt-cu12"
+version = "0.7.1"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/56/79/12978b96bd44274fe38b5dde5cfb660b1d114f70a65ef962bcbbed99b549/nvidia_cusparselt_cu12-0.7.1-py3-none-manylinux2014_x86_64.whl", hash = "sha256:f1bb701d6b930d5a7cea44c19ceb973311500847f81b634d802b7b539dc55623", size = 287193691, upload-time = "2025-02-26T00:15:44.104Z" },
+]
+
+[[package]]
+name = "nvidia-nccl-cu12"
+version = "2.27.5"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6e/89/f7a07dc961b60645dbbf42e80f2bc85ade7feb9a491b11a1e973aa00071f/nvidia_nccl_cu12-2.27.5-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ad730cf15cb5d25fe849c6e6ca9eb5b76db16a80f13f425ac68d8e2e55624457", size = 322348229, upload-time = "2025-06-26T04:11:28.385Z" },
+]
+
+[[package]]
+name = "nvidia-nvjitlink-cu12"
+version = "12.8.93"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f6/74/86a07f1d0f42998ca31312f998bd3b9a7eff7f52378f4f270c8679c77fb9/nvidia_nvjitlink_cu12-12.8.93-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:81ff63371a7ebd6e6451970684f916be2eab07321b73c9d244dc2b4da7f73b88", size = 39254836, upload-time = "2025-03-07T01:49:55.661Z" },
+]
+
+[[package]]
+name = "nvidia-nvshmem-cu12"
+version = "3.4.5"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b5/09/6ea3ea725f82e1e76684f0708bbedd871fc96da89945adeba65c3835a64c/nvidia_nvshmem_cu12-3.4.5-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:042f2500f24c021db8a06c5eec2539027d57460e1c1a762055a6554f72c369bd", size = 139103095, upload-time = "2025-09-06T00:32:31.266Z" },
+]
+
+[[package]]
+name = "nvidia-nvtx-cu12"
+version = "12.8.90"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a2/eb/86626c1bbc2edb86323022371c39aa48df6fd8b0a1647bc274577f72e90b/nvidia_nvtx_cu12-12.8.90-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5b17e2001cc0d751a5bc2c6ec6d26ad95913324a4adb86788c944f8ce9ba441f", size = 89954, upload-time = "2025-03-07T01:42:44.131Z" },
 ]
 
 [[package]]
@@ -2627,6 +2866,67 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/89/41/d7dfb63d2407f12055215070c42fc6ac41b66e90a2946cdc5e759058398b/pandas-3.0.1-cp314-cp314t-win_amd64.whl", hash = "sha256:44f1364411d5670efa692b146c748f4ed013df91ee91e9bec5677fb1fd58b937", size = 10884622, upload-time = "2026-02-17T22:20:11.711Z" },
     { url = "https://files.pythonhosted.org/packages/68/b0/34937815889fa982613775e4b97fddd13250f11012d769949c5465af2150/pandas-3.0.1-cp314-cp314t-win_arm64.whl", hash = "sha256:108dd1790337a494aa80e38def654ca3f0968cf4f362c85f44c15e471667102d", size = 9452085, upload-time = "2026-02-17T22:20:14.331Z" },
 ]
+
+[[package]]
+name = "paper-qa"
+version = "2026.3.18"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "fhaviary", extra = ["llm"] },
+    { name = "fhlmi" },
+    { name = "html2text" },
+    { name = "httpx" },
+    { name = "httpx-aiohttp" },
+    { name = "numpy" },
+    { name = "paper-qa-pypdf" },
+    { name = "pybtex" },
+    { name = "pydantic" },
+    { name = "pydantic-settings" },
+    { name = "rich" },
+    { name = "setuptools" },
+    { name = "tantivy" },
+    { name = "tenacity" },
+    { name = "tiktoken" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f5/3e/fc064437bd881a2686eea9e76beb1760f181517aa5ebb42497cda7f450cb/paper_qa-2026.3.18.tar.gz", hash = "sha256:e036802bb794b6b16b682b047a5ad1413ca653370452ead3d0a9a83a66fb9761", size = 27570424, upload-time = "2026-03-18T18:57:04.072Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/be/ab/9dc635e0ea42ecb6a384b9f2b5da72a5f6b513814e158810859dffdb2999/paper_qa-2026.3.18-py3-none-any.whl", hash = "sha256:c4a37457f4a6ac1e6d02187345db0ede8b0a07f31b39014ceecdbdbc8145a162", size = 536506, upload-time = "2026-03-18T18:56:57.055Z" },
+]
+
+[[package]]
+name = "paper-qa-pypdf"
+version = "2026.3.18"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "paper-qa" },
+    { name = "pypdf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4e/80/54d499171a0708d70ad9c688ffc5167254db6f20d4c5d6b9e0f1e73c6960/paper_qa_pypdf-2026.3.18.tar.gz", hash = "sha256:0c112cd3b92be7a1d3012ccbc768e7e5ea77fc788d17c17ea8e8ea35580b8d98", size = 18022, upload-time = "2026-03-18T18:57:09.885Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/02/4b/b69dd0f328fc9b925e8b146e43c7989421095e12d8949448814446e80486/paper_qa_pypdf-2026.3.18-py3-none-any.whl", hash = "sha256:b08ed0a1d12bfcdf32106f28ecad12e155b66f0b1b2ce04e83658f5bc5de0174", size = 16292, upload-time = "2026-03-18T18:57:02.004Z" },
+]
+
+[[package]]
+name = "paperqa2-cyberian"
+version = "0.1.0"
+source = { editable = "../paperqa2_cyberian" }
+dependencies = [
+    { name = "httpx" },
+    { name = "paper-qa" },
+    { name = "pypdf", extra = ["image"] },
+    { name = "sentence-transformers" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "httpx", specifier = ">=0.28" },
+    { name = "paper-qa", specifier = ">=2026.2.16" },
+    { name = "pypdf", extras = ["image"], specifier = ">=6.7.1" },
+    { name = "pytest", marker = "extra == 'test'", specifier = ">=8" },
+    { name = "sentence-transformers", specifier = ">=5.2.3" },
+]
+provides-extras = ["test"]
 
 [[package]]
 name = "pathable"
@@ -2909,6 +3209,19 @@ wheels = [
 ]
 
 [[package]]
+name = "pybtex"
+version = "0.26.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "latexcodec" },
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4d/f5/f30da9c93f0fa6d619332b2f69597219b625f35780473a05164a9981fd9a/pybtex-0.26.1.tar.gz", hash = "sha256:2e5543bea424e60e9e42eef70bff597be48649d8f68ba061a7a092b2477d5464", size = 692991, upload-time = "2026-04-03T13:05:39.014Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/44/f6/775eb92e865b28cdb4ad1f2bed7a5446197516f76b58a950faa3be3fd08d/pybtex-0.26.1-py3-none-any.whl", hash = "sha256:e26c0412cc54f5f21b2a6d9d175762a2d2af9ccf3a8f651cdb89ec035db77aa1", size = 126134, upload-time = "2026-04-03T13:05:40.623Z" },
+]
+
+[[package]]
 name = "pycparser"
 version = "3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3173,6 +3486,20 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f3/91/9c6ee907786a473bf81c5f53cf703ba0957b23ab84c264080fb5a450416f/pyparsing-3.3.2.tar.gz", hash = "sha256:c777f4d763f140633dcb6d8a3eda953bf7a214dc4eff598413c070bcdc117cbc", size = 6851574, upload-time = "2026-01-21T03:57:59.36Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl", hash = "sha256:850ba148bd908d7e2411587e247a1e4f0327839c40e2e5e6d05a007ecc69911d", size = 122781, upload-time = "2026-01-21T03:57:55.912Z" },
+]
+
+[[package]]
+name = "pypdf"
+version = "6.12.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0a/6d/20879428577c1e57ecd41b69dc86beabf43db9287ad2e702207f8b48c751/pypdf-6.12.2.tar.gz", hash = "sha256:111669eb6680c04495ae0c113a1476e3bf93a95761d23c7406b591c80a6490b1", size = 6468184, upload-time = "2026-05-26T13:31:26.911Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/44/fee070a16639d9869bb6a7e0f3a1b3946da1d66f32b9260b4d19cb90d7b2/pypdf-6.12.2-py3-none-any.whl", hash = "sha256:67b2699357a1f3f4c945940ea80826349ee507c9e2577724a14b4941982c104d", size = 343865, upload-time = "2026-05-26T13:31:25.068Z" },
+]
+
+[package.optional-dependencies]
+image = [
+    { name = "pillow" },
 ]
 
 [[package]]
@@ -3575,6 +3902,28 @@ wheels = [
 ]
 
 [[package]]
+name = "safetensors"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/29/9c/6e74567782559a63bd040a236edca26fd71bc7ba88de2ef35d75df3bca5e/safetensors-0.7.0.tar.gz", hash = "sha256:07663963b67e8bd9f0b8ad15bb9163606cd27cc5a1b96235a50d8369803b96b0", size = 200878, upload-time = "2025-11-19T15:18:43.199Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/47/aef6c06649039accf914afef490268e1067ed82be62bcfa5b7e886ad15e8/safetensors-0.7.0-cp38-abi3-macosx_10_12_x86_64.whl", hash = "sha256:c82f4d474cf725255d9e6acf17252991c3c8aac038d6ef363a4bf8be2f6db517", size = 467781, upload-time = "2025-11-19T15:18:35.84Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/00/374c0c068e30cd31f1e1b46b4b5738168ec79e7689ca82ee93ddfea05109/safetensors-0.7.0-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:94fd4858284736bb67a897a41608b5b0c2496c9bdb3bf2af1fa3409127f20d57", size = 447058, upload-time = "2025-11-19T15:18:34.416Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/06/578ffed52c2296f93d7fd2d844cabfa92be51a587c38c8afbb8ae449ca89/safetensors-0.7.0-cp38-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e07d91d0c92a31200f25351f4acb2bc6aff7f48094e13ebb1d0fb995b54b6542", size = 491748, upload-time = "2025-11-19T15:18:09.79Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/33/1debbbb70e4791dde185edb9413d1fe01619255abb64b300157d7f15dddd/safetensors-0.7.0-cp38-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:8469155f4cb518bafb4acf4865e8bb9d6804110d2d9bdcaa78564b9fd841e104", size = 503881, upload-time = "2025-11-19T15:18:16.145Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/1c/40c2ca924d60792c3be509833df711b553c60effbd91da6f5284a83f7122/safetensors-0.7.0-cp38-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:54bef08bf00a2bff599982f6b08e8770e09cc012d7bba00783fc7ea38f1fb37d", size = 623463, upload-time = "2025-11-19T15:18:21.11Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/3a/13784a9364bd43b0d61eef4bea2845039bc2030458b16594a1bd787ae26e/safetensors-0.7.0-cp38-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:42cb091236206bb2016d245c377ed383aa7f78691748f3bb6ee1bfa51ae2ce6a", size = 532855, upload-time = "2025-11-19T15:18:25.719Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/60/429e9b1cb3fc651937727befe258ea24122d9663e4d5709a48c9cbfceecb/safetensors-0.7.0-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dac7252938f0696ddea46f5e855dd3138444e82236e3be475f54929f0c510d48", size = 507152, upload-time = "2025-11-19T15:18:33.023Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/a8/4b45e4e059270d17af60359713ffd83f97900d45a6afa73aaa0d737d48b6/safetensors-0.7.0-cp38-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1d060c70284127fa805085d8f10fbd0962792aed71879d00864acda69dbab981", size = 541856, upload-time = "2025-11-19T15:18:31.075Z" },
+    { url = "https://files.pythonhosted.org/packages/06/87/d26d8407c44175d8ae164a95b5a62707fcc445f3c0c56108e37d98070a3d/safetensors-0.7.0-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:cdab83a366799fa730f90a4ebb563e494f28e9e92c4819e556152ad55e43591b", size = 674060, upload-time = "2025-11-19T15:18:37.211Z" },
+    { url = "https://files.pythonhosted.org/packages/11/f5/57644a2ff08dc6325816ba7217e5095f17269dada2554b658442c66aed51/safetensors-0.7.0-cp38-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:672132907fcad9f2aedcb705b2d7b3b93354a2aec1b2f706c4db852abe338f85", size = 771715, upload-time = "2025-11-19T15:18:38.689Z" },
+    { url = "https://files.pythonhosted.org/packages/86/31/17883e13a814bd278ae6e266b13282a01049b0c81341da7fd0e3e71a80a3/safetensors-0.7.0-cp38-abi3-musllinux_1_2_i686.whl", hash = "sha256:5d72abdb8a4d56d4020713724ba81dac065fedb7f3667151c4a637f1d3fb26c0", size = 714377, upload-time = "2025-11-19T15:18:40.162Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/d8/0c8a7dc9b41dcac53c4cbf9df2b9c83e0e0097203de8b37a712b345c0be5/safetensors-0.7.0-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:b0f6d66c1c538d5a94a73aa9ddca8ccc4227e6c9ff555322ea40bdd142391dd4", size = 677368, upload-time = "2025-11-19T15:18:41.627Z" },
+    { url = "https://files.pythonhosted.org/packages/05/e5/cb4b713c8a93469e3c5be7c3f8d77d307e65fe89673e731f5c2bfd0a9237/safetensors-0.7.0-cp38-abi3-win32.whl", hash = "sha256:c74af94bf3ac15ac4d0f2a7c7b4663a15f8c2ab15ed0fc7531ca61d0835eccba", size = 326423, upload-time = "2025-11-19T15:18:45.74Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/e6/ec8471c8072382cb91233ba7267fd931219753bb43814cbc71757bfd4dab/safetensors-0.7.0-cp38-abi3-win_amd64.whl", hash = "sha256:d1239932053f56f3456f32eb9625590cc7582e905021f94636202a864d470755", size = 341380, upload-time = "2025-11-19T15:18:44.427Z" },
+]
+
+[[package]]
 name = "scikit-learn"
 version = "1.8.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3688,6 +4037,34 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/46/f5af3402b579fd5e11573ce652019a67074317e18c1935cc0b4ba9b35552/secretstorage-3.5.0-py3-none-any.whl", hash = "sha256:0ce65888c0725fcb2c5bc0fdb8e5438eece02c523557ea40ce0703c266248137", size = 15554, upload-time = "2025-11-23T19:02:51.545Z" },
+]
+
+[[package]]
+name = "sentence-transformers"
+version = "5.5.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "huggingface-hub" },
+    { name = "numpy" },
+    { name = "scikit-learn" },
+    { name = "scipy" },
+    { name = "torch" },
+    { name = "tqdm" },
+    { name = "transformers" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cf/d4/7ef93157485e978c016f49da05363c1e4e7237beb5343b64b5631101f0f1/sentence_transformers-5.5.1.tar.gz", hash = "sha256:02b7740dfc60bdbbcb6061625f5d97a5c1a4e2d3baac5f9391b912bb5eae2290", size = 445161, upload-time = "2026-05-20T07:37:44.465Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bf/03/ee99a6b030e7a2e056547729f8a4709dd93e13d9c6f07590f74c395c4017/sentence_transformers-5.5.1-py3-none-any.whl", hash = "sha256:4fe11d433badc5282d32f7fc08bc714216b7a5aca426f9df77a45a554756deb7", size = 588887, upload-time = "2026-05-20T07:37:43.004Z" },
+]
+
+[[package]]
+name = "setuptools"
+version = "82.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4f/db/cfac1baf10650ab4d1c111714410d2fbb77ac5a616db26775db562c8fab2/setuptools-82.0.1.tar.gz", hash = "sha256:7d872682c5d01cfde07da7bccc7b65469d3dca203318515ada1de5eda35efbf9", size = 1152316, upload-time = "2026-03-09T12:47:17.221Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/76/f789f7a86709c6b087c5a2f52f911838cad707cc613162401badc665acfe/setuptools-82.0.1-py3-none-any.whl", hash = "sha256:a59e362652f08dcd477c78bb6e7bd9d80a7995bc73ce773050228a348ce2e5bb", size = 1006223, upload-time = "2026-03-09T12:47:15.026Z" },
 ]
 
 [[package]]
@@ -3846,6 +4223,41 @@ wheels = [
 ]
 
 [[package]]
+name = "sympy"
+version = "1.14.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mpmath" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/83/d3/803453b36afefb7c2bb238361cd4ae6125a569b4db67cd9e79846ba2d68c/sympy-1.14.0.tar.gz", hash = "sha256:d3d3fe8df1e5a0b42f0e7bdf50541697dbe7d23746e894990c030e2b05e72517", size = 7793921, upload-time = "2025-04-27T18:05:01.611Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a2/09/77d55d46fd61b4a135c444fc97158ef34a095e5681d0a6c10b75bf356191/sympy-1.14.0-py3-none-any.whl", hash = "sha256:e091cc3e99d2141a0ba2847328f5479b05d94a6635cb96148ccb3f34671bd8f5", size = 6299353, upload-time = "2025-04-27T18:04:59.103Z" },
+]
+
+[[package]]
+name = "tantivy"
+version = "0.26.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/74/ec8c3f7bb3599af86c19f1a774c37e36a6e7524d3563f3aeb99220981f6f/tantivy-0.26.0.tar.gz", hash = "sha256:7c9507fcc62bac4ef1d40b1ed37ff7fa07e44b5043b30288f63bcf4fdc62644a", size = 93615, upload-time = "2026-04-29T11:51:31.115Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/56/aef45e8ec7fddbca4885516bc1d8cc61950f666ba8b44ef9e50b8db51f91/tantivy-0.26.0-cp313-cp313-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:7509b06fab07d4209bf37759e3c0c407f6c53fa3184d694ec82416fc8d189e7d", size = 8301236, upload-time = "2026-04-29T11:50:59.299Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/3b/8ce1a1662e6e6c303a65055a42206853adfeaa14596e62b6f218b5af5526/tantivy-0.26.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:0c77962afc03f8a7081991fee088d09891acaa3401cdf882b1cc40d9d839a683", size = 4284342, upload-time = "2026-04-29T11:51:01.626Z" },
+    { url = "https://files.pythonhosted.org/packages/32/15/4f4e74669bdc26e7508d527f27be1a12d249e1d9ab6bba05f47ba1cdedfa/tantivy-0.26.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9f017f6991752da8092c46c670e0eae349a1266d2315720ff5b252ed1ea4acd4", size = 4610161, upload-time = "2026-04-29T11:51:03.966Z" },
+    { url = "https://files.pythonhosted.org/packages/50/3e/4648f7fc34834f3f4c99465111f50add73f0517f21ceae7c81771942c99b/tantivy-0.26.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bb7df28cc98497c767b86ebc5f167e3f2552739f748a1c28c10e14e7db726cd1", size = 4571125, upload-time = "2026-04-29T11:51:06.162Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/04/1fcf362fbe115c1dde654727cd24ae55888ca66d1dfcbe70b75b347a4d58/tantivy-0.26.0-cp313-cp313-win_amd64.whl", hash = "sha256:9d4278d25df78ebd71dcf5510273fa0f4c552e1eed1b6e35a8f2d00b2003b2d7", size = 3759480, upload-time = "2026-04-29T11:51:08.365Z" },
+    { url = "https://files.pythonhosted.org/packages/59/3d/a85ffd178a6b00813cd144e4af2db100023a5a7cd9cae3a5f998e74d5cbd/tantivy-0.26.0-cp313-cp313t-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:7b9a350e59513e330fbcb0930ef2f574d86a8aa46047a1ad1c5b4c91838e3aec", size = 8296228, upload-time = "2026-04-29T11:51:10.844Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/81/c78c3ae37c52e1244da340139e11cca0d44ee742e227bba19ecefbbf54b5/tantivy-0.26.0-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:e1bdf6dcbd25fdc3244e6b09f5114253a81ec533ad5346eff135ee98668f04c7", size = 4279507, upload-time = "2026-04-29T11:51:13.065Z" },
+    { url = "https://files.pythonhosted.org/packages/39/df/a409dad06800793d7dd2cc831aeb46b808b4ce00df7d506e6760acee2cc2/tantivy-0.26.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a9450186861d6f350ec5969ff2e349377d2ed5617f084a8ad0f303ed7a91a2e3", size = 4605550, upload-time = "2026-04-29T11:51:15.289Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/24/68245511021df5b19879d262ef2b1adf214ec67cc69761e1a83fd28571b1/tantivy-0.26.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e69569ec68c0e8d1c3aa3cf52423ced6b9b9b5bb0156e8b32088390919d41964", size = 4566249, upload-time = "2026-04-29T11:51:17.398Z" },
+    { url = "https://files.pythonhosted.org/packages/15/73/8c6e544358d45b863b64645b5cd88374279d13cfcdea1b4a9c7554fce0ec/tantivy-0.26.0-cp313-cp313t-win_amd64.whl", hash = "sha256:2064dd212455666b0f212d832bed38cc5b2de6c5f8069009926ad103bc2eb428", size = 3756762, upload-time = "2026-04-29T11:51:19.278Z" },
+    { url = "https://files.pythonhosted.org/packages/98/53/0c9ec136930dad07c8f24cd31210181e7ba2228aeea9fd75d751b9d716e5/tantivy-0.26.0-cp314-cp314-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:7983206d75c7334fdcb1c49372adf6afe8aeb89ad2abfc7a5fd9701254735134", size = 8319819, upload-time = "2026-04-29T11:51:21.451Z" },
+    { url = "https://files.pythonhosted.org/packages/10/5b/35b7f2af5101883dde8f0523a69944bd5b2471ce399339e97e2e3775a227/tantivy-0.26.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:4a970d35402612208b077de5feb9da978380c173e7835335c50d15d0f13cbaba", size = 4289015, upload-time = "2026-04-29T11:51:23.435Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/4b/fbc1293fc8108eaa2f11718d77070e09cefe4aac4055fd2036548a776946/tantivy-0.26.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:22f6acf0c4d9dff2aecb161071db921c9a0bd3e2485dbc8304fd4561fe50c6a7", size = 4622332, upload-time = "2026-04-29T11:51:25.483Z" },
+    { url = "https://files.pythonhosted.org/packages/86/68/d1ae76c42b523b076434a357b675c37fd9684ac0fc6e0e63f703a1f1014a/tantivy-0.26.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a92825f3215fc4b5ef55da8a577eb9ad30c7ee5c7371daea82329e67aa4c7d12", size = 4573494, upload-time = "2026-04-29T11:51:27.512Z" },
+    { url = "https://files.pythonhosted.org/packages/be/3b/6f1ababc26839b3baa0299da2319567ffbecfe0c1b295de1e75e605d98e4/tantivy-0.26.0-cp314-cp314-win_amd64.whl", hash = "sha256:0c9ce6c5a04c4a18244f38601ea18a94044c07f8e713894d456dcbfccd3fa0f5", size = 3761380, upload-time = "2026-04-29T11:51:29.546Z" },
+]
+
+[[package]]
 name = "temporalio"
 version = "1.20.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3949,6 +4361,60 @@ wheels = [
 ]
 
 [[package]]
+name = "torch"
+version = "2.10.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cuda-bindings", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "filelock" },
+    { name = "fsspec" },
+    { name = "jinja2" },
+    { name = "networkx" },
+    { name = "nvidia-cublas-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cuda-cupti-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cuda-nvrtc-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cuda-runtime-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cudnn-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cufft-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cufile-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-curand-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cusolver-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cusparse-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cusparselt-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-nccl-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-nvjitlink-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-nvshmem-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-nvtx-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "setuptools" },
+    { name = "sympy" },
+    { name = "triton", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "typing-extensions" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/23/2c9fe0c9c27f7f6cb865abcea8a4568f29f00acaeadfc6a37f6801f84cb4/torch-2.10.0-2-cp313-none-macosx_11_0_arm64.whl", hash = "sha256:e521c9f030a3774ed770a9c011751fb47c4d12029a3d6522116e48431f2ff89e", size = 79498254, upload-time = "2026-02-10T21:44:44.095Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/c6/4dfe238342ffdcec5aef1c96c457548762d33c40b45a1ab7033bb26d2ff2/torch-2.10.0-3-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:80b1b5bfe38eb0e9f5ff09f206dcac0a87aadd084230d4a36eea5ec5232c115b", size = 915627275, upload-time = "2026-03-11T14:16:11.325Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/f0/72bf18847f58f877a6a8acf60614b14935e2f156d942483af1ffc081aea0/torch-2.10.0-3-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:46b3574d93a2a8134b3f5475cfb98e2eb46771794c57015f6ad1fb795ec25e49", size = 915523474, upload-time = "2026-03-11T14:17:44.422Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/39/590742415c3030551944edc2ddc273ea1fdfe8ffb2780992e824f1ebee98/torch-2.10.0-3-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:b1d5e2aba4eb7f8e87fbe04f86442887f9167a35f092afe4c237dfcaaef6e328", size = 915632474, upload-time = "2026-03-11T14:15:13.666Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/8e/34949484f764dde5b222b7fe3fede43e4a6f0da9d7f8c370bb617d629ee2/torch-2.10.0-3-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:0228d20b06701c05a8f978357f657817a4a63984b0c90745def81c18aedfa591", size = 915523882, upload-time = "2026-03-11T14:14:46.311Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/6f/f2e91e34e3fcba2e3fc8d8f74e7d6c22e74e480bbd1db7bc8900fdf3e95c/torch-2.10.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:5c4d217b14741e40776dd7074d9006fd28b8a97ef5654db959d8635b2fe5f29b", size = 146004247, upload-time = "2026-01-21T16:24:29.335Z" },
+    { url = "https://files.pythonhosted.org/packages/98/fb/5160261aeb5e1ee12ee95fe599d0541f7c976c3701d607d8fc29e623229f/torch-2.10.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:6b71486353fce0f9714ca0c9ef1c850a2ae766b409808acd58e9678a3edb7738", size = 915716445, upload-time = "2026-01-21T16:22:45.353Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/16/502fb1b41e6d868e8deb5b0e3ae926bbb36dab8ceb0d1b769b266ad7b0c3/torch-2.10.0-cp313-cp313-win_amd64.whl", hash = "sha256:c2ee399c644dc92ef7bc0d4f7e74b5360c37cdbe7c5ba11318dda49ffac2bc57", size = 113757050, upload-time = "2026-01-21T16:24:19.204Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/0b/39929b148f4824bc3ad6f9f72a29d4ad865bcf7ebfc2fa67584773e083d2/torch-2.10.0-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:3202429f58309b9fa96a614885eace4b7995729f44beb54d3e4a47773649d382", size = 79851305, upload-time = "2026-01-21T16:24:09.209Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/14/21fbce63bc452381ba5f74a2c0a959fdf5ad5803ccc0c654e752e0dbe91a/torch-2.10.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:aae1b29cd68e50a9397f5ee897b9c24742e9e306f88a807a27d617f07adb3bd8", size = 146005472, upload-time = "2026-01-21T16:22:29.022Z" },
+    { url = "https://files.pythonhosted.org/packages/54/fd/b207d1c525cb570ef47f3e9f836b154685011fce11a2f444ba8a4084d042/torch-2.10.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:6021db85958db2f07ec94e1bc77212721ba4920c12a18dc552d2ae36a3eb163f", size = 915612644, upload-time = "2026-01-21T16:21:47.019Z" },
+    { url = "https://files.pythonhosted.org/packages/36/53/0197f868c75f1050b199fe58f9bf3bf3aecac9b4e85cc9c964383d745403/torch-2.10.0-cp313-cp313t-win_amd64.whl", hash = "sha256:ff43db38af76fda183156153983c9a096fc4c78d0cd1e07b14a2314c7f01c2c8", size = 113997015, upload-time = "2026-01-21T16:23:00.767Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/13/e76b4d9c160e89fff48bf16b449ea324bda84745d2ab30294c37c2434c0d/torch-2.10.0-cp313-none-macosx_11_0_arm64.whl", hash = "sha256:cdf2a523d699b70d613243211ecaac14fe9c5df8a0b0a9c02add60fb2a413e0f", size = 79498248, upload-time = "2026-01-21T16:23:09.315Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/93/716b5ac0155f1be70ed81bacc21269c3ece8dba0c249b9994094110bfc51/torch-2.10.0-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:bf0d9ff448b0218e0433aeb198805192346c4fd659c852370d5cc245f602a06a", size = 79464992, upload-time = "2026-01-21T16:23:05.162Z" },
+    { url = "https://files.pythonhosted.org/packages/69/2b/51e663ff190c9d16d4a8271203b71bc73a16aa7619b9f271a69b9d4a936b/torch-2.10.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:233aed0659a2503b831d8a67e9da66a62c996204c0bba4f4c442ccc0c68a3f60", size = 146018567, upload-time = "2026-01-21T16:22:23.393Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/cd/4b95ef7f293b927c283db0b136c42be91c8ec6845c44de0238c8c23bdc80/torch-2.10.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:682497e16bdfa6efeec8cde66531bc8d1fbbbb4d8788ec6173c089ed3cc2bfe5", size = 915721646, upload-time = "2026-01-21T16:21:16.983Z" },
+    { url = "https://files.pythonhosted.org/packages/56/97/078a007208f8056d88ae43198833469e61a0a355abc0b070edd2c085eb9a/torch-2.10.0-cp314-cp314-win_amd64.whl", hash = "sha256:6528f13d2a8593a1a412ea07a99812495bec07e9224c28b2a25c0a30c7da025c", size = 113752373, upload-time = "2026-01-21T16:22:13.471Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/94/71994e7d0d5238393df9732fdab607e37e2b56d26a746cb59fdb415f8966/torch-2.10.0-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:f5ab4ba32383061be0fb74bda772d470140a12c1c3b58a0cfbf3dae94d164c28", size = 79850324, upload-time = "2026-01-21T16:22:09.494Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/65/1a05346b418ea8ccd10360eef4b3e0ce688fba544e76edec26913a8d0ee0/torch-2.10.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:716b01a176c2a5659c98f6b01bf868244abdd896526f1c692712ab36dbaf9b63", size = 146006482, upload-time = "2026-01-21T16:22:18.42Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/b9/5f6f9d9e859fc3235f60578fa64f52c9c6e9b4327f0fe0defb6de5c0de31/torch-2.10.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:d8f5912ba938233f86361e891789595ff35ca4b4e2ac8fe3670895e5976731d6", size = 915613050, upload-time = "2026-01-21T16:20:49.035Z" },
+    { url = "https://files.pythonhosted.org/packages/66/4d/35352043ee0eaffdeff154fad67cd4a31dbed7ff8e3be1cc4549717d6d51/torch-2.10.0-cp314-cp314t-win_amd64.whl", hash = "sha256:71283a373f0ee2c89e0f0d5f446039bdabe8dbc3c9ccf35f0f784908b0acd185", size = 113995816, upload-time = "2026-01-21T16:22:05.312Z" },
+]
+
+[[package]]
 name = "tqdm"
 version = "4.67.3"
 source = { registry = "https://pypi.org/simple" }
@@ -3958,6 +4424,37 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/09/a9/6ba95a270c6f1fbcd8dac228323f2777d886cb206987444e4bce66338dd4/tqdm-4.67.3.tar.gz", hash = "sha256:7d825f03f89244ef73f1d4ce193cb1774a8179fd96f31d7e1dcde62092b960bb", size = 169598, upload-time = "2026-02-03T17:35:53.048Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl", hash = "sha256:ee1e4c0e59148062281c49d80b25b67771a127c85fc9676d3be5f243206826bf", size = 78374, upload-time = "2026-02-03T17:35:50.982Z" },
+]
+
+[[package]]
+name = "transformers"
+version = "5.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "huggingface-hub" },
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "pyyaml" },
+    { name = "regex" },
+    { name = "safetensors" },
+    { name = "tokenizers" },
+    { name = "tqdm" },
+    { name = "typer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/51/58/7f843608f2e8421f86bb97060b54649be6239ec612b82bf9d41e65c26c00/transformers-5.9.0.tar.gz", hash = "sha256:25997cb8fa6053533171634b6162d7df54346530ec2aa9b42bb834e63668c842", size = 8642240, upload-time = "2026-05-20T14:50:49.278Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/02/ca/2eaa5359f2ccb8c2e1656bc26305ad0cf438aa392ce4b29ae67a315c186e/transformers-5.9.0-py3-none-any.whl", hash = "sha256:1d19509bcff7028ebc6b277d71caa712e8353778463d38764237d14b42b52788", size = 10787648, upload-time = "2026-05-20T14:50:45.337Z" },
+]
+
+[[package]]
+name = "triton"
+version = "3.6.0"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f9/0b/37d991d8c130ce81a8728ae3c25b6e60935838e9be1b58791f5997b24a54/triton-3.6.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:10c7f76c6e72d2ef08df639e3d0d30729112f47a56b0c81672edc05ee5116ac9", size = 188289450, upload-time = "2026-01-20T16:00:49.136Z" },
+    { url = "https://files.pythonhosted.org/packages/35/f8/9c66bfc55361ec6d0e4040a0337fb5924ceb23de4648b8a81ae9d33b2b38/triton-3.6.0-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d002e07d7180fd65e622134fbd980c9a3d4211fb85224b56a0a0efbd422ab72f", size = 188400296, upload-time = "2026-01-20T16:00:56.042Z" },
+    { url = "https://files.pythonhosted.org/packages/df/3d/9e7eee57b37c80cec63322c0231bb6da3cfe535a91d7a4d64896fcb89357/triton-3.6.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a17a5d5985f0ac494ed8a8e54568f092f7057ef60e1b0fa09d3fd1512064e803", size = 188273063, upload-time = "2026-01-20T16:01:07.278Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/56/6113c23ff46c00aae423333eb58b3e60bdfe9179d542781955a5e1514cb3/triton-3.6.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:46bd1c1af4b6704e554cad2eeb3b0a6513a980d470ccfa63189737340c7746a7", size = 188397994, upload-time = "2026-01-20T16:01:14.236Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Adds a **local snippet index** for atlases whose source paper isn't yet indexed in Semantic Scholar / EuropePMC (e.g. fresh bioRxiv preprints). Built from the JATS XML alone, it emits objects shaped exactly like ASTA `snippet_search` responses — so the existing `_summarize_snippets` → `validate_report` machinery (quote substring check, paper catalogue, blockquote enforcement) works unchanged. Triggers automatically when `projects/{name}/local_index/manifest.json` exists; falls through to ASTA-only otherwise.

Background and alternatives surveyed in [`docs/preprint_citation_options.md`](docs/preprint_citation_options.md). The chosen design (Option B) is the smallest one that preserves the existing validation contract while unlocking quoted cross-paper evidence for unindexed atlases.

## Why

ASTA's `snippet_search` scoped to a fresh preprint DOI returns nothing because Semantic Scholar's ingestion lags bioRxiv by weeks. The Steele et al. 2026 spatial skin atlas was the trigger: 107 cell types to report on, but reports could only ground blockquotes in the atlas paper itself (paraphrasing all referenced literature) because there was no snippet API for either the atlas or its citation graph.

## What's in the branch

**New services** (all under `src/atlas_chat/atlas_chat/services/`):
- [`fetch_preprint.py`](src/atlas_chat/atlas_chat/services/fetch_preprint.py) — DOI → JATS via EuropePMC → `curl_cffi` (TLS-impersonating bioRxiv fetch) → Playwright fallback. Normalises bioRxiv's bogus double-slash in `jatsxml` URLs. Explicit `PreprintFetchError` listing tried paths.
- [`local_snippet_index.py`](src/atlas_chat/atlas_chat/services/local_snippet_index.py) — the heavy lifter:
  - `_normalize_biorxiv_jats` strips `hwp:*` attrs (which otherwise overwrite real `id`s after namespace stripping) and renames `<citation>` → `<element-citation>` so paperqa2_cyberian's parser matches.
  - `extract_body_segments` / `chunk_segments` produce ~2.8k-char paragraph chunks with 200-char overlap, section labels, and char offsets. `<sup>` blocks containing bibr-xrefs are wrapped as `[12-15]` so the rendered text matches paperqa's sentence output and reads naturally.
  - `build_sentence_rows` calls `paperqa2_cyberian.parse_jats_citations` for sentence-level citations and aligns each to a fulltext char offset.
  - `_resolve_refs_to_corpus_ids` does DOI batch first, then S2 `/paper/search/match` per ref for refs without DOIs (with year + first-author guards). **Resolution rate on Steele 2026: 7% → 93%** (132/142 refs).
  - `_merge_snippets` joins chunks with overlapping sentences, emitting one ASTA-shape snippet per chunk with `refMentions` (`matchedPaperCorpusId`, `ref_id`, char offsets) baked in.
  - `search()` cosine-ranks via MiniLM and returns dicts shaped to match `citation_traverser._snippet_to_dict(AstaSnippet(...))` — same keys (`snippet`, `paper_id`, `corpus_id`, `title`, `authors`, `year`, `score`) plus the extras.
  - Manifest-based idempotency: SHA256 of (JATS bytes, embedding model, parser version). Re-runs short-circuit unless `--force`.

**Wiring** (in [`graphs/report_graph.py`](src/atlas_chat/atlas_chat/graphs/report_graph.py)):
- `FanOut._citation_traverse` runs ASTA + local search in parallel via `asyncio.gather` when a manifest exists; merges with dedup; tags every snippet `source_method: "asta" | "local_snippet"`. `_summarize_snippets` propagates the tag onto evidence items.
- [`citation_traverser.traverse_local()`](src/atlas_chat/atlas_chat/services/citation_traverser.py) — mirrors `traverse()`'s `(snippets, catalogue)` two-tuple so the call-site is symmetric.

**Corpus ID scheme**: atlas paper itself is `CorpusId:local_<sha1[:10](doi)>`. The `local_` token has no digits, so it sidesteps the legacy `CorpusId:\d+` regex in `check_references` without false positives; DOI validation covers the atlas. Cited refs keep their real CorpusIds.

**CLI + skill**: [`scripts/setup_local_index.py`](scripts/setup_local_index.py) for one-shot project setup (reads DOI from `cell_type_annotations.json`). [`.claude/skills/local-paper-index/SKILL.md`](.claude/skills/local-paper-index/SKILL.md) documents build + query for agentic use. [`AGENT.md`](AGENT.md) step 4b note about the local-index branch.

**Bonus**: [`.claude/skills/anndata-zarr-summary/run.py`](.claude/skills/anndata-zarr-summary/run.py) gets fixes discovered during the spatial-skin pilot work — blosc/lz4 dispatch via `numcodecs` (the skill was hard-coded to zstd), and graceful handling of empty categorical columns (shape `[0]`, no chunk file).

## Dependencies

Behind a new `[project.optional-dependencies] local-index` extra in `src/atlas_chat/pyproject.toml`:
- `paperqa2-cyberian @ git+https://github.com/Cellular-Semantics/paperqa2_cyberian.git@main` — reuses the JATS parser, embedding retrieval, and ASTA refMention schema as a library.
- `curl-cffi>=0.7.0` for TLS-impersonating preprint fetch.

Pulls in `sentence-transformers` + `paper-qa` + `torch` (~500 MB), so default installs unaffected. Dev uses a `[tool.uv.sources]` local-path override to `paperqa2_cyberian` until its Python pin (currently `>=3.14`) is relaxed to `>=3.13` upstream and pushed to `main`. **Pre-merge follow-up: push paperqa2_cyberian's pin relax (already made locally, see `git diff` in that repo), then flip the source override back to the git URL.**

## Verification

- **Unit** (no network, no ML stack): `uv run pytest tests/unit/test_local_snippet_index.py` — 7 tests covering bioRxiv JATS normaliser, body extraction skipping ref-list, chunk text → fulltext substring invariant, sentence→ref-id resolution, ASTA-shape parity for `_merge_snippets`, `local_<hash>` corpus-id format, missing-manifest gating. All pass; ruff clean.
- **Integration** (network): `uv run python scripts/setup_local_index.py --project spatial_skin_atlas --doi 10.64898/2026.03.20.713219` → 29 chunks, 64 cited sentences, 132/142 refs resolved (9 DOI, 123 title-match, 9 unmatched), 125 refMentions baked into the snippet index, 24/29 chunks carry mentions. Rebuild is idempotent.
- **End-to-end search**: `python -m atlas_chat.services.local_snippet_index search --project projects/spatial_skin_atlas --query "ILC3 CCL1 PTGDS inflammation"` returns ranked ASTA-shape chunks with `source_method: "local_snippet"` and refMentions to real CorpusIds (e.g. chunk #1 carries 17 mentions including `c32→278393848`, `c33→215779056`, `c34→259148158`, `c35→210124135`).

**Not verified here:** regression on a fully ASTA-indexed atlas (`fetal_skin_atlas`) — its project files aren't on this branch (deliberately, content lives on `spatial-skin-atlas`). Worth running before merge.

## Known limitations / follow-ups

- **bioRxiv ref quality**: only 10 of 142 Steele refs have explicit DOIs in JATS; the rest are author+title+year strings. Title-match handles 123 of them via S2 `/paper/search/match` with year + first-author guards. The remaining 9 are typically book chapters / web URLs that S2 has no record of.
- **paperqa Python pin**: requires the local-path override in `pyproject.toml` until upstream `paperqa2_cyberian` accepts the `>=3.13` pin relax.
- **MiniLM install footprint**: ~500 MB. Lazy imports + optional extra keep default users out of it; the `_citation_traverse` gate is a file-existence check, not an import, so missing deps don't break the default path.
- **Cited-paper text**: out of scope. The local index covers only the atlas paper. References that ASTA *also* lacks would need a recursive local index — flag for a future phase if it becomes a real failure mode.
- **Catalogue collision later**: if S2 eventually indexes the atlas, the real CorpusId will diverge from `local_<hash>`. Manifest should record both once known; `_backfill_catalogue` can reconcile on subsequent runs.

## Commits

- `7d0cd81` Add local snippet index for fresh-preprint atlases (Option B) — 13 files, +2274
- `28b7420` Bracket-wrap bibr citations during JATS body extraction — 2 files, +34/-16

## Files

| Change | Path |
|---|---|
| new | `src/atlas_chat/atlas_chat/services/fetch_preprint.py` (259 LOC) |
| new | `src/atlas_chat/atlas_chat/services/local_snippet_index.py` (824 LOC) |
| new | `scripts/setup_local_index.py` (86 LOC) |
| new | `tests/unit/test_local_snippet_index.py` (184 LOC) |
| new | `.claude/skills/local-paper-index/SKILL.md` |
| new | `docs/preprint_citation_options.md` (211 LOC) |
| modified | `src/atlas_chat/atlas_chat/graphs/report_graph.py` (parallel local+ASTA branch in `_citation_traverse`) |
| modified | `src/atlas_chat/atlas_chat/services/citation_traverser.py` (`traverse_local`) |
| modified | `src/atlas_chat/pyproject.toml` (new `[local-index]` extra) |
| modified | `pyproject.toml` (uv local-path source override) |
| modified | `AGENT.md` (step 4b note) |
| modified | `.claude/skills/anndata-zarr-summary/run.py` (blosc + empty-col fixes) |
