### PR TITLE
Refactor local snippet index to a per-project corpus of multiple papers

### DIFF
--- a/.claude/skills/local-paper-index/SKILL.md
+++ b/.claude/skills/local-paper-index/SKILL.md
@@ -1,68 +1,95 @@
 ---
 name: local-paper-index
-description: Build and query a local ASTA-shape snippet index for a fresh preprint atlas paper not yet indexed in EuropePMC or Semantic Scholar. Use when ASTA snippet_search returns nothing for the atlas DOI and you need quoted evidence from the paper text. Installs the [local-index] extra (~500 MB of MiniLM via sentence-transformers).
+description: Build and query a local ASTA-shape snippet index for an atlas project's papers — the primary atlas paper plus its subatlas references (upstream studies that contributed cell types). Supports JATS XML (preprints + EuropePMC) and PDF (closed-access journals via pymupdf4llm). Installs the [local-index] extra (~500 MB of MiniLM via sentence-transformers, ~25 MB PyMuPDF).
 ---
 
 # local-paper-index
 
-When the atlas paper is a fresh bioRxiv preprint, ASTA `snippet_search` scoped
-to the paper returns nothing. This skill builds a project-wide local index
-that emits ASTA-shape snippet objects so the existing
-`_summarize_snippets` / `validate_report` machinery works unchanged.
+A project's `local_index/` is a **corpus** of one or more papers:
+
+- Exactly one `role: atlas` paper — the DOI in `cell_type_annotations.json.source.doi`.
+- Zero or more `role: subatlas` papers — upstream studies whose cell types were folded into the atlas (sourced from `label_provenance.json` study labels).
+
+Snippets emitted by the corpus are ASTA-shape, so `_summarize_snippets` / `validate_report` consume them unchanged.
 
 ## When to invoke
 
-- `mcp__Asta_semanticscholar__snippet_search` returns no hits for the atlas DOI.
-- The project's `cell_type_annotations.json` has a recent (≤ 6 months) bioRxiv DOI.
-- `atlas_chat.services.local_snippet_index.has_local_index(project_dir)` is False.
+- Atlas setup: after `anndata-zarr-summary` has produced `cell_type_annotations.json` + `label_provenance.json`, run the discover → review → ingest flow to build the corpus.
+- Adding a new subatlas paper: when fan-out logs a `needs_pdf` warning, download the publisher PDF and run `add --pdf …`.
 
-## Build
-
-```bash
-uv run python scripts/setup_local_index.py --project <name> [--doi DOI] [--force]
-```
-
-If `--doi` is omitted, the DOI is read from
-`projects/<name>/cell_type_annotations.json`. Output lives under
-`projects/<name>/local_index/`:
-
-```
-local_index/
-  source/paper.jats.xml         # fetched via EuropePMC → curl_cffi → Playwright
-  chunks/{chunks.jsonl, embeddings.npy, chunks.fulltext.txt}
-  citations/{sentences.jsonl, ref_resolution.json}
-  snippet_index/snippets.json   # ASTA-shape snippet objects
-  manifest.json
-```
-
-Build is idempotent — a re-run short-circuits unless `--force` or the JATS
-SHA256 changed.
-
-## Query
+## Flow
 
 ```bash
-uv run python -m atlas_chat.services.local_snippet_index search \
-  --project projects/<name> --query "ILC3 CCL1 PTGDS skin inflammation" -k 10
+# 1. Propose subatlas papers from label_provenance.json (S2 title-match + author/year hints).
+uv run python scripts/setup_local_index.py discover-subatlas --project <name>
+
+# 2. Review projects/<name>/cell_type_annotations.json:
+#    For each entry under source.subatlas_papers, copy `proposed_doi` → `doi`
+#    (or replace with the correct DOI). Delete entries that aren't useful.
+
+# 3. Run the waterfall: ASTA probe → JATS fetch → mark needs_pdf if neither.
+#    Also builds the atlas paper's local index.
+uv run python scripts/setup_local_index.py init-corpus --project <name>
+
+# 4. Inspect:
+uv run python scripts/setup_local_index.py list --project <name>
+cat projects/<name>/subatlas_todo.md   # papers awaiting PDF, with publisher links
+
+# 5. After downloading any needs_pdf paper:
+uv run python scripts/setup_local_index.py add \
+  --project <name> --doi <DOI> --pdf path/to/paper.pdf --role subatlas
+
+# 6. Query:
+uv run python scripts/setup_local_index.py search \
+  --project <name> --query "ILC3 CCL1 PTGDS skin inflammation" -k 10
+uv run python scripts/setup_local_index.py search \
+  --project <name> --query "..." --role subatlas   # restrict to subatlas papers
 ```
 
-Returns JSON of ASTA-shape dicts (`snippet`, `paper_id`, `title`, `authors`,
-`year`, `corpus_id`, `score`, `annotations.refMentions`).
+## Output layout
 
-## Integration
+```
+projects/<name>/local_index/
+  corpus.json                # version, atlas_doi, use_in_fanout flag, papers list
+  papers/<paper_slug>/
+    manifest.json            # role, source_type, hash, n_chunks, paper metadata
+    source/{paper.jats.xml | paper.pdf}
+    chunks/{chunks.jsonl, embeddings.npy, chunks.fulltext.txt}
+    citations/{sentences.jsonl, ref_resolution.json}   # JATS papers only
+    snippet_index/snippets.json
+```
 
-Once built, the report graph picks the local index up automatically via
-`FanOut._citation_traverse` — runs in parallel with ASTA and merges results.
-No flag or env var needed; existence of `manifest.json` is the gate.
+`paper_slug` = DOI lowercased with `/` → `_` (e.g. `10.1126_science.adf1226`), sha1 fallback for pathological DOIs.
+
+Builds are idempotent — per-paper hash short-circuits a rebuild unless `--force` or the source changed. Adding or removing one paper never re-embeds the others.
+
+## Integration with fan-out
+
+**Default: local index is NOT queried during `FanOut._citation_traverse`.** Subatlas papers are surfaced as a curated corpus; fan-out relies on ASTA for citation traversal.
+
+To opt in to parallel local-index search during fan-out, edit `corpus.json` and set `"use_in_fanout": true`. Hits from the local index are merged with ASTA results, with local taking precedence on `(corpus_id, chunk_id)` dedupe.
+
+Even with the default (off), fan-out **does** emit a non-blocking warning row whenever the corpus has subatlas entries at `status: needs_pdf`, listing them in `traversal_output/<cell_type>/subatlas_missing.json`. Useful for spotting papers worth grabbing.
+
+## Source-type behavior
+
+| Source | Parser | Citation graph | Metadata |
+|---|---|---|---|
+| JATS XML | `_jats_parser` (vendored) | yes — `xref → ref_id → CorpusId` | bioRxiv API |
+| PDF | `pymupdf4llm` via `_pdf_parser` | no (PDFs lack xref markers) | Crossref REST API |
+
+PDF parser notes:
+- Reading order at the *document* level may be shuffled across columns on multi-column layouts (Science, etc.). Each *paragraph* is internally coherent — fine for embedding-based retrieval.
+- Figure-internal text (axis labels, panel tags, gene-name strips) is tagged `section: IN_FIGURE` so consumers can filter it from quoted evidence while still indexing it for recall.
+- Front-matter paragraphs that near-duplicate the abstract (e.g. Science "Research Article Summary") are deduped by prefix.
+
+## Migration from the old single-paper layout
+
+Projects built with the previous version of this skill have `local_index/manifest.json` at the corpus root. On first read, `local_snippet_index` automatically moves the existing files under `papers/<atlas_slug>/` and synthesises `corpus.json` with that paper as `role: atlas`. One-shot, no flag needed.
 
 ## Limitations
 
-- bioRxiv JATS ref-list quality varies; many references lack DOIs and are
-  therefore unresolvable to CorpusIds. Cited-paper traversal via ASTA covers
-  the gap for indexed references.
-- Image-based supplementary PDFs aren't OCR'd; supplementary text only enters
-  the index if the JATS includes structured tables.
-- Heavy ML stack: pulls in `sentence-transformers` + torch. Behind the
-  `[local-index]` optional extra to keep default installs lean.
-- The JATS parser is vendored at `src/atlas_chat/atlas_chat/services/_jats_parser.py`
-  (source: Cellular-Semantics/paperqa2_cyberian@4d5d153). Re-sync periodically
-  by `cp` if upstream picks up additional JATS dialect support.
+- bioRxiv JATS ref-list quality varies; references without DOIs can't be auto-resolved to CorpusIds. Cited-paper traversal via ASTA covers the gap for indexed references.
+- Image-only PDFs aren't OCR'd. If `pymupdf4llm` returns an empty markdown for a PDF, the paper falls back to `needs_pdf` (manual re-OCR + re-add).
+- Heavy ML stack: pulls in `sentence-transformers` + torch + PyMuPDF. Behind the `[local-index]` optional extra to keep default installs lean.
+- The vendored JATS parser is at `src/atlas_chat/atlas_chat/services/_jats_parser.py` (source: Cellular-Semantics/paperqa2_cyberian@4d5d153). Re-sync periodically by `cp` if upstream picks up additional JATS dialect support.

--- a/scripts/setup_local_index.py
+++ b/scripts/setup_local_index.py
@@ -1,11 +1,17 @@
-"""Project-setup CLI: build the local snippet index for a fresh-preprint atlas.
+"""CLI for the per-project local snippet index (multi-paper corpus model).
 
-Wraps `atlas_chat.services.local_snippet_index.build_local_index` with project
-discovery (reads DOI from cell_type_annotations.json if --doi isn't passed).
+Subcommands::
 
-Example:
-    uv run python scripts/setup_local_index.py --project spatial_skin_atlas
-    uv run python scripts/setup_local_index.py --project some_atlas --doi 10.1101/... --force
+    discover-subatlas   Propose subatlas DOIs from label_provenance.json.
+    init-corpus         Run the asta/jats/pdf waterfall + build atlas index.
+    add                 Add a paper from a PDF or JATS file.
+    list                List papers in the corpus.
+    remove              Remove a paper from the corpus.
+    search              Query the corpus.
+    build               (legacy) Build only the atlas paper from JATS.
+
+Project resolution: ``--project`` accepts either a path to a project dir or a
+bare name. Bare names are looked up under ``./projects/``.
 """
 
 from __future__ import annotations
@@ -21,7 +27,6 @@ def _resolve_project_dir(project_arg: str) -> Path:
     p = Path(project_arg)
     if p.is_dir():
         return p.resolve()
-    # Try projects/<name>
     candidate = Path.cwd() / "projects" / project_arg
     if candidate.is_dir():
         return candidate.resolve()
@@ -38,48 +43,134 @@ def _doi_from_config(project_dir: Path) -> str | None:
         return None
 
 
-def main(argv: list[str] | None = None) -> int:
+def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__.split("\n", maxsplit=1)[0])
-    parser.add_argument(
-        "--project",
-        required=True,
-        help="Project directory or name (under projects/)",
-    )
-    parser.add_argument(
-        "--doi",
-        default=None,
-        help="DOI of the preprint. Read from cell_type_annotations.json if omitted.",
-    )
-    parser.add_argument(
-        "--jats",
-        type=Path,
-        default=None,
-        help="Path to an existing JATS XML; skip fetch step.",
-    )
-    parser.add_argument("--force", action="store_true", help="Rebuild even if up to date")
     parser.add_argument("-v", "--verbose", action="store_true")
-    args = parser.parse_args(argv)
+    sub = parser.add_subparsers(dest="cmd")
 
+    p_disc = sub.add_parser("discover-subatlas")
+    p_disc.add_argument("--project", required=True)
+
+    p_init = sub.add_parser("init-corpus")
+    p_init.add_argument("--project", required=True)
+    p_init.add_argument("--force", action="store_true")
+
+    p_add = sub.add_parser("add")
+    p_add.add_argument("--project", required=True)
+    p_add.add_argument("--doi", required=True)
+    src = p_add.add_mutually_exclusive_group()
+    src.add_argument("--pdf", type=Path, default=None)
+    src.add_argument("--jats", type=Path, default=None)
+    p_add.add_argument("--role", default="subatlas", choices=("atlas", "subatlas"))
+    p_add.add_argument("--force", action="store_true")
+
+    p_list = sub.add_parser("list")
+    p_list.add_argument("--project", required=True)
+
+    p_rm = sub.add_parser("remove")
+    p_rm.add_argument("--project", required=True)
+    p_rm.add_argument("--doi", required=True)
+
+    p_search = sub.add_parser("search")
+    p_search.add_argument("--project", required=True)
+    p_search.add_argument("--query", required=True)
+    p_search.add_argument("-k", type=int, default=10)
+    p_search.add_argument("--paper", action="append", default=None)
+    p_search.add_argument("--role", action="append", default=None, choices=("atlas", "subatlas"))
+
+    p_build = sub.add_parser("build", help="(legacy) build only the atlas paper")
+    p_build.add_argument("--project", required=True)
+    p_build.add_argument("--doi", default=None)
+    p_build.add_argument("--jats", type=Path, default=None)
+    p_build.add_argument("--force", action="store_true")
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
     logging.basicConfig(
         level=logging.INFO if args.verbose else logging.WARNING,
         format="%(levelname)s: %(message)s",
     )
 
+    if args.cmd is None:
+        parser.print_help()
+        return 0
+
     project_dir = _resolve_project_dir(args.project)
-    doi = args.doi or _doi_from_config(project_dir)
-    if not doi:
-        print(
-            "ERROR: no DOI supplied and none found in cell_type_annotations.json",
-            file=sys.stderr,
+
+    if args.cmd == "discover-subatlas":
+        from atlas_chat.services.subatlas_resolver import discover
+
+        result = discover(project_dir)
+        print(json.dumps(result, indent=2))
+        return 0
+
+    if args.cmd == "init-corpus":
+        from atlas_chat.services.subatlas_resolver import ingest
+
+        result = ingest(project_dir, force=args.force)
+        print(json.dumps(result, indent=2))
+        return 0
+
+    if args.cmd == "add":
+        from atlas_chat.services.local_snippet_index import add_paper
+
+        manifest = add_paper(
+            project_dir,
+            args.doi,
+            pdf_path=args.pdf,
+            jats_path=args.jats,
+            role=args.role,
+            force=args.force,
         )
-        return 1
+        print(json.dumps(manifest, indent=2))
+        return 0
 
-    # Lazy import — keeps `--help` snappy when the heavy ML stack isn't installed.
-    from atlas_chat.services.local_snippet_index import build_local_index
+    if args.cmd == "list":
+        from atlas_chat.services.local_snippet_index import list_papers
 
-    manifest = build_local_index(project_dir, doi, args.jats, args.force)
-    print(json.dumps(manifest, indent=2))
-    return 0
+        print(json.dumps(list_papers(project_dir), indent=2))
+        return 0
+
+    if args.cmd == "remove":
+        from atlas_chat.services.local_snippet_index import remove_paper
+
+        present = remove_paper(project_dir, args.doi)
+        print(json.dumps({"removed": present}, indent=2))
+        return 0
+
+    if args.cmd == "search":
+        from atlas_chat.services.local_snippet_index import search
+
+        results = search(
+            project_dir,
+            args.query,
+            k=args.k,
+            papers=args.paper,
+            roles=args.role,
+        )
+        print(json.dumps(results, indent=2))
+        return 0
+
+    if args.cmd == "build":
+        from atlas_chat.services.local_snippet_index import build_local_index
+
+        doi = args.doi or _doi_from_config(project_dir)
+        if not doi:
+            print(
+                "ERROR: no DOI supplied and none found in cell_type_annotations.json",
+                file=sys.stderr,
+            )
+            return 1
+        manifest = build_local_index(project_dir, doi, args.jats, args.force)
+        print(json.dumps(manifest, indent=2))
+        return 0
+
+    parser.print_help()
+    return 2
 
 
 if __name__ == "__main__":

--- a/src/atlas_chat/atlas_chat/graphs/report_graph.py
+++ b/src/atlas_chat/atlas_chat/graphs/report_graph.py
@@ -285,19 +285,23 @@ class FanOut(BaseNode[ReportState, ReportDeps, str]):
                 depth=state.depth,
                 output_dir=ctx.deps.traversal_dir,
             )
-            # Run ASTA + local index in parallel when the project has a local
-            # snippet index (built via `setup_local_index.py`). Falls through
-            # to ASTA-only when no manifest.json is present.
+            # Local snippet index is opt-in for fan-out (per the multi-paper
+            # corpus design): the project's `corpus.json` must set
+            # `use_in_fanout: true` for parallel local search. Default is
+            # ASTA-only; subatlas papers that ASTA can't reach are surfaced as
+            # a non-blocking warning below.
             local_task = None
+            needs_pdf_warning: list[dict[str, Any]] = []
             try:
                 from atlas_chat.services import local_snippet_index
 
-                if local_snippet_index.has_local_index(config.project_dir):
+                if local_snippet_index.use_in_fanout(config.project_dir):
                     local_task = citation_traverser.traverse_local(
                         query=query,
                         project_dir=config.project_dir,
                         k=20,
                     )
+                needs_pdf_warning = local_snippet_index.needs_pdf_subatlas(config.project_dir)
             except ImportError:
                 logger.info("local_snippet_index unavailable; ASTA-only")
 
@@ -334,6 +338,17 @@ class FanOut(BaseNode[ReportState, ReportDeps, str]):
                 for s in raw_snippets:
                     s.setdefault("source_method", "asta")
             state.paper_catalogue = catalogue
+
+            if needs_pdf_warning:
+                labels = [f"{e.get('label') or e.get('doi')}" for e in needs_pdf_warning]
+                logger.warning(
+                    "Subatlas papers without retrievable text (status=needs_pdf): %s. "
+                    "Consider running `setup_local_index.py add --pdf ...` to ingest them.",
+                    ", ".join(labels),
+                )
+                (ctx.deps.traversal_dir / "subatlas_missing.json").write_text(
+                    json.dumps(needs_pdf_warning, indent=2)
+                )
         except (ImportError, Exception) as exc:
             logger.warning("Citation traversal failed: %s", exc)
             state.all_summaries = []

--- a/src/atlas_chat/atlas_chat/services/_pdf_parser.py
+++ b/src/atlas_chat/atlas_chat/services/_pdf_parser.py
@@ -1,0 +1,197 @@
+"""PDF → paragraph segments for the local snippet index.
+
+Uses ``pymupdf4llm.to_markdown`` to reassemble multi-column PDFs into clean
+paragraph-level markdown, then splits the markdown into ``_BodySegment``
+records compatible with the existing JATS-derived chunker.
+
+Document-level reading order across columns is not always preserved by
+pymupdf4llm (a known limitation on heavily-floated layouts like 3-column
+Science articles), but each emitted paragraph is internally coherent — which
+is what the embedding-based snippet retriever needs.
+
+Figure-internal text (axis labels, panel tags, gene-name strips) is emitted
+by pymupdf4llm inside ``Start of picture text`` / ``End of picture text``
+blocks. We tag those as ``section="IN_FIGURE"`` so downstream consumers can
+exclude them from quoted evidence while still indexing them for recall.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+from dataclasses import dataclass
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class PdfSegment:
+    """Paragraph segment extracted from a PDF.
+
+    Mirrors ``local_snippet_index._BodySegment``. Kept as a separate class so
+    the chunker's type hint can be widened to a Protocol without coupling
+    the JATS parser to PDF concerns.
+    """
+
+    section: str
+    text: str
+
+
+# Pattern for pymupdf4llm picture-text blocks. Capture the raw <br>-separated
+# content so we can keep it as a single "figure" segment per picture.
+_PICTURE_BLOCK_RE = re.compile(
+    r"\*\*-+ Start of picture text -+\*\*<br>\s*(.*?)\s*\*\*-+ End of picture text -+\*\*<br>",
+    re.DOTALL,
+)
+
+# pymupdf4llm headings: ##, ###, etc. Strip leading hashes for the section label.
+_HEADING_RE = re.compile(r"^(#{1,6})\s+(.*?)\s*$")
+
+# "==> picture [W x H] intentionally omitted <==" — drop entirely (no text).
+_OMITTED_PIC_RE = re.compile(r"\*\*==>\s*picture\s*\[[^\]]+\]\s*intentionally omitted\s*<==\*\*")
+
+# pymupdf4llm sometimes emits a leading `>` blockquote marker for author /
+# affiliation footers. Strip the marker but keep the text.
+_BLOCKQUOTE_RE = re.compile(r"^>\s+")
+
+# Minimum body-paragraph length to keep. Very short fragments (page numbers,
+# "1 of 14", standalone figure-label tokens) are noise.
+_MIN_BODY_CHARS = 40
+_MIN_FIGURE_CHARS = 20
+
+
+def extract_pdf_segments(pdf_path: str | os.PathLike[str]) -> list[PdfSegment]:
+    """Run pymupdf4llm and split the markdown output into paragraph segments.
+
+    Parameters
+    ----------
+    pdf_path:
+        Path to the PDF file.
+
+    Returns
+    -------
+    list[PdfSegment]
+        Paragraph segments tagged with a section label inferred from the
+        nearest preceding markdown heading (``BODY`` if none seen yet,
+        ``IN_FIGURE`` for picture-text blocks). Order follows pymupdf4llm's
+        output, which is paragraph-coherent but may shuffle across columns.
+    """
+    import pymupdf4llm  # type: ignore[import-untyped]
+
+    md = pymupdf4llm.to_markdown(str(pdf_path))
+    return _split_markdown(md)
+
+
+def _split_markdown(md: str) -> list[PdfSegment]:
+    """Split pymupdf4llm markdown into segments. Pure-function for testability."""
+    segments: list[PdfSegment] = []
+    cur_section = "BODY"
+
+    # Replace picture blocks with sentinels so we can emit them as their own
+    # IN_FIGURE segments and keep their position in the stream.
+    pic_payloads: list[str] = []
+
+    def _stash_pic(match: re.Match[str]) -> str:
+        idx = len(pic_payloads)
+        pic_payloads.append(match.group(1))
+        return f"\n\n@@PIC{idx}@@\n\n"
+
+    md = _PICTURE_BLOCK_RE.sub(_stash_pic, md)
+    md = _OMITTED_PIC_RE.sub("", md)
+
+    # Split on blank lines — pymupdf4llm uses blank-line-separated paragraphs.
+    for raw_para in re.split(r"\n\s*\n", md):
+        para = raw_para.strip()
+        if not para:
+            continue
+
+        # Picture-text payload?
+        pic_match = re.fullmatch(r"@@PIC(\d+)@@", para)
+        if pic_match:
+            payload = pic_payloads[int(pic_match.group(1))]
+            text = _clean_picture_text(payload)
+            if len(text) >= _MIN_FIGURE_CHARS:
+                segments.append(PdfSegment(section="IN_FIGURE", text=text))
+            continue
+
+        # Strip a leading blockquote marker if present.
+        para = _BLOCKQUOTE_RE.sub("", para)
+
+        # Heading?
+        head_match = _HEADING_RE.match(para)
+        if head_match:
+            cur_section = head_match.group(2).strip()[:80] or "BODY"
+            continue
+
+        # Body paragraph — collapse internal newlines and dedupe whitespace.
+        text = _clean_body_text(para)
+        if len(text) < _MIN_BODY_CHARS:
+            continue
+        segments.append(PdfSegment(section=cur_section, text=text))
+
+    return _dedupe_front_matter(segments)
+
+
+def _clean_body_text(text: str) -> str:
+    """Collapse markdown body text to a single whitespace-normalised line.
+
+    Fixes the residual ``word- word`` artifacts that pymupdf4llm leaves when
+    a hyphenated word straddles a column boundary it couldn't fully resolve
+    (e.g. ``regionspecific`` from ``region-specific`` is already merged, but
+    occasional ``oppositetrends`` survives).
+    """
+    # Drop superscript / subscript markup like `[+]`, `[12-15]` is kept though
+    # — it's a useful citation token for retrieval.
+    text = re.sub(r"\s+", " ", text).strip()
+    return text
+
+
+def _clean_picture_text(payload: str) -> str:
+    """Flatten a picture-text block to a space-separated token stream.
+
+    pymupdf4llm emits picture text with `<br>` separators between visual
+    rows; we don't try to reconstruct geometry — the stream is keyword fuel
+    for the embedder, not quotable prose.
+    """
+    cleaned = payload.replace("<br>", " ")
+    return re.sub(r"\s+", " ", cleaned).strip()
+
+
+def _dedupe_front_matter(segments: list[PdfSegment]) -> list[PdfSegment]:
+    """Drop a Research Article Summary paragraph if it is a strict prefix of
+    a longer paragraph elsewhere in the document.
+
+    Heuristic: a shorter paragraph that is the literal opening of a longer
+    one is the duplicated summary version (e.g. Science 1-page Research
+    Article Summary vs. the full Abstract on the article page). Conservative
+    — only drops on exact prefix match after whitespace collapse.
+    """
+    if len(segments) < 2:
+        return segments
+    drop: set[int] = set()
+    # Compare each pair where one text could be a prefix of the other.
+    by_head: dict[str, list[int]] = {}
+    for i, seg in enumerate(segments):
+        head = seg.text[:60].lower()
+        if len(head) < 40:
+            continue
+        by_head.setdefault(head, []).append(i)
+    for indices in by_head.values():
+        if len(indices) < 2:
+            continue
+        # Keep only the longest; drop strict-prefix duplicates.
+        longest = max(indices, key=lambda i: len(segments[i].text))
+        longest_text = segments[longest].text
+        for i in indices:
+            if i == longest:
+                continue
+            if longest_text.startswith(segments[i].text):
+                drop.add(i)
+    if not drop:
+        return segments
+    logger.info("Dropped %d duplicate front-matter paragraphs", len(drop))
+    return [s for i, s in enumerate(segments) if i not in drop]
+
+
+__all__ = ["PdfSegment", "extract_pdf_segments"]

--- a/src/atlas_chat/atlas_chat/services/local_snippet_index.py
+++ b/src/atlas_chat/atlas_chat/services/local_snippet_index.py
@@ -1,36 +1,62 @@
-"""Local snippet index for fresh-preprint atlases.
+"""Local snippet index for atlases and their subatlas papers.
 
-Builds a project-wide chunk store + sentence-citation graph + ASTA-shape
-snippet index from a single JATS XML file. The `search()` API returns dicts
-shaped like `citation_traverser._snippet_to_dict(AstaSnippet(...))` so the
-downstream `_summarize_snippets` / `validate_report` machinery consumes them
+A project's ``local_index/`` is a **corpus** of one or more papers:
+
+* Exactly one ``role: atlas`` paper (the DOI from ``cell_type_annotations.json``).
+* Zero or more ``role: subatlas`` papers (upstream studies whose cell types
+  were folded into the atlas — see ``subatlas_resolver``).
+
+Each paper lives in its own subdir under ``papers/<slug>/`` with its own
+manifest, chunks, embeddings, and ASTA-shape snippet index. A corpus-level
+``corpus.json`` lists papers, points at the atlas, and carries an
+``use_in_fanout`` flag (default ``false``) which gates whether
+``FanOut._citation_traverse`` queries the local index at all.
+
+On-disk layout::
+
+    local_index/
+      corpus.json
+      papers/
+        <paper_slug>/
+          manifest.json
+          source/{paper.jats.xml|paper.pdf|paper.md}
+          chunks/{chunks.jsonl, embeddings.npy, chunks.fulltext.txt}
+          citations/{sentences.jsonl, ref_resolution.json}   # JATS only
+          snippet_index/snippets.json
+
+Snippet shape returned by ``search`` is identical to
+``citation_traverser._snippet_to_dict(AstaSnippet)`` so the downstream
+``_summarize_snippets`` / ``validate_report`` machinery consumes them
 unchanged.
-
-The index is gated by `local_index/manifest.json` — if absent, the pipeline
-falls through to ASTA-only.
 """
 
 from __future__ import annotations
 
 import argparse
+import contextlib
 import hashlib
 import json
 import logging
 import re
 import sys
+import urllib.parse
 import urllib.request
 import xml.etree.ElementTree as ET
 from dataclasses import asdict, dataclass, field
 from functools import lru_cache
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 logger = logging.getLogger(__name__)
 
 EMBED_MODEL = "sentence-transformers/all-MiniLM-L6-v2"
 CHUNK_TARGET_CHARS = 2800
 CHUNK_OVERLAP_CHARS = 200
-MANIFEST_VERSION = 1
+MANIFEST_VERSION = 2  # bumped: per-paper manifest, corpus model
+CORPUS_VERSION = 1
+
+SourceType = Literal["jats", "pdf"]
+PaperRole = Literal["atlas", "subatlas"]
 
 
 # ------------------------------------------------------------------
@@ -58,26 +84,64 @@ class SentenceRow:
     doi_list: list[str] = field(default_factory=list)
 
 
+@dataclass
+class _BodySegment:
+    section: str
+    text: str  # paragraph text (whitespace collapsed)
+
+
+# ------------------------------------------------------------------
+# Paper slug + path helpers
+# ------------------------------------------------------------------
+
+
+_SLUG_SAFE_RE = re.compile(r"[^a-z0-9._-]")
+
+
+def paper_slug(doi: str) -> str:
+    """Stable, human-readable directory slug for a paper.
+
+    Lowercases, replaces ``/`` with ``_`` and any other unsafe char with ``-``,
+    truncates at 80 chars. For pathological DOIs (rare), falls back to a sha1
+    prefix.
+    """
+    s = doi.strip().lower()
+    s = s.replace("/", "_")
+    s = _SLUG_SAFE_RE.sub("-", s)
+    s = s.strip("-_.")
+    if not s or len(s) > 120:
+        return "doi-" + hashlib.sha1(doi.encode("utf-8")).hexdigest()[:16]
+    return s[:80]
+
+
+def _papers_dir(project_dir: Path) -> Path:
+    return project_dir / "local_index" / "papers"
+
+
+def _paper_dir(project_dir: Path, slug: str) -> Path:
+    return _papers_dir(project_dir) / slug
+
+
+def _corpus_json_path(project_dir: Path) -> Path:
+    return project_dir / "local_index" / "corpus.json"
+
+
 # ------------------------------------------------------------------
 # JATS normalisation (bioRxiv quirks)
 # ------------------------------------------------------------------
 
 
 def _normalize_biorxiv_jats(xml: str) -> str:
-    """Make bioRxiv JATS digestible by `_jats_parser.parse_jats_citations`.
+    """Make bioRxiv JATS digestible by ``_jats_parser.parse_jats_citations``.
 
     Two fixes:
-      1. Strip `hwp:*` namespaced attributes that get aliased to `id` after
-         namespace strip, overwriting the real `<ref id="cNN">` value.
-      2. Rename `<citation>` (Highwire convention) to `<element-citation>`
+      1. Strip ``hwp:*`` namespaced attributes that get aliased to ``id`` after
+         namespace strip, overwriting the real ``<ref id="cNN">`` value.
+      2. Rename ``<citation>`` (Highwire convention) to ``<element-citation>``
          (JATS standard) so the parser's ref-detail extractor matches.
     """
-    # Remove hwp:* attributes from any element. Match on attribute name to
-    # avoid pulling in unrelated namespaces.
     xml = re.sub(r'\s+hwp:[\w:-]+="[^"]*"', "", xml)
     xml = re.sub(r'\s+xmlns:hw="[^"]*"', "", xml)
-    # Rename <citation ...> → <element-citation ...> only when it carries
-    # publication-type (the JATS-ish citation, not other uses of <citation>).
     xml = re.sub(
         r"<citation(\s+[^>]*publication-type=)",
         r"<element-citation\1",
@@ -90,12 +154,6 @@ def _normalize_biorxiv_jats(xml: str) -> str:
 # ------------------------------------------------------------------
 # JATS → plain text + sections
 # ------------------------------------------------------------------
-
-
-@dataclass
-class _BodySegment:
-    section: str
-    text: str  # paragraph text (whitespace collapsed)
 
 
 def _strip_ns(root: ET.Element) -> None:
@@ -116,10 +174,7 @@ def _text_of(el: ET.Element, in_citation: bool = False) -> str:
     """Concatenate all descendant text, skipping ref-list and tables.
 
     Wraps citation markers in brackets so the rendered text shows e.g.
-    ``[12-15]`` rather than a bare ``12-15`` run (which would otherwise
-    appear glued to surrounding words and make blockquote validation
-    against `parse_jats_citations`'s sentence output — which already
-    bracket-wraps — impossible).
+    ``[12-15]`` rather than a bare ``12-15`` run.
     """
     parts: list[str] = []
     if el.text:
@@ -144,14 +199,12 @@ def extract_body_segments(xml: str) -> list[_BodySegment]:
 
     segments: list[_BodySegment] = []
 
-    # Abstract first
     for abs_el in root.iter("abstract"):
         for p in abs_el.iter("p"):
             txt = re.sub(r"\s+", " ", _text_of(p)).strip()
             if txt:
                 segments.append(_BodySegment("ABSTRACT", txt))
 
-    # Body sections (recursive)
     body = root.find(".//body")
     if body is None:
         return segments
@@ -173,13 +226,19 @@ def extract_body_segments(xml: str) -> list[_BodySegment]:
 
     for sec in body.findall("sec"):
         walk(sec, "BODY")
-    # Top-level <p> inside body (no sec wrapper)
     for p in body.findall("p"):
         txt = re.sub(r"\s+", " ", _text_of(p)).strip()
         if txt:
             segments.append(_BodySegment("BODY", txt))
 
     return segments
+
+
+def _extract_pdf_segments(pdf_path: Path) -> list[_BodySegment]:
+    """Adapter: convert ``_pdf_parser.PdfSegment`` to ``_BodySegment``."""
+    from atlas_chat.services._pdf_parser import extract_pdf_segments
+
+    return [_BodySegment(section=s.section, text=s.text) for s in extract_pdf_segments(pdf_path)]
 
 
 # ------------------------------------------------------------------
@@ -192,13 +251,7 @@ def chunk_segments(
     target_chars: int = CHUNK_TARGET_CHARS,
     overlap_chars: int = CHUNK_OVERLAP_CHARS,
 ) -> tuple[str, list[Chunk]]:
-    """Build paragraph-aware chunks. Returns (concatenated_fulltext, chunks).
-
-    Adjacent paragraphs from the same section are concatenated up to target
-    size. Section boundaries flush the current chunk. Overlap is added by
-    re-emitting the tail of the previous chunk if the next paragraph would
-    otherwise start a fresh chunk.
-    """
+    """Build paragraph-aware chunks. Returns ``(concatenated_fulltext, chunks)``."""
     fulltext_parts: list[str] = []
     chunks: list[Chunk] = []
     cursor = 0
@@ -226,7 +279,6 @@ def chunk_segments(
         fulltext_parts.append(para)
         cursor += len(para)
 
-        # New section → flush current
         if cur_section and seg.section != cur_section:
             flush()
         if not cur_text:
@@ -237,7 +289,6 @@ def chunk_segments(
             cur_text += para
         else:
             flush()
-            # Carry overlap from end of the previous chunk
             if chunks and overlap_chars > 0:
                 tail = chunks[-1].text[-overlap_chars:]
                 cur_text = tail + para
@@ -253,7 +304,7 @@ def chunk_segments(
 
 
 # ------------------------------------------------------------------
-# Sentence-level citation graph
+# Sentence-level citation graph (JATS only)
 # ------------------------------------------------------------------
 
 
@@ -261,26 +312,15 @@ def build_sentence_rows(
     xml: str,
     fulltext: str,
 ) -> tuple[list[SentenceRow], dict[str, Any]]:
-    """Run the vendored `_jats_parser.parse_jats_citations` and align each cited sentence
-    to a char offset in `fulltext`. Returns (rows, refs_dict).
-
-    `refs_dict` is the full {ref_id → ResolvedRef} mapping from the parser —
-    callers can read `.doi`, `.title`, `.year`, `.first_author` for downstream
-    resolution (DOI batch + title-match fallback).
-    """
+    """Run the vendored ``_jats_parser.parse_jats_citations`` and align each cited
+    sentence to a char offset in ``fulltext``. Returns ``(rows, refs_dict)``."""
     from atlas_chat.services._jats_parser import parse_jats_citations
 
     cited, refs = parse_jats_citations(xml)
-
     ref_id_to_doi = {rid: r.doi for rid, r in refs.items() if r.doi}
 
     rows: list[SentenceRow] = []
     for cs in cited:
-        # parse_jats_citations emits sentence text with bracketed citation
-        # markers like [12-15]. The body chunker now also bracket-wraps
-        # bibr xrefs, so the sentence text should match the fulltext
-        # directly. Fall back to a bracket-stripped form for any cases the
-        # two extractors render differently.
         anchor = cs.text[:80]
         pos = fulltext.find(anchor)
         if pos < 0:
@@ -310,9 +350,7 @@ def build_sentence_rows(
 
 
 def _resolve_dois_to_corpus_ids(dois: list[str]) -> dict[str, str]:
-    """Batch-resolve DOIs to Semantic Scholar CorpusIds.
-
-    Retries on 429 with exponential backoff (3 attempts, 2-4-8 second sleeps)."""
+    """Batch-resolve DOIs to Semantic Scholar CorpusIds. Retries on 429."""
     import time
 
     import httpx
@@ -364,12 +402,7 @@ def _resolve_title_to_corpus_id(
     first_author: str | None,
     client: Any,
 ) -> tuple[str | None, str | None]:
-    """Single-paper title-match via Semantic Scholar.
-
-    Returns (corpus_id, doi) — both None if no confident match. Uses S2's
-    /paper/search/match endpoint, which returns the single best title match
-    (or empty data if confidence is too low). Retries once on 429.
-    """
+    """Single-paper title-match via Semantic Scholar /paper/search/match."""
     import time
 
     api = "https://api.semanticscholar.org/graph/v1/paper/search/match"
@@ -381,18 +414,15 @@ def _resolve_title_to_corpus_id(
                 time.sleep(2 ** (attempt + 1))
                 continue
             if resp.status_code == 404:
-                return None, None  # no match
+                return None, None
             if resp.status_code != 200:
                 return None, None
             data = resp.json().get("data", [])
             if not data:
                 return None, None
             best = data[0]
-            # Year guard: discard matches more than 2 years off if year was supplied.
             if year and best.get("year") and abs(int(best["year"]) - year) > 2:
                 return None, None
-            # Author guard: require first-author surname appears in the matched
-            # author list when both are present.
             if first_author and best.get("authors"):
                 au_text = " ".join(a.get("name", "") for a in best["authors"]).lower()
                 if first_author.lower() not in au_text:
@@ -408,19 +438,11 @@ def _resolve_title_to_corpus_id(
 
 
 def _resolve_refs_to_corpus_ids(refs: dict[str, Any]) -> dict[str, dict[str, str | None]]:
-    """Resolve every ref to a CorpusId, using DOI batch first then title-match.
-
-    Returns a dict keyed by ref_id with shape:
-        {"corpus_id": str | None, "doi": str | None,
-         "method": "doi" | "title" | "none"}
-
-    `refs` is the dict returned by `parse_jats_citations` — values have `.doi`,
-    `.title`, `.year`, `.first_author` attributes (ResolvedRef dataclass)."""
+    """Resolve every ref to a CorpusId, using DOI batch first then title-match."""
     import httpx
 
     out: dict[str, dict[str, str | None]] = {}
 
-    # Phase 1: DOI batch resolution for refs that carry a DOI.
     dois_to_lookup = [r.doi for r in refs.values() if r.doi]
     doi_to_corpus = _resolve_dois_to_corpus_ids(dois_to_lookup)
     for ref_id, r in refs.items():
@@ -432,7 +454,6 @@ def _resolve_refs_to_corpus_ids(refs: dict[str, Any]) -> dict[str, dict[str, str
                 "method": "doi" if cid else "doi_unmatched",
             }
 
-    # Phase 2: title-match for refs without DOIs (or whose DOI didn't resolve).
     title_candidates = [
         (rid, r) for rid, r in refs.items() if r.title and not out.get(rid, {}).get("corpus_id")
     ]
@@ -472,7 +493,7 @@ def _resolve_refs_to_corpus_ids(refs: dict[str, Any]) -> dict[str, dict[str, str
 
 
 # ------------------------------------------------------------------
-# bioRxiv metadata
+# Paper metadata: bioRxiv (for JATS preprints) + Crossref (for PDFs)
 # ------------------------------------------------------------------
 
 
@@ -489,145 +510,91 @@ def _biorxiv_meta(doi: str) -> dict | None:
         return None
 
 
+def _crossref_meta(doi: str) -> dict | None:
+    """Fetch metadata from Crossref REST API. Public, no key required.
+
+    Returns a dict with keys ``title``, ``authors`` (semicolon-joined string),
+    ``year``, ``container_title``, or ``None`` on failure.
+    """
+    url = f"https://api.crossref.org/works/{urllib.parse.quote(doi, safe='')}"
+    try:
+        req = urllib.request.Request(url, headers={"User-Agent": "atlas-chat/0.1"})
+        with urllib.request.urlopen(req, timeout=20) as fh:
+            payload = json.load(fh)
+        msg = payload.get("message", {})
+        title = (msg.get("title") or [""])[0]
+        authors = msg.get("author") or []
+        au_parts = []
+        for a in authors:
+            given = a.get("given", "")
+            family = a.get("family", "")
+            if family:
+                au_parts.append(f"{given} {family}".strip())
+        date_parts = (msg.get("issued") or {}).get("date-parts") or [[None]]
+        year = date_parts[0][0] if date_parts and date_parts[0] else None
+        container = (msg.get("container-title") or [""])[0]
+        return {
+            "title": title,
+            "authors": "; ".join(au_parts),
+            "year": int(year) if year else None,
+            "container_title": container,
+        }
+    except Exception as exc:
+        logger.warning("Crossref metadata fetch failed for %s: %s", doi, exc)
+        return None
+
+
+def _build_paper_meta(doi: str, source_type: SourceType) -> dict[str, Any]:
+    """Best-effort paper metadata for the ASTA-shape ``paper`` field."""
+    if source_type == "jats":
+        meta = _biorxiv_meta(doi) or {}
+        year = None
+        if date := meta.get("date", ""):
+            m = re.match(r"(\d{4})", date)
+            if m:
+                year = int(m.group(1))
+        return {
+            "title": meta.get("title", ""),
+            "authors": meta.get("authors", ""),
+            "year": year,
+            "doi": doi,
+            "corpus_id": _local_corpus_id(doi),
+            "url": f"https://www.biorxiv.org/content/{doi}v{meta.get('version', 1)}",
+            "venue": "bioRxiv",
+        }
+    # PDF: Crossref
+    cm = _crossref_meta(doi) or {}
+    return {
+        "title": cm.get("title", ""),
+        "authors": cm.get("authors", ""),
+        "year": cm.get("year"),
+        "doi": doi,
+        "corpus_id": _local_corpus_id(doi),
+        "url": f"https://doi.org/{doi}",
+        "venue": cm.get("container_title", ""),
+    }
+
+
 # ------------------------------------------------------------------
 # Build orchestrator
 # ------------------------------------------------------------------
 
 
 def _local_corpus_id(doi: str) -> str:
-    """Stable atlas CorpusId for an unindexed preprint.
+    """Stable atlas CorpusId for an unindexed paper.
 
-    Format `CorpusId:local_<sha1[:10]>` — the `local_` token has no digits so
-    it sidesteps the legacy `CorpusId:\\d+` validation regex in
-    `report_checker.py::check_references` while preserving shape parity."""
+    Format ``CorpusId:local_<sha1[:10]>`` — the ``local_`` token has no digits so
+    it sidesteps the legacy ``CorpusId:\\d+`` validation regex in
+    ``report_checker.py::check_references`` while preserving shape parity."""
     h = hashlib.sha1(doi.encode("utf-8")).hexdigest()[:10]
     return f"CorpusId:local_{h}"
 
 
-def _manifest_hash(xml_bytes: bytes, parser_version: int = 1) -> str:
+def _manifest_hash(source_bytes: bytes, source_type: SourceType) -> str:
     h = hashlib.sha256()
-    h.update(xml_bytes)
-    h.update(f"|emb={EMBED_MODEL}|p={parser_version}|m={MANIFEST_VERSION}".encode())
+    h.update(source_bytes)
+    h.update(f"|emb={EMBED_MODEL}|st={source_type}|m={MANIFEST_VERSION}".encode())
     return h.hexdigest()
-
-
-def build_local_index(
-    project_dir: Path,
-    doi: str,
-    jats_path: Path | None = None,
-    force: bool = False,
-) -> dict[str, Any]:
-    """Build (or refresh) the local snippet index for a project.
-
-    If `jats_path` is None, `services.fetch_preprint.fetch_preprint` is called
-    to populate it. Otherwise the existing JATS file is used as-is.
-    Idempotent: a re-run with unchanged JATS short-circuits unless force=True.
-    Returns the manifest dict.
-    """
-    project_dir = Path(project_dir)
-    idx_dir = project_dir / "local_index"
-    source_dir = idx_dir / "source"
-    chunks_dir = idx_dir / "chunks"
-    citations_dir = idx_dir / "citations"
-    snippet_dir = idx_dir / "snippet_index"
-    for d in (idx_dir, source_dir, chunks_dir, citations_dir, snippet_dir):
-        d.mkdir(parents=True, exist_ok=True)
-
-    # 1. Resolve JATS path
-    if jats_path is None:
-        jats_path = source_dir / "paper.jats.xml"
-        if not jats_path.exists() or force:
-            from atlas_chat.services.fetch_preprint import fetch_preprint
-
-            fetched = fetch_preprint(doi, source_dir)
-            jats_path = fetched.jats_path
-    else:
-        # Copy / link into source dir for self-containment
-        target = source_dir / "paper.jats.xml"
-        if jats_path.resolve() != target.resolve():
-            target.write_bytes(jats_path.read_bytes())
-            jats_path = target
-
-    raw_xml_bytes = jats_path.read_bytes()
-    manifest_path = idx_dir / "manifest.json"
-    expected_hash = _manifest_hash(raw_xml_bytes)
-    if manifest_path.exists() and not force:
-        try:
-            existing = json.loads(manifest_path.read_text())
-            if existing.get("hash") == expected_hash:
-                logger.info("Local index already up to date (manifest hash match).")
-                return existing
-        except Exception:
-            pass
-
-    xml = raw_xml_bytes.decode("utf-8")
-    normalized = _normalize_biorxiv_jats(xml)
-
-    # 2. Body text + paragraph segments → chunks
-    segments = extract_body_segments(normalized)
-    fulltext, chunks = chunk_segments(segments)
-    (chunks_dir / "chunks.fulltext.txt").write_text(fulltext)
-    with (chunks_dir / "chunks.jsonl").open("w") as fh:
-        for c in chunks:
-            fh.write(json.dumps(asdict(c)) + "\n")
-
-    # 3. Embeddings
-    embeddings_path = chunks_dir / "embeddings.npy"
-    _embed_and_save([c.text for c in chunks], embeddings_path)
-
-    # 4. Sentence-level citation graph (and full refs dict)
-    sent_rows, refs_full = build_sentence_rows(normalized, fulltext)
-    with (citations_dir / "sentences.jsonl").open("w") as fh:
-        for r in sent_rows:
-            fh.write(json.dumps(asdict(r)) + "\n")
-
-    # 5. Resolve EVERY cited ref to a CorpusId — DOI batch first, then title-match
-    #    for refs without a DOI (or whose DOI didn't resolve).
-    ref_resolution = _resolve_refs_to_corpus_ids(refs_full)
-    (citations_dir / "ref_resolution.json").write_text(json.dumps(ref_resolution, indent=2))
-    ref_id_to_corpus = {
-        rid: entry["corpus_id"] for rid, entry in ref_resolution.items() if entry["corpus_id"]
-    }
-
-    # 6. Atlas-paper metadata (for ASTA-shape paper field)
-    meta = _biorxiv_meta(doi) or {}
-    paper_meta = {
-        "title": meta.get("title", ""),
-        "authors": meta.get("authors", ""),
-        "year": int(re.match(r"(\d{4})", meta.get("date", "") or "").group(1))
-        if re.match(r"(\d{4})", meta.get("date", "") or "")
-        else None,
-        "doi": doi,
-        "corpus_id": _local_corpus_id(doi),
-        "url": f"https://www.biorxiv.org/content/{doi}v{meta.get('version', 1)}",
-    }
-
-    # 7. Merge chunks ↔ sentences → ASTA-shape snippet index
-    snippets = _merge_snippets(chunks, sent_rows, ref_id_to_corpus, paper_meta)
-    (snippet_dir / "snippets.json").write_text(json.dumps(snippets, indent=2))
-
-    manifest = {
-        "version": MANIFEST_VERSION,
-        "doi": doi,
-        "hash": expected_hash,
-        "embedding_model": EMBED_MODEL,
-        "n_chunks": len(chunks),
-        "n_sentences": len(sent_rows),
-        "n_refs": len(refs_full),
-        "n_corpus_ids_resolved": len(ref_id_to_corpus),
-        "resolution_methods": _resolution_breakdown(ref_resolution),
-        "paper": paper_meta,
-    }
-    manifest_path.write_text(json.dumps(manifest, indent=2))
-    logger.info(
-        "Built local_index: %d chunks, %d cited sentences, %d/%d refs resolved (%s)",
-        len(chunks),
-        len(sent_rows),
-        len(ref_id_to_corpus),
-        len(refs_full),
-        manifest["resolution_methods"],
-    )
-    return manifest
 
 
 def _embed_and_save(texts: list[str], out_path: Path) -> None:
@@ -636,7 +603,6 @@ def _embed_and_save(texts: list[str], out_path: Path) -> None:
 
     model = SentenceTransformer(EMBED_MODEL)
     vecs = model.encode(texts, convert_to_numpy=True, show_progress_bar=False)
-    # Normalise for cosine similarity at search time
     norms = np.linalg.norm(vecs, axis=1, keepdims=True)
     norms[norms == 0] = 1.0
     vecs = vecs / norms
@@ -644,12 +610,154 @@ def _embed_and_save(texts: list[str], out_path: Path) -> None:
 
 
 def _resolution_breakdown(ref_resolution: dict[str, dict[str, str | None]]) -> dict[str, int]:
-    """Count refs by resolution method for the manifest."""
     counts: dict[str, int] = {}
     for entry in ref_resolution.values():
         m = entry.get("method") or "none"
         counts[m] = counts.get(m, 0) + 1
     return counts
+
+
+def build_paper_index(
+    project_dir: Path,
+    doi: str,
+    *,
+    jats_path: Path | None = None,
+    pdf_path: Path | None = None,
+    role: PaperRole = "atlas",
+    force: bool = False,
+) -> dict[str, Any]:
+    """Build (or refresh) the local index entry for one paper.
+
+    Exactly one of ``jats_path`` or ``pdf_path`` must be provided. The atlas
+    paper additionally supports auto-fetching JATS when neither is supplied
+    (back-compat path).
+
+    Returns the per-paper manifest dict and updates ``corpus.json``.
+    """
+    project_dir = Path(project_dir)
+    _migrate_legacy_layout_if_needed(project_dir)
+
+    slug = paper_slug(doi)
+    p_dir = _paper_dir(project_dir, slug)
+    source_dir = p_dir / "source"
+    chunks_dir = p_dir / "chunks"
+    citations_dir = p_dir / "citations"
+    snippet_dir = p_dir / "snippet_index"
+    for d in (p_dir, source_dir, chunks_dir, citations_dir, snippet_dir):
+        d.mkdir(parents=True, exist_ok=True)
+
+    # Resolve source path + type
+    if pdf_path is not None and jats_path is not None:
+        raise ValueError("Pass jats_path OR pdf_path, not both")
+    if pdf_path is not None:
+        source_type: SourceType = "pdf"
+        target = source_dir / "paper.pdf"
+        if pdf_path.resolve() != target.resolve():
+            target.write_bytes(pdf_path.read_bytes())
+        source_path = target
+    elif jats_path is not None:
+        source_type = "jats"
+        target = source_dir / "paper.jats.xml"
+        if jats_path.resolve() != target.resolve():
+            target.write_bytes(jats_path.read_bytes())
+        source_path = target
+    else:
+        # No source given — for atlas role we may auto-fetch JATS.
+        source_type = "jats"
+        source_path = source_dir / "paper.jats.xml"
+        if not source_path.exists() or force:
+            from atlas_chat.services.fetch_preprint import fetch_preprint
+
+            fetched = fetch_preprint(doi, source_dir)
+            source_path = fetched.jats_path
+
+    raw_bytes = source_path.read_bytes()
+    expected_hash = _manifest_hash(raw_bytes, source_type)
+    manifest_path = p_dir / "manifest.json"
+    if manifest_path.exists() and not force:
+        try:
+            existing = json.loads(manifest_path.read_text())
+            if existing.get("hash") == expected_hash:
+                logger.info("Paper %s already up to date.", slug)
+                _upsert_corpus_entry(project_dir, slug, existing)
+                return existing
+        except Exception:
+            pass
+
+    # Extract body segments
+    if source_type == "jats":
+        xml = raw_bytes.decode("utf-8")
+        normalized = _normalize_biorxiv_jats(xml)
+        segments = extract_body_segments(normalized)
+    else:
+        segments = _extract_pdf_segments(source_path)
+        normalized = None  # used only for citation graph below
+
+    if not segments:
+        raise RuntimeError(f"No body segments extracted from {source_path}")
+
+    fulltext, chunks = chunk_segments(segments)
+    (chunks_dir / "chunks.fulltext.txt").write_text(fulltext)
+    with (chunks_dir / "chunks.jsonl").open("w") as fh:
+        for c in chunks:
+            fh.write(json.dumps(asdict(c)) + "\n")
+
+    _embed_and_save([c.text for c in chunks], chunks_dir / "embeddings.npy")
+
+    # Citation graph: JATS only — PDFs have no xref markers.
+    sent_rows: list[SentenceRow] = []
+    ref_resolution: dict[str, dict[str, str | None]] = {}
+    ref_id_to_corpus: dict[str, str] = {}
+    citation_graph = False
+    if source_type == "jats" and normalized is not None:
+        try:
+            sent_rows, refs_full = build_sentence_rows(normalized, fulltext)
+            with (citations_dir / "sentences.jsonl").open("w") as fh:
+                for r in sent_rows:
+                    fh.write(json.dumps(asdict(r)) + "\n")
+            ref_resolution = _resolve_refs_to_corpus_ids(refs_full)
+            (citations_dir / "ref_resolution.json").write_text(json.dumps(ref_resolution, indent=2))
+            ref_id_to_corpus = {
+                rid: entry["corpus_id"]
+                for rid, entry in ref_resolution.items()
+                if entry["corpus_id"]
+            }
+            citation_graph = True
+        except Exception as exc:
+            logger.warning("Citation graph build failed for %s: %s", slug, exc)
+
+    paper_meta = _build_paper_meta(doi, source_type)
+    snippets = _merge_snippets(chunks, sent_rows, ref_id_to_corpus, paper_meta)
+    (snippet_dir / "snippets.json").write_text(json.dumps(snippets, indent=2))
+
+    manifest = {
+        "version": MANIFEST_VERSION,
+        "slug": slug,
+        "doi": doi,
+        "role": role,
+        "source_type": source_type,
+        "citation_graph": citation_graph,
+        "hash": expected_hash,
+        "embedding_model": EMBED_MODEL,
+        "n_chunks": len(chunks),
+        "n_sentences": len(sent_rows),
+        "n_refs": len(ref_resolution),
+        "n_corpus_ids_resolved": len(ref_id_to_corpus),
+        "resolution_methods": _resolution_breakdown(ref_resolution) if ref_resolution else {},
+        "paper": paper_meta,
+    }
+    manifest_path.write_text(json.dumps(manifest, indent=2))
+    logger.info(
+        "Built paper index [%s/%s]: %d chunks, %d sentences, citation_graph=%s",
+        slug,
+        source_type,
+        len(chunks),
+        len(sent_rows),
+        citation_graph,
+    )
+
+    _upsert_corpus_entry(project_dir, slug, manifest)
+    return manifest
 
 
 def _merge_snippets(
@@ -658,11 +766,7 @@ def _merge_snippets(
     ref_id_to_corpus: dict[str, str],
     paper_meta: dict,
 ) -> list[dict]:
-    """Emit one ASTA-shape snippet per chunk with refMentions baked in.
-
-    refMentions are emitted per `ref_id` (not per DOI), so refs resolved via
-    title-match (no DOI) still produce mentions."""
-    # Index sentences by char_start for fast lookup
+    """Emit one ASTA-shape snippet per chunk with refMentions baked in."""
     sent_rows_sorted = sorted(sent_rows, key=lambda r: r.char_start)
     snippets: list[dict] = []
     for c in chunks:
@@ -672,7 +776,6 @@ def _merge_snippets(
                 break
             if r.char_end <= c.char_start:
                 continue
-            # Only keep sentences fully inside the chunk (loss-tolerant)
             if r.char_start < c.char_start or r.char_end > c.char_end:
                 continue
             for ref_id in r.ref_ids:
@@ -708,73 +811,344 @@ def _merge_snippets(
 
 
 # ------------------------------------------------------------------
-# Retrieval API (Phase 3)
+# Corpus-level orchestration
+# ------------------------------------------------------------------
+
+
+def _empty_corpus(atlas_doi: str | None = None) -> dict[str, Any]:
+    return {
+        "version": CORPUS_VERSION,
+        "embedding_model": EMBED_MODEL,
+        "atlas_doi": atlas_doi,
+        "use_in_fanout": False,
+        "papers": [],
+    }
+
+
+def _load_corpus_json(project_dir: Path) -> dict[str, Any]:
+    path = _corpus_json_path(project_dir)
+    if path.exists():
+        try:
+            return json.loads(path.read_text())
+        except Exception:
+            logger.warning("corpus.json unreadable, treating as empty")
+    return _empty_corpus()
+
+
+def _save_corpus_json(project_dir: Path, corpus: dict[str, Any]) -> None:
+    path = _corpus_json_path(project_dir)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(corpus, indent=2))
+
+
+def _upsert_corpus_entry(project_dir: Path, slug: str, manifest: dict[str, Any]) -> None:
+    corpus = _load_corpus_json(project_dir)
+    entry = {
+        "slug": slug,
+        "doi": manifest["doi"],
+        "role": manifest["role"],
+        "source_type": manifest["source_type"],
+        "title": manifest.get("paper", {}).get("title", ""),
+        "n_chunks": manifest.get("n_chunks", 0),
+    }
+    by_slug = {p["slug"]: p for p in corpus.get("papers", [])}
+    by_slug[slug] = entry
+    corpus["papers"] = sorted(by_slug.values(), key=lambda p: (p["role"] != "atlas", p["slug"]))
+    if manifest["role"] == "atlas":
+        corpus["atlas_doi"] = manifest["doi"]
+    _save_corpus_json(project_dir, corpus)
+
+
+def _migrate_legacy_layout_if_needed(project_dir: Path) -> None:
+    """If ``local_index/manifest.json`` exists at the old single-paper location,
+    move all files under ``papers/<atlas_slug>/`` and synthesize ``corpus.json``.
+
+    Idempotent. Safe to call on every read or build.
+    """
+    idx = project_dir / "local_index"
+    legacy_manifest = idx / "manifest.json"
+    if not legacy_manifest.exists():
+        return
+    if _corpus_json_path(project_dir).exists():
+        # Already migrated — but legacy manifest still hanging around. Drop it.
+        with contextlib.suppress(OSError):
+            legacy_manifest.unlink()
+        return
+
+    try:
+        legacy = json.loads(legacy_manifest.read_text())
+    except Exception:
+        logger.warning("Legacy manifest.json unreadable; skipping migration")
+        return
+
+    doi = legacy.get("doi")
+    if not doi:
+        logger.warning("Legacy manifest has no DOI; skipping migration")
+        return
+    slug = paper_slug(doi)
+    target_dir = _paper_dir(project_dir, slug)
+    if target_dir.exists() and (target_dir / "manifest.json").exists():
+        logger.info("Migration: target %s already populated, just dropping legacy file", slug)
+        legacy_manifest.unlink()
+        return
+    target_dir.mkdir(parents=True, exist_ok=True)
+
+    # Move subdirs that the old layout placed directly under local_index/.
+    for subdir in ("source", "chunks", "citations", "snippet_index"):
+        old = idx / subdir
+        new = target_dir / subdir
+        if old.exists() and not new.exists():
+            old.rename(new)
+
+    # Synthesize a v2 manifest from the v1 fields we can fill.
+    new_manifest = {
+        "version": MANIFEST_VERSION,
+        "slug": slug,
+        "doi": doi,
+        "role": "atlas",
+        "source_type": "jats",
+        "citation_graph": True,
+        "hash": legacy.get("hash", ""),
+        "embedding_model": legacy.get("embedding_model", EMBED_MODEL),
+        "n_chunks": legacy.get("n_chunks", 0),
+        "n_sentences": legacy.get("n_sentences", 0),
+        "n_refs": legacy.get("n_refs", 0),
+        "n_corpus_ids_resolved": legacy.get("n_corpus_ids_resolved", 0),
+        "resolution_methods": legacy.get("resolution_methods", {}),
+        "paper": legacy.get("paper", {}),
+    }
+    (target_dir / "manifest.json").write_text(json.dumps(new_manifest, indent=2))
+
+    corpus = _empty_corpus(atlas_doi=doi)
+    corpus["papers"] = [
+        {
+            "slug": slug,
+            "doi": doi,
+            "role": "atlas",
+            "source_type": "jats",
+            "title": new_manifest["paper"].get("title", ""),
+            "n_chunks": new_manifest["n_chunks"],
+        }
+    ]
+    _save_corpus_json(project_dir, corpus)
+
+    with contextlib.suppress(OSError):
+        legacy_manifest.unlink()
+    logger.info("Migrated legacy local_index layout → papers/%s/", slug)
+
+
+# ------------------------------------------------------------------
+# Public build entry points
+# ------------------------------------------------------------------
+
+
+def build_local_index(
+    project_dir: Path,
+    doi: str,
+    jats_path: Path | None = None,
+    force: bool = False,
+) -> dict[str, Any]:
+    """Back-compat entry point: build the atlas paper for this project.
+
+    Equivalent to ``build_paper_index(..., role='atlas')`` with JATS auto-fetch
+    when ``jats_path`` is ``None``.
+    """
+    return build_paper_index(
+        project_dir,
+        doi,
+        jats_path=jats_path,
+        role="atlas",
+        force=force,
+    )
+
+
+def add_paper(
+    project_dir: Path,
+    doi: str,
+    *,
+    pdf_path: Path | None = None,
+    jats_path: Path | None = None,
+    role: PaperRole = "subatlas",
+    force: bool = False,
+) -> dict[str, Any]:
+    """Add a subatlas reference paper to the corpus."""
+    return build_paper_index(
+        project_dir,
+        doi,
+        pdf_path=pdf_path,
+        jats_path=jats_path,
+        role=role,
+        force=force,
+    )
+
+
+def remove_paper(project_dir: Path, doi: str) -> bool:
+    """Remove a paper from the corpus. Returns True if it was present."""
+    import shutil
+
+    _migrate_legacy_layout_if_needed(project_dir)
+    slug = paper_slug(doi)
+    p_dir = _paper_dir(project_dir, slug)
+    existed = p_dir.exists()
+    if existed:
+        shutil.rmtree(p_dir)
+    corpus = _load_corpus_json(project_dir)
+    before = len(corpus["papers"])
+    corpus["papers"] = [p for p in corpus["papers"] if p["slug"] != slug]
+    if before != len(corpus["papers"]):
+        _save_corpus_json(project_dir, corpus)
+    _load_index.cache_clear()
+    return existed
+
+
+def list_papers(project_dir: Path) -> list[dict[str, Any]]:
+    """Return the corpus.json papers list (empty if no corpus)."""
+    _migrate_legacy_layout_if_needed(project_dir)
+    return _load_corpus_json(project_dir).get("papers", [])
+
+
+# ------------------------------------------------------------------
+# Retrieval API
 # ------------------------------------------------------------------
 
 
 @lru_cache(maxsize=8)
 def _load_index(project_dir_str: str) -> dict[str, Any]:
-    project_dir = Path(project_dir_str)
-    idx_dir = project_dir / "local_index"
-    manifest = json.loads((idx_dir / "manifest.json").read_text())
-    chunks: list[dict] = []
-    with (idx_dir / "chunks" / "chunks.jsonl").open() as fh:
-        for line in fh:
-            chunks.append(json.loads(line))
-    snippets = json.loads((idx_dir / "snippet_index" / "snippets.json").read_text())
-    snippet_by_chunk = {s["chunk_id"]: s for s in snippets}
+    """Load corpus + all per-paper indices into memory.
 
+    Returns a dict with concatenated embeddings keyed to a global row index,
+    plus a parallel list mapping each row → (slug, paper_meta, chunk dict,
+    snippet dict). Single ``np.load`` per paper; cheap to rebuild after add/remove.
+    """
     import numpy as np
 
-    embeddings = np.load(idx_dir / "chunks" / "embeddings.npy")
+    project_dir = Path(project_dir_str)
+    _migrate_legacy_layout_if_needed(project_dir)
+    corpus = _load_corpus_json(project_dir)
+    papers = corpus.get("papers", [])
+
+    embeddings_parts: list[Any] = []
+    row_index: list[dict[str, Any]] = []
+
+    for entry in papers:
+        slug = entry["slug"]
+        p_dir = _paper_dir(project_dir, slug)
+        manifest_path = p_dir / "manifest.json"
+        emb_path = p_dir / "chunks" / "embeddings.npy"
+        chunks_path = p_dir / "chunks" / "chunks.jsonl"
+        snippets_path = p_dir / "snippet_index" / "snippets.json"
+        if not (manifest_path.exists() and emb_path.exists() and chunks_path.exists()):
+            logger.warning("Paper %s incomplete on disk; skipping", slug)
+            continue
+        manifest = json.loads(manifest_path.read_text())
+        paper_meta = manifest.get("paper", {})
+        role = manifest.get("role", entry.get("role", "subatlas"))
+
+        chunks = []
+        with chunks_path.open() as fh:
+            for line in fh:
+                chunks.append(json.loads(line))
+
+        snippets_by_chunk: dict[int, dict[str, Any]] = {}
+        if snippets_path.exists():
+            snip_list = json.loads(snippets_path.read_text())
+            snippets_by_chunk = {s["chunk_id"]: s for s in snip_list}
+
+        vecs = np.load(emb_path)
+        embeddings_parts.append(vecs)
+        for ch in chunks:
+            row_index.append(
+                {
+                    "slug": slug,
+                    "role": role,
+                    "paper_meta": paper_meta,
+                    "chunk": ch,
+                    "snippet_entry": snippets_by_chunk.get(ch["chunk_id"], {}),
+                }
+            )
+
+    embeddings = np.vstack(embeddings_parts) if embeddings_parts else np.zeros((0, 0))
+
     return {
-        "manifest": manifest,
-        "chunks": chunks,
-        "snippets_by_chunk": snippet_by_chunk,
+        "corpus": corpus,
+        "row_index": row_index,
         "embeddings": embeddings,
     }
 
 
-def search(project_dir: Path, query: str, k: int = 20) -> list[dict[str, Any]]:
-    """Local snippet search returning ASTA-shape dicts compatible with
-    `_summarize_snippets` and `_snippet_to_dict(AstaSnippet)`.
+def search(
+    project_dir: Path,
+    query: str,
+    k: int = 20,
+    *,
+    papers: list[str] | None = None,
+    roles: list[PaperRole] | None = None,
+) -> list[dict[str, Any]]:
+    """Search the corpus. Returns ASTA-shape snippet dicts.
+
+    Optional filters:
+      * ``papers``: DOIs to restrict the search to.
+      * ``roles``: paper roles to restrict the search to (e.g. ``["subatlas"]``).
     """
     import numpy as np
     from sentence_transformers import SentenceTransformer
 
     state = _load_index(str(Path(project_dir).resolve()))
     embeddings = state["embeddings"]
-    manifest = state["manifest"]
+    row_index: list[dict[str, Any]] = state["row_index"]
+    if embeddings.size == 0 or not row_index:
+        return []
+
+    paper_slug_filter: set[str] | None = None
+    if papers:
+        paper_slug_filter = {paper_slug(d) for d in papers}
+    role_filter: set[str] | None = set(roles) if roles else None
 
     model = SentenceTransformer(EMBED_MODEL)
     q_vec = model.encode([query], convert_to_numpy=True)[0]
     q_vec = q_vec / max(np.linalg.norm(q_vec), 1e-9)
     scores = embeddings @ q_vec
-    top_idx = np.argsort(-scores)[:k].tolist()
 
-    paper_meta = manifest["paper"]
+    # Eligible rows
+    if paper_slug_filter is not None or role_filter is not None:
+        eligible = [
+            i
+            for i, row in enumerate(row_index)
+            if (paper_slug_filter is None or row["slug"] in paper_slug_filter)
+            and (role_filter is None or row["role"] in role_filter)
+        ]
+        if not eligible:
+            return []
+        eligible_scores = [(i, scores[i]) for i in eligible]
+        eligible_scores.sort(key=lambda x: -x[1])
+        top = eligible_scores[:k]
+    else:
+        top_idx = np.argsort(-scores)[:k].tolist()
+        top = [(i, scores[i]) for i in top_idx]
+
     out: list[dict[str, Any]] = []
-    for i in top_idx:
-        chunk = state["chunks"][i]
-        snippet_entry = state["snippets_by_chunk"].get(chunk["chunk_id"], {})
+    for i, score in top:
+        row = row_index[i]
+        paper_meta = row["paper_meta"]
+        chunk = row["chunk"]
         ref_mentions = (
-            snippet_entry.get("snippet", {}).get("annotations", {}).get("refMentions", [])
+            row["snippet_entry"].get("snippet", {}).get("annotations", {}).get("refMentions", [])
         )
         out.append(
             {
-                # Fields required by _snippet_to_dict + snippet_summarizer prompt:
                 "snippet": chunk["text"],
-                "paper_id": paper_meta["corpus_id"],
-                "corpus_id": paper_meta["corpus_id"],
-                "title": paper_meta["title"],
-                "authors": paper_meta["authors"],
-                "year": paper_meta["year"],
-                "url": paper_meta["url"],
-                "score": float(scores[i]),
-                # Extras for downstream / debugging:
+                "paper_id": paper_meta.get("corpus_id", ""),
+                "corpus_id": paper_meta.get("corpus_id", ""),
+                "title": paper_meta.get("title", ""),
+                "authors": paper_meta.get("authors", ""),
+                "year": paper_meta.get("year"),
+                "url": paper_meta.get("url", ""),
+                "score": float(score),
                 "doi": paper_meta.get("doi", ""),
                 "section": chunk["section"],
                 "chunk_id": chunk["chunk_id"],
+                "paper_slug": row["slug"],
+                "paper_role": row["role"],
                 "annotations": {"refMentions": ref_mentions},
                 "source_method": "local_snippet",
             }
@@ -783,7 +1157,43 @@ def search(project_dir: Path, query: str, k: int = 20) -> list[dict[str, Any]]:
 
 
 def has_local_index(project_dir: Path) -> bool:
-    return (Path(project_dir) / "local_index" / "manifest.json").exists()
+    """True iff the project has any paper in its corpus (post-migration)."""
+    project_dir = Path(project_dir)
+    _migrate_legacy_layout_if_needed(project_dir)
+    if not _corpus_json_path(project_dir).exists():
+        return False
+    return bool(_load_corpus_json(project_dir).get("papers"))
+
+
+def use_in_fanout(project_dir: Path) -> bool:
+    """Whether the local index should be queried during ``FanOut._citation_traverse``.
+
+    Defaults to ``False`` per the multi-paper design: subatlas papers are
+    surfaced as a corpus and only consulted when the user opts in via the
+    ``use_in_fanout`` flag in ``corpus.json``.
+    """
+    project_dir = Path(project_dir)
+    _migrate_legacy_layout_if_needed(project_dir)
+    if not _corpus_json_path(project_dir).exists():
+        return False
+    return bool(_load_corpus_json(project_dir).get("use_in_fanout", False))
+
+
+def needs_pdf_subatlas(project_dir: Path) -> list[dict[str, Any]]:
+    """Return any subatlas entries in cell_type_annotations.json with status ``needs_pdf``.
+
+    Used by ``FanOut._citation_traverse`` to emit a non-blocking warning row.
+    Empty list if the project has no subatlas list or no needs_pdf entries.
+    """
+    cfg_path = Path(project_dir) / "cell_type_annotations.json"
+    if not cfg_path.exists():
+        return []
+    try:
+        data = json.loads(cfg_path.read_text())
+    except Exception:
+        return []
+    refs = (data.get("source") or {}).get("subatlas_papers") or []
+    return [r for r in refs if r.get("status") == "needs_pdf"]
 
 
 # ------------------------------------------------------------------
@@ -795,16 +1205,39 @@ def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__.split("\n", maxsplit=1)[0])
     sub = parser.add_subparsers(dest="cmd", required=True)
 
-    p_build = sub.add_parser("build", help="Build / refresh the local index")
+    p_build = sub.add_parser("build", help="Build / refresh the atlas paper index")
     p_build.add_argument("--project", required=True, type=Path)
     p_build.add_argument("--doi", required=True)
-    p_build.add_argument("--jats", type=Path, default=None, help="Use existing JATS XML")
+    p_build.add_argument("--jats", type=Path, default=None)
     p_build.add_argument("--force", action="store_true")
 
-    p_search = sub.add_parser("search", help="Query the local index")
+    p_add = sub.add_parser("add", help="Add a paper to the corpus")
+    p_add.add_argument("--project", required=True, type=Path)
+    p_add.add_argument("--doi", required=True)
+    src = p_add.add_mutually_exclusive_group()
+    src.add_argument("--pdf", type=Path, default=None)
+    src.add_argument("--jats", type=Path, default=None)
+    p_add.add_argument("--role", default="subatlas", choices=("atlas", "subatlas"))
+    p_add.add_argument("--force", action="store_true")
+
+    p_rm = sub.add_parser("remove", help="Remove a paper from the corpus")
+    p_rm.add_argument("--project", required=True, type=Path)
+    p_rm.add_argument("--doi", required=True)
+
+    p_list = sub.add_parser("list", help="List papers in the corpus")
+    p_list.add_argument("--project", required=True, type=Path)
+
+    p_search = sub.add_parser("search", help="Query the corpus")
     p_search.add_argument("--project", required=True, type=Path)
     p_search.add_argument("--query", required=True)
     p_search.add_argument("-k", type=int, default=10)
+    p_search.add_argument("--paper", action="append", default=None, help="Filter by DOI")
+    p_search.add_argument(
+        "--role",
+        action="append",
+        default=None,
+        choices=("atlas", "subatlas"),
+    )
 
     args = parser.parse_args(argv)
     logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
@@ -813,8 +1246,32 @@ def main(argv: list[str] | None = None) -> int:
         manifest = build_local_index(args.project, args.doi, args.jats, args.force)
         print(json.dumps(manifest, indent=2))
         return 0
+    if args.cmd == "add":
+        manifest = add_paper(
+            args.project,
+            args.doi,
+            pdf_path=args.pdf,
+            jats_path=args.jats,
+            role=args.role,
+            force=args.force,
+        )
+        print(json.dumps(manifest, indent=2))
+        return 0
+    if args.cmd == "remove":
+        present = remove_paper(args.project, args.doi)
+        print(json.dumps({"removed": present}, indent=2))
+        return 0
+    if args.cmd == "list":
+        print(json.dumps(list_papers(args.project), indent=2))
+        return 0
     if args.cmd == "search":
-        results = search(args.project, args.query, k=args.k)
+        results = search(
+            args.project,
+            args.query,
+            k=args.k,
+            papers=args.paper,
+            roles=args.role,
+        )
         print(json.dumps(results, indent=2))
         return 0
     return 2

--- a/src/atlas_chat/atlas_chat/services/subatlas_resolver.py
+++ b/src/atlas_chat/atlas_chat/services/subatlas_resolver.py
@@ -1,0 +1,419 @@
+"""Subatlas paper resolver — atlas-init phase.
+
+Two passes, both keyed off ``cell_type_annotations.json``:
+
+1. ``discover``: seed ``source.subatlas_papers`` from ``label_provenance.json``.
+   Reads contributing-study labels (e.g. ``Sridhar_et_al_2020_CellPress``),
+   queries Semantic Scholar for best-match candidates, and writes draft entries
+   with ``status: candidate`` and a ``proposed_doi``. The user edits the file
+   to confirm/correct each DOI before re-running.
+
+2. ``ingest``: for each confirmed entry in ``source.subatlas_papers`` (with a
+   non-empty ``doi``), runs the resolution waterfall:
+
+   * ASTA probe — if S2 already indexes the paper with retrievable snippets,
+     mark ``status: asta`` (no local index built; fan-out reaches it directly).
+   * JATS fetch via ``fetch_preprint`` (EuropePMC → bioRxiv) — on success,
+     build the per-paper local index and mark ``status: local`` (source_type
+     ``jats``).
+   * Else — mark ``status: needs_pdf`` and add an entry to
+     ``subatlas_todo.md``. The user downloads the PDF and runs
+     ``setup_local_index.py add --pdf ...``.
+
+The atlas paper itself is also processed (role ``atlas``); it always builds a
+local index since its full text is the report's primary evidence base.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# Study labels that don't refer to a single published paper. These are
+# atlas-internal partitions (e.g. unpublished aggregated data) and are skipped
+# during discovery.
+_NON_PAPER_LABELS = {
+    "whole_embryo",
+    "unpublished",
+    "atlas_internal",
+    "this_study",
+}
+
+
+@dataclass
+class StudyLabel:
+    """Parsed contributing-study label."""
+
+    raw: str
+    first_author: str | None
+    year: int | None
+    venue: str | None
+    total_cells: int = 0
+
+
+# ------------------------------------------------------------------
+# Label parsing + provenance reading
+# ------------------------------------------------------------------
+
+
+_LABEL_RE = re.compile(
+    r"^(?P<author>[A-Z][A-Za-z'-]+)_et_al_(?P<year>\d{4})_(?P<venue>[A-Za-z0-9._-]+)$"
+)
+# Looser fallback: just author + year somewhere.
+_FALLBACK_AUTHOR_YEAR = re.compile(r"(?P<author>[A-Z][A-Za-z'-]+).*?(?P<year>\d{4})")
+
+
+def parse_label(label: str) -> StudyLabel:
+    m = _LABEL_RE.match(label)
+    if m:
+        return StudyLabel(
+            raw=label,
+            first_author=m.group("author"),
+            year=int(m.group("year")),
+            venue=m.group("venue").replace("_", " "),
+        )
+    m = _FALLBACK_AUTHOR_YEAR.search(label)
+    if m:
+        return StudyLabel(
+            raw=label,
+            first_author=m.group("author"),
+            year=int(m.group("year")),
+            venue=None,
+        )
+    return StudyLabel(raw=label, first_author=None, year=None, venue=None)
+
+
+def read_provenance_labels(project_dir: Path) -> list[StudyLabel]:
+    """Aggregate contributing-study labels across all cell types.
+
+    Returns one ``StudyLabel`` per distinct raw label, with ``total_cells``
+    summed across cell types. Skips known non-paper labels.
+    """
+    prov_path = project_dir / "label_provenance.json"
+    if not prov_path.exists():
+        return []
+    data = json.loads(prov_path.read_text())
+    totals: dict[str, int] = {}
+    for entry in data.values():
+        for study, n_cells, _share in entry.get("studies", []):
+            if study in _NON_PAPER_LABELS:
+                continue
+            totals[study] = totals.get(study, 0) + int(n_cells)
+    out: list[StudyLabel] = []
+    for raw, total in sorted(totals.items(), key=lambda x: -x[1]):
+        sl = parse_label(raw)
+        sl.total_cells = total
+        out.append(sl)
+    return out
+
+
+# ------------------------------------------------------------------
+# Semantic Scholar discovery
+# ------------------------------------------------------------------
+
+
+def _s2_search_candidates(label: StudyLabel, max_results: int = 3) -> list[dict[str, Any]]:
+    """Query Semantic Scholar /paper/search for plausible matches for a label.
+
+    Filters by year (±1) when available. Returns up to ``max_results``
+    candidates as dicts with ``doi``, ``title``, ``year``, ``corpus_id``.
+    """
+    import httpx
+
+    if not label.first_author:
+        return []
+    query_parts = [label.first_author]
+    if label.venue:
+        query_parts.append(label.venue)
+    query = " ".join(query_parts)
+    params: dict[str, str | int] = {
+        "query": query,
+        "limit": max(max_results, 5),
+        "fields": "externalIds,title,year,authors,venue",
+    }
+    if label.year:
+        params["year"] = f"{label.year - 1}-{label.year + 1}"
+    try:
+        with httpx.Client(timeout=30) as client:
+            resp = client.get(
+                "https://api.semanticscholar.org/graph/v1/paper/search",
+                params=params,
+            )
+            if resp.status_code != 200:
+                logger.warning("S2 search returned %d for %s", resp.status_code, label.raw)
+                return []
+            data = resp.json().get("data", []) or []
+    except Exception as exc:
+        logger.warning("S2 search failed for %s: %s", label.raw, exc)
+        return []
+
+    out: list[dict[str, Any]] = []
+    for p in data:
+        if not p:
+            continue
+        ext = p.get("externalIds") or {}
+        # Require first-author match to filter out coincidental hits.
+        if label.first_author:
+            au_text = " ".join((a.get("name") or "") for a in (p.get("authors") or [])).lower()
+            if label.first_author.lower() not in au_text:
+                continue
+        out.append(
+            {
+                "doi": ext.get("DOI", ""),
+                "title": p.get("title", ""),
+                "year": p.get("year"),
+                "corpus_id": str(ext.get("CorpusId", "")) if ext.get("CorpusId") else "",
+                "venue": p.get("venue", ""),
+            }
+        )
+        if len(out) >= max_results:
+            break
+    return out
+
+
+def discover(project_dir: Path) -> dict[str, Any]:
+    """Pass 1: propose ``subatlas_papers`` entries.
+
+    Reads ``label_provenance.json``, queries S2 for each contributing study,
+    and writes draft entries into ``cell_type_annotations.json``.
+
+    Returns a summary dict. Does NOT build any indices.
+    """
+    cfg_path = project_dir / "cell_type_annotations.json"
+    if not cfg_path.exists():
+        raise FileNotFoundError(f"No cell_type_annotations.json at {project_dir}")
+    cfg = json.loads(cfg_path.read_text())
+    source = cfg.setdefault("source", {})
+
+    labels = read_provenance_labels(project_dir)
+    if not labels:
+        logger.warning("No contributing-study labels in label_provenance.json")
+        source.setdefault("subatlas_papers", [])
+        cfg_path.write_text(json.dumps(cfg, indent=2))
+        return {"n_labels": 0, "candidates": 0}
+
+    existing = {e.get("label"): e for e in source.get("subatlas_papers", []) if e.get("label")}
+    drafts: list[dict[str, Any]] = []
+    n_with_proposal = 0
+    for label in labels:
+        if label.raw in existing and existing[label.raw].get("doi"):
+            drafts.append(existing[label.raw])
+            continue
+        candidates = _s2_search_candidates(label)
+        entry: dict[str, Any] = {
+            "label": label.raw,
+            "first_author": label.first_author,
+            "year": label.year,
+            "venue": label.venue,
+            "total_cells": label.total_cells,
+            "doi": "",
+            "status": "candidate",
+            "proposed": candidates,
+        }
+        if candidates:
+            entry["proposed_doi"] = candidates[0]["doi"]
+            n_with_proposal += 1
+        drafts.append(entry)
+
+    source["subatlas_papers"] = drafts
+    cfg_path.write_text(json.dumps(cfg, indent=2))
+
+    logger.info(
+        "discover: %d labels, %d with S2 proposals (drafts written to cell_type_annotations.json)",
+        len(labels),
+        n_with_proposal,
+    )
+    return {
+        "n_labels": len(labels),
+        "candidates": n_with_proposal,
+        "note": (
+            "Review cell_type_annotations.json: copy proposed_doi → doi for each entry you "
+            "accept (or replace with the correct DOI), then run `ingest`."
+        ),
+    }
+
+
+# ------------------------------------------------------------------
+# Ingest waterfall
+# ------------------------------------------------------------------
+
+
+def _probe_asta(doi: str, title: str | None) -> bool:
+    """Return True iff S2 indexes this paper. Best-effort, non-fatal."""
+    import httpx
+
+    try:
+        with httpx.Client(timeout=30) as client:
+            resp = client.get(
+                f"https://api.semanticscholar.org/graph/v1/paper/DOI:{doi}",
+                params={"fields": "externalIds,isOpenAccess,openAccessPdf"},
+            )
+            if resp.status_code != 200:
+                return False
+            data = resp.json() or {}
+            return bool(data.get("externalIds", {}).get("CorpusId"))
+    except Exception as exc:
+        logger.debug("ASTA probe failed for %s: %s", doi, exc)
+        return False
+
+
+def _try_jats_fetch(doi: str, dest_dir: Path) -> Path | None:
+    """Try ``fetch_preprint``; return the JATS path on success, ``None`` on failure."""
+    from atlas_chat.services.fetch_preprint import PreprintFetchError, fetch_preprint
+
+    try:
+        result = fetch_preprint(doi, dest_dir)
+        return result.jats_path
+    except PreprintFetchError as exc:
+        logger.info("JATS fetch failed for %s: %s", doi, exc)
+        return None
+    except Exception as exc:
+        logger.warning("JATS fetch errored for %s: %s", doi, exc)
+        return None
+
+
+def _write_todo(project_dir: Path, todos: list[dict[str, Any]]) -> None:
+    if not todos:
+        # Remove a stale todo file if all are now resolved.
+        path = project_dir / "subatlas_todo.md"
+        if path.exists():
+            path.unlink()
+        return
+    lines = [
+        "# Subatlas papers needing PDF",
+        "",
+        "These contributing studies could not be fetched via ASTA or JATS. Download",
+        "the PDF from the publisher and run:",
+        "",
+        "```bash",
+        "uv run python scripts/setup_local_index.py add \\",
+        f"  --project {project_dir.name} --doi <DOI> --pdf <path/to/paper.pdf> --role subatlas",
+        "```",
+        "",
+    ]
+    for t in todos:
+        lines.append(f"## {t.get('label', t['doi'])}")
+        lines.append("")
+        lines.append(f"- DOI: `{t['doi']}`")
+        if t.get("title"):
+            lines.append(f"- Title: {t['title']}")
+        if t.get("year"):
+            lines.append(f"- Year: {t['year']}")
+        if t.get("venue"):
+            lines.append(f"- Venue: {t['venue']}")
+        lines.append(f"- Cells contributed to atlas: {t.get('total_cells', 'unknown')}")
+        lines.append(f"- DOI link: https://doi.org/{t['doi']}")
+        lines.append("")
+    (project_dir / "subatlas_todo.md").write_text("\n".join(lines))
+
+
+def ingest(project_dir: Path, *, force: bool = False) -> dict[str, Any]:
+    """Pass 2: run the asta/jats/pdf waterfall for confirmed subatlas entries.
+
+    Also (re)builds the atlas paper's local index.
+    """
+    from atlas_chat.services.local_snippet_index import build_paper_index
+
+    cfg_path = project_dir / "cell_type_annotations.json"
+    if not cfg_path.exists():
+        raise FileNotFoundError(f"No cell_type_annotations.json at {project_dir}")
+    cfg = json.loads(cfg_path.read_text())
+    source = cfg["source"]
+    atlas_doi = source.get("doi")
+    if not atlas_doi:
+        raise ValueError("cell_type_annotations.json source.doi is required")
+
+    summary: dict[str, Any] = {
+        "atlas_doi": atlas_doi,
+        "atlas_status": "skipped",
+        "subatlas": {"asta": [], "local": [], "needs_pdf": [], "unresolved": []},
+    }
+
+    # Atlas paper — always try to build (it's the primary evidence base).
+    try:
+        build_paper_index(project_dir, atlas_doi, role="atlas", force=force)
+        summary["atlas_status"] = "local"
+    except Exception as exc:
+        logger.error("Atlas paper build failed: %s", exc)
+        summary["atlas_status"] = f"error: {exc}"
+
+    refs = source.get("subatlas_papers", []) or []
+    todos: list[dict[str, Any]] = []
+
+    for entry in refs:
+        doi = entry.get("doi") or ""
+        if not doi:
+            entry["status"] = "unresolved"
+            summary["subatlas"]["unresolved"].append(entry.get("label") or "<no-label>")
+            continue
+
+        # 1. ASTA probe
+        title = entry.get("title") or (entry.get("proposed") or [{}])[0].get("title", "")
+        if _probe_asta(doi, title):
+            entry["status"] = "asta"
+            summary["subatlas"]["asta"].append(doi)
+            continue
+
+        # 2. JATS fetch + local build
+        slug_dir = project_dir / "local_index" / "papers" / _slug(doi) / "source"
+        slug_dir.mkdir(parents=True, exist_ok=True)
+        jats_path = _try_jats_fetch(doi, slug_dir)
+        if jats_path and jats_path.exists():
+            try:
+                build_paper_index(
+                    project_dir, doi, jats_path=jats_path, role="subatlas", force=force
+                )
+                entry["status"] = "local"
+                entry["source_type"] = "jats"
+                summary["subatlas"]["local"].append(doi)
+                continue
+            except Exception as exc:
+                logger.warning("Local build failed for %s: %s", doi, exc)
+
+        # 3. needs_pdf
+        entry["status"] = "needs_pdf"
+        summary["subatlas"]["needs_pdf"].append(doi)
+        todos.append(
+            {
+                "label": entry.get("label"),
+                "doi": doi,
+                "title": title,
+                "year": entry.get("year"),
+                "venue": entry.get("venue"),
+                "total_cells": entry.get("total_cells"),
+            }
+        )
+
+    cfg_path.write_text(json.dumps(cfg, indent=2))
+    _write_todo(project_dir, todos)
+    logger.info(
+        "ingest: atlas=%s | subatlas asta=%d local=%d needs_pdf=%d unresolved=%d",
+        summary["atlas_status"],
+        len(summary["subatlas"]["asta"]),
+        len(summary["subatlas"]["local"]),
+        len(summary["subatlas"]["needs_pdf"]),
+        len(summary["subatlas"]["unresolved"]),
+    )
+    return summary
+
+
+def _slug(doi: str) -> str:
+    # Re-export from local_snippet_index to avoid a circular import at module load.
+    from atlas_chat.services.local_snippet_index import paper_slug
+
+    return paper_slug(doi)
+
+
+__all__ = [
+    "StudyLabel",
+    "discover",
+    "ingest",
+    "parse_label",
+    "read_provenance_labels",
+]

--- a/src/atlas_chat/pyproject.toml
+++ b/src/atlas_chat/pyproject.toml
@@ -27,6 +27,7 @@ local-index = [
     "sentence-transformers>=5.0",
     "numpy>=1.26",
     "curl-cffi>=0.7.0",
+    "pymupdf4llm>=0.0.17",
 ]
 
 [project.scripts]

--- a/tests/unit/test_local_snippet_index_corpus.py
+++ b/tests/unit/test_local_snippet_index_corpus.py
@@ -1,0 +1,377 @@
+"""Unit tests for the corpus model (multi-paper layout + migration).
+
+Avoids the embedding step by direct manifest manipulation. Tests are
+network-free.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from atlas_chat.services import local_snippet_index as lsi
+
+# ---------------------------------------------------------------------------
+# paper_slug
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_paper_slug_basic() -> None:
+    assert lsi.paper_slug("10.1126/science.adf1226") == "10.1126_science.adf1226"
+    assert lsi.paper_slug("10.1101/2024.03.20.123456") == "10.1101_2024.03.20.123456"
+
+
+@pytest.mark.unit
+def test_paper_slug_handles_uppercase_and_unsafe() -> None:
+    s = lsi.paper_slug("10.1234/Foo Bar(Baz)")
+    assert "/" not in s
+    assert " " not in s
+    assert "(" not in s
+    assert s.startswith("10.1234_foo")
+
+
+@pytest.mark.unit
+def test_paper_slug_pathological_falls_back_to_hash() -> None:
+    long_doi = "10.1234/" + "x" * 200
+    s = lsi.paper_slug(long_doi)
+    assert s.startswith("doi-") or len(s) <= 80
+
+
+# ---------------------------------------------------------------------------
+# Corpus init + upsert
+# ---------------------------------------------------------------------------
+
+
+def _write_paper_files(
+    project_dir: Path,
+    slug: str,
+    doi: str,
+    role: str,
+    chunks: list[dict],
+    embeddings: np.ndarray,
+) -> dict:
+    p_dir = project_dir / "local_index" / "papers" / slug
+    (p_dir / "chunks").mkdir(parents=True, exist_ok=True)
+    (p_dir / "snippet_index").mkdir(parents=True, exist_ok=True)
+    with (p_dir / "chunks" / "chunks.jsonl").open("w") as fh:
+        for c in chunks:
+            fh.write(json.dumps(c) + "\n")
+    np.save(p_dir / "chunks" / "embeddings.npy", embeddings)
+    paper_meta = {
+        "corpus_id": lsi._local_corpus_id(doi),
+        "title": f"Paper {slug}",
+        "authors": "Test, A.",
+        "year": 2024,
+        "doi": doi,
+        "url": f"https://doi.org/{doi}",
+    }
+    snippets = [
+        {
+            "chunk_id": c["chunk_id"],
+            "paper": paper_meta,
+            "snippet": {
+                "text": c["text"],
+                "section": c["section"],
+                "annotations": {"refMentions": []},
+            },
+        }
+        for c in chunks
+    ]
+    (p_dir / "snippet_index" / "snippets.json").write_text(json.dumps(snippets))
+    manifest = {
+        "version": lsi.MANIFEST_VERSION,
+        "slug": slug,
+        "doi": doi,
+        "role": role,
+        "source_type": "jats",
+        "citation_graph": False,
+        "hash": "deadbeef",
+        "embedding_model": lsi.EMBED_MODEL,
+        "n_chunks": len(chunks),
+        "n_sentences": 0,
+        "n_refs": 0,
+        "n_corpus_ids_resolved": 0,
+        "resolution_methods": {},
+        "paper": paper_meta,
+    }
+    (p_dir / "manifest.json").write_text(json.dumps(manifest))
+    return manifest
+
+
+@pytest.mark.unit
+def test_upsert_creates_corpus_json(tmp_path: Path) -> None:
+    manifest = _write_paper_files(
+        tmp_path,
+        "10.1234_atlas",
+        "10.1234/atlas",
+        "atlas",
+        [{"chunk_id": 0, "section": "BODY", "char_start": 0, "char_end": 10, "text": "hello"}],
+        np.array([[1.0, 0.0]]),
+    )
+    lsi._upsert_corpus_entry(tmp_path, "10.1234_atlas", manifest)
+    corpus = json.loads((tmp_path / "local_index" / "corpus.json").read_text())
+    assert corpus["atlas_doi"] == "10.1234/atlas"
+    assert corpus["use_in_fanout"] is False
+    assert len(corpus["papers"]) == 1
+    assert corpus["papers"][0]["role"] == "atlas"
+
+
+@pytest.mark.unit
+def test_upsert_keeps_atlas_first(tmp_path: Path) -> None:
+    atlas_m = _write_paper_files(
+        tmp_path,
+        "atlas-slug",
+        "10.1234/atlas",
+        "atlas",
+        [{"chunk_id": 0, "section": "BODY", "char_start": 0, "char_end": 5, "text": "atlas"}],
+        np.array([[1.0, 0.0]]),
+    )
+    sub_m = _write_paper_files(
+        tmp_path,
+        "sub-slug",
+        "10.1234/sub",
+        "subatlas",
+        [{"chunk_id": 0, "section": "BODY", "char_start": 0, "char_end": 6, "text": "subref"}],
+        np.array([[0.0, 1.0]]),
+    )
+    lsi._upsert_corpus_entry(tmp_path, "atlas-slug", atlas_m)
+    lsi._upsert_corpus_entry(tmp_path, "sub-slug", sub_m)
+    corpus = json.loads((tmp_path / "local_index" / "corpus.json").read_text())
+    assert [p["role"] for p in corpus["papers"]] == ["atlas", "subatlas"]
+
+
+# ---------------------------------------------------------------------------
+# Migration from legacy single-paper layout
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_migration_moves_legacy_files(tmp_path: Path) -> None:
+    idx = tmp_path / "local_index"
+    (idx / "source").mkdir(parents=True)
+    (idx / "chunks").mkdir()
+    (idx / "snippet_index").mkdir()
+    (idx / "source" / "paper.jats.xml").write_text("<article/>")
+    (idx / "chunks" / "chunks.jsonl").write_text(
+        '{"chunk_id":0,"section":"BODY","char_start":0,"char_end":3,"text":"abc"}\n'
+    )
+    np.save(idx / "chunks" / "embeddings.npy", np.array([[1.0, 0.0]]))
+    (idx / "snippet_index" / "snippets.json").write_text("[]")
+    legacy_manifest = {
+        "version": 1,
+        "doi": "10.1234/legacy",
+        "hash": "abc",
+        "embedding_model": lsi.EMBED_MODEL,
+        "n_chunks": 1,
+        "n_sentences": 0,
+        "n_refs": 0,
+        "n_corpus_ids_resolved": 0,
+        "resolution_methods": {},
+        "paper": {"title": "Legacy", "doi": "10.1234/legacy", "corpus_id": "CorpusId:local_x"},
+    }
+    (idx / "manifest.json").write_text(json.dumps(legacy_manifest))
+
+    lsi._migrate_legacy_layout_if_needed(tmp_path)
+
+    slug = lsi.paper_slug("10.1234/legacy")
+    p_dir = idx / "papers" / slug
+    assert p_dir.is_dir()
+    assert (p_dir / "manifest.json").is_file()
+    assert (p_dir / "source" / "paper.jats.xml").is_file()
+    assert not (idx / "manifest.json").exists()
+    assert (idx / "corpus.json").is_file()
+    corpus = json.loads((idx / "corpus.json").read_text())
+    assert corpus["atlas_doi"] == "10.1234/legacy"
+    new_manifest = json.loads((p_dir / "manifest.json").read_text())
+    assert new_manifest["role"] == "atlas"
+    assert new_manifest["version"] == lsi.MANIFEST_VERSION
+
+
+@pytest.mark.unit
+def test_migration_idempotent(tmp_path: Path) -> None:
+    # Run on a tree that already has corpus.json — should be a no-op.
+    idx = tmp_path / "local_index"
+    idx.mkdir(parents=True)
+    (idx / "corpus.json").write_text(json.dumps(lsi._empty_corpus()))
+    lsi._migrate_legacy_layout_if_needed(tmp_path)
+    assert (idx / "corpus.json").exists()
+
+
+# ---------------------------------------------------------------------------
+# use_in_fanout flag
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_use_in_fanout_default_false(tmp_path: Path) -> None:
+    idx = tmp_path / "local_index"
+    idx.mkdir()
+    (idx / "corpus.json").write_text(json.dumps(lsi._empty_corpus("10.1/x")))
+    assert lsi.use_in_fanout(tmp_path) is False
+
+
+@pytest.mark.unit
+def test_use_in_fanout_true_when_flag_set(tmp_path: Path) -> None:
+    idx = tmp_path / "local_index"
+    idx.mkdir()
+    corpus = lsi._empty_corpus("10.1/x")
+    corpus["use_in_fanout"] = True
+    (idx / "corpus.json").write_text(json.dumps(corpus))
+    assert lsi.use_in_fanout(tmp_path) is True
+
+
+@pytest.mark.unit
+def test_needs_pdf_subatlas_lists_only_needs_pdf(tmp_path: Path) -> None:
+    cfg = {
+        "source": {
+            "doi": "10.1/atlas",
+            "subatlas_papers": [
+                {"label": "Foo_et_al_2023_X", "doi": "10.1/a", "status": "asta"},
+                {"label": "Bar_et_al_2024_Y", "doi": "10.1/b", "status": "needs_pdf"},
+                {"label": "Baz_et_al_2024_Z", "doi": "", "status": "unresolved"},
+            ],
+        }
+    }
+    (tmp_path / "cell_type_annotations.json").write_text(json.dumps(cfg))
+    missing = lsi.needs_pdf_subatlas(tmp_path)
+    assert len(missing) == 1
+    assert missing[0]["doi"] == "10.1/b"
+
+
+# ---------------------------------------------------------------------------
+# remove_paper + list_papers
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_remove_paper_drops_dir_and_corpus_entry(tmp_path: Path) -> None:
+    doi = "10.1234/rm"
+    slug = lsi.paper_slug(doi)
+    m = _write_paper_files(
+        tmp_path,
+        slug,
+        doi,
+        "subatlas",
+        [{"chunk_id": 0, "section": "BODY", "char_start": 0, "char_end": 3, "text": "abc"}],
+        np.array([[1.0, 0.0]]),
+    )
+    lsi._upsert_corpus_entry(tmp_path, slug, m)
+    assert (tmp_path / "local_index" / "papers" / slug).exists()
+    removed = lsi.remove_paper(tmp_path, doi)
+    assert removed is True
+    assert not (tmp_path / "local_index" / "papers" / slug).exists()
+    papers = lsi.list_papers(tmp_path)
+    assert not any(p["doi"] == doi for p in papers)
+
+
+# ---------------------------------------------------------------------------
+# Multi-paper retrieval (filter by role, by paper)
+# ---------------------------------------------------------------------------
+
+
+class _FakeEmbedder:
+    """Encodes a 'query' to a 2-d vector via simple keyword counting against
+    a known token vocabulary. Used to make the search test deterministic
+    without loading sentence-transformers."""
+
+    def encode(self, texts, convert_to_numpy=True, show_progress_bar=False):  # noqa: D401
+        out = []
+        for t in texts:
+            t_low = t.lower()
+            out.append([float("atlas" in t_low), float("sub" in t_low)])
+        return np.array(out)
+
+
+@pytest.fixture
+def multi_paper_project(tmp_path, monkeypatch):
+    # Atlas paper: text matches the 'atlas' axis.
+    _write_paper_files(
+        tmp_path,
+        "atlas-slug",
+        "10.1234/atlas",
+        "atlas",
+        [
+            {
+                "chunk_id": 0,
+                "section": "BODY",
+                "char_start": 0,
+                "char_end": 20,
+                "text": "Atlas-specific content about cells",
+            },
+        ],
+        np.array([[1.0, 0.0]]),
+    )
+    _write_paper_files(
+        tmp_path,
+        "sub-slug",
+        "10.1234/sub",
+        "subatlas",
+        [
+            {
+                "chunk_id": 0,
+                "section": "BODY",
+                "char_start": 0,
+                "char_end": 20,
+                "text": "Sub-atlas reference content",
+            },
+        ],
+        np.array([[0.0, 1.0]]),
+    )
+    # Manually write corpus.json (skips upsert reorder logic).
+    corpus = lsi._empty_corpus("10.1234/atlas")
+    corpus["papers"] = [
+        {
+            "slug": "atlas-slug",
+            "doi": "10.1234/atlas",
+            "role": "atlas",
+            "source_type": "jats",
+            "title": "Atlas",
+            "n_chunks": 1,
+        },
+        {
+            "slug": "sub-slug",
+            "doi": "10.1234/sub",
+            "role": "subatlas",
+            "source_type": "pdf",
+            "title": "Sub",
+            "n_chunks": 1,
+        },
+    ]
+    (tmp_path / "local_index" / "corpus.json").write_text(json.dumps(corpus))
+
+    # Stub SentenceTransformer to avoid downloading a model.
+    monkeypatch.setattr(
+        "sentence_transformers.SentenceTransformer",
+        lambda *args, **kwargs: _FakeEmbedder(),
+    )
+    lsi._load_index.cache_clear()
+    return tmp_path
+
+
+@pytest.mark.unit
+def test_search_returns_both_papers_default(multi_paper_project: Path) -> None:
+    hits = lsi.search(multi_paper_project, "atlas sub", k=5)
+    slugs = {h["paper_slug"] for h in hits}
+    assert slugs == {"atlas-slug", "sub-slug"}
+
+
+@pytest.mark.unit
+def test_search_filter_by_role(multi_paper_project: Path) -> None:
+    hits = lsi.search(multi_paper_project, "atlas sub", k=5, roles=["subatlas"])
+    assert all(h["paper_role"] == "subatlas" for h in hits)
+    assert all(h["paper_slug"] == "sub-slug" for h in hits)
+
+
+@pytest.mark.unit
+def test_search_filter_by_doi(multi_paper_project: Path) -> None:
+    hits = lsi.search(multi_paper_project, "atlas sub", k=5, papers=["10.1234/atlas"])
+    assert all(h["doi"] == "10.1234/atlas" for h in hits)
+
+
+@pytest.mark.unit
+def test_search_empty_corpus_returns_empty(tmp_path: Path) -> None:
+    assert lsi.search(tmp_path, "anything", k=5) == []

--- a/tests/unit/test_pdf_parser.py
+++ b/tests/unit/test_pdf_parser.py
@@ -1,0 +1,106 @@
+"""Unit tests for the PDF → segment converter.
+
+Operates on synthetic pymupdf4llm-flavoured markdown so no real PDF parse is
+needed. The pymupdf4llm dependency is only exercised by the integration
+test that ingests the actual Braun PDF.
+"""
+
+from __future__ import annotations
+
+from textwrap import dedent
+
+import pytest
+from atlas_chat.services._pdf_parser import _split_markdown
+
+
+@pytest.mark.unit
+def test_headings_become_section_labels() -> None:
+    md = dedent(
+        """\
+        ## Introduction
+
+        This is the first body paragraph. It is long enough to survive the
+        minimum-character filter applied to body paragraphs.
+
+        ## Results
+
+        We discovered that ILC3 cells localise to the dermis in fetal skin
+        and express CCL1 plus PTGDS as defining markers.
+        """
+    )
+    segs = _split_markdown(md)
+    assert any(s.section == "Introduction" for s in segs)
+    assert any(s.section == "Results" for s in segs)
+    assert all(len(s.text) >= 40 for s in segs if s.section != "IN_FIGURE")
+
+
+@pytest.mark.unit
+def test_picture_blocks_become_in_figure_segments() -> None:
+    md = (
+        "**----- Start of picture text -----**<br>\n"
+        "Panel A<br>Panel B<br>NEUROD6 SOX2 PAX5 EMX1<br>\n"
+        "**----- End of picture text -----**<br>\n"
+        "\n"
+        "This is the figure caption describing what panels A and B show.\n"
+    )
+    segs = _split_markdown(md)
+    fig_segs = [s for s in segs if s.section == "IN_FIGURE"]
+    body_segs = [s for s in segs if s.section != "IN_FIGURE"]
+    assert len(fig_segs) == 1
+    # <br> markers collapsed to spaces.
+    assert "<br>" not in fig_segs[0].text
+    assert "NEUROD6" in fig_segs[0].text
+    # The caption is body.
+    assert body_segs and "figure caption" in body_segs[0].text.lower()
+
+
+@pytest.mark.unit
+def test_omitted_picture_blocks_dropped() -> None:
+    md = (
+        "**==> picture [400 x 200] intentionally omitted <==**\n"
+        "\n"
+        "Real paragraph that should survive the noise filter for body text.\n"
+    )
+    segs = _split_markdown(md)
+    assert all("intentionally omitted" not in s.text for s in segs)
+    assert any("Real paragraph" in s.text for s in segs)
+
+
+@pytest.mark.unit
+def test_short_fragments_dropped() -> None:
+    md = (
+        "## Title\n\nA\n\n"
+        "Real body paragraph that comfortably exceeds the threshold for inclusion.\n"
+    )
+    segs = _split_markdown(md)
+    # The 'A' fragment should be filtered out as too short.
+    body = [s for s in segs if s.section != "IN_FIGURE"]
+    assert all(s.text != "A" for s in body)
+    assert any("Real body paragraph" in s.text for s in body)
+
+
+@pytest.mark.unit
+def test_blockquote_marker_stripped() -> None:
+    md = (
+        "> Author affiliations: Karolinska Institute, 171 65 Stockholm, "
+        "Sweden, plus collaborators at KTH and Cambridge.\n"
+    )
+    segs = _split_markdown(md)
+    assert segs
+    assert not segs[0].text.startswith(">")
+    assert "Karolinska" in segs[0].text
+
+
+@pytest.mark.unit
+def test_front_matter_duplicates_dropped() -> None:
+    body1 = "This is the abstract paragraph that begins with a distinctive enough opener to dedupe."
+    md = (
+        f"{body1}\n\n"
+        f"{body1} It also continues with additional detail in the longer copy of the paragraph.\n"
+    )
+    segs = _split_markdown(md)
+    # Only one of the two near-duplicate paragraphs should survive
+    surviving = [s for s in segs if s.text.startswith("This is the abstract paragraph")]
+    assert len(surviving) == 1
+    # The longer one wins.
+    assert "additional detail" in surviving[0].text

--- a/uv.lock
+++ b/uv.lock
@@ -251,6 +251,7 @@ dev = [
 local-index = [
     { name = "curl-cffi" },
     { name = "numpy" },
+    { name = "pymupdf4llm" },
     { name = "sentence-transformers" },
 ]
 
@@ -264,6 +265,7 @@ requires-dist = [
     { name = "numpy", marker = "extra == 'local-index'", specifier = ">=1.26" },
     { name = "pydantic", specifier = ">=2.7.0" },
     { name = "pydantic-ai", specifier = ">=1.16.0" },
+    { name = "pymupdf4llm", marker = "extra == 'local-index'", specifier = ">=0.0.17" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.1.0" },
     { name = "python-dotenv", specifier = ">=1.0.1" },
@@ -1165,6 +1167,14 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/94/b8/00651a0f559862f3bb7d6f7477b192afe3f583cc5e26403b44e59a55ab34/filelock-3.25.2.tar.gz", hash = "sha256:b64ece2b38f4ca29dd3e810287aa8c48182bbecd1ae6e9ae126c9b35f1382694", size = 40480, upload-time = "2026-03-11T20:45:38.487Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a4/a5/842ae8f0c08b61d6484b52f99a03510a3a72d23141942d216ebe81fefbce/filelock-3.25.2-py3-none-any.whl", hash = "sha256:ca8afb0da15f229774c9ad1b455ed96e85a81373065fb10446672f64444ddf70", size = 26759, upload-time = "2026-03-11T20:45:37.437Z" },
+]
+
+[[package]]
+name = "flatbuffers"
+version = "25.12.19"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e8/2d/d2a548598be01649e2d46231d151a6c56d10b964d94043a335ae56ea2d92/flatbuffers-25.12.19-py2.py3-none-any.whl", hash = "sha256:7634f50c427838bb021c2d66a3d1168e9d199b0607e6329399f04846d42e20b4", size = 26661, upload-time = "2025-12-19T23:16:13.622Z" },
 ]
 
 [[package]]
@@ -2621,6 +2631,33 @@ wheels = [
 ]
 
 [[package]]
+name = "onnxruntime"
+version = "1.26.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "flatbuffers" },
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "protobuf" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cf/a2/c801242685e0ce48a4ca51dfafbb588765e0446397e123be53ba5598f3f5/onnxruntime-1.26.0-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:ccce19c5f771b8268902f77d9fed9e88f9499465d6780808faa6611a789d33f0", size = 18016563, upload-time = "2026-05-08T19:07:28.081Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/64/0492c0b1db04e29b2630c87cfa36f9d6872b1ca8614b90c5cad58fac7d76/onnxruntime-1.26.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bdbed8cf3b672b66acb032f33a253bc27f42bce6ece48ae3fab4fa483a5e96e0", size = 16052634, upload-time = "2026-05-08T19:07:16.885Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/26/4d09ddc755a84fc8d5e192991626b0e0680e8f6c5d58f4f1d05c42bc48cf/onnxruntime-1.26.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c07af6fc6d5557835f2b6ee7a96d8b3235d0c57a8e230efdedaee106a8a3cbc6", size = 18185632, upload-time = "2026-05-08T19:07:38.756Z" },
+    { url = "https://files.pythonhosted.org/packages/77/89/3e52249aa08fa301e217ecba07b5246a8338fa2b401e109326e3fc5be0f9/onnxruntime-1.26.0-cp313-cp313-win_amd64.whl", hash = "sha256:61bec80655efa460591c2bc655392d57d2650ce85533a6b9b3b7a790d7ea7916", size = 13026751, upload-time = "2026-05-08T19:08:06.2Z" },
+    { url = "https://files.pythonhosted.org/packages/06/b3/c1c8782b14af6797c303de132d6eef26a9fb80dfacd3750ce57911d11c6b/onnxruntime-1.26.0-cp313-cp313-win_arm64.whl", hash = "sha256:a6677545ff451e3539a02746d2f207d8c5baa4a0a818886bb9d6a6eb9511ee89", size = 12796807, upload-time = "2026-05-08T19:07:54.879Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/f5/47b0676408abec652c14b84d7173e389837832d850c24f87184277313e8d/onnxruntime-1.26.0-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5e016edc15d3c19f36807e1c6b10be5b27807688c32720f91b5ae480a95215d0", size = 16057265, upload-time = "2026-05-08T19:07:19.603Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/45/33ab6deeef010ca844c877dd618cebc079590bbe52d2a3678e7223b1b908/onnxruntime-1.26.0-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f5fc48a91a046a6a5c9b147f83fb41d65d24d24923373b222cdd248f0f4f4aac", size = 18197590, upload-time = "2026-05-08T19:07:41.422Z" },
+    { url = "https://files.pythonhosted.org/packages/40/89/17546c1c20f6bfc3ae41c22152378a26edfea918af3129e2139dcd7c99f3/onnxruntime-1.26.0-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:33a791f31432a3af1a96db5e54818b37aba5e5eefc2e6af5794c10a9118a9993", size = 18019724, upload-time = "2026-05-08T19:07:30.723Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/24/89457a35f6af29538a76647f2c18c3a28277e6c19234c847e7b4b7c19860/onnxruntime-1.26.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e90c00732c4553618103149d93f688e8c3063017938f8983e21a71d9f3b6d22e", size = 16054821, upload-time = "2026-05-08T19:07:22.348Z" },
+    { url = "https://files.pythonhosted.org/packages/12/f9/15b2e1815cf570d238e0135529f80d2dce64e8e8818a1489cae83823c5c6/onnxruntime-1.26.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:01498e80ba8988428d08c2d51b1338f89e3de2a93e6ffe555f79c68f26a5c06b", size = 18185815, upload-time = "2026-05-08T19:07:44.179Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/65/2e11055faf015e4b07f45b513fa49b391baf2e19d92d77d73ebee13c1004/onnxruntime-1.26.0-cp314-cp314-win_amd64.whl", hash = "sha256:7ead61450d8405167c87dd3a31d8da1d576b490a57dab1aa8b82a7da6825f5aa", size = 13349887, upload-time = "2026-05-08T19:08:08.671Z" },
+    { url = "https://files.pythonhosted.org/packages/19/e4/0f9d1a5718b1781c610c1e354765a3820597081754277a6a9a2b50705702/onnxruntime-1.26.0-cp314-cp314-win_arm64.whl", hash = "sha256:31d71a53490e46910877d0902b5ad99c69a5955e5c7ea6c82863519410e1ba7c", size = 13140121, upload-time = "2026-05-08T19:07:57.804Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/42/3b8e635f067d06d9f45bede470b8d539d101a4166c272213158dfd08b6ce/onnxruntime-1.26.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d7b6d258fb78fdfcf049795bcfaa74dcb90ae7baa277afd21e6fd28b83f2c496", size = 16057240, upload-time = "2026-05-08T19:07:25.163Z" },
+    { url = "https://files.pythonhosted.org/packages/93/99/f2be40a31b908d96b861ae0ce98582fa376c18a7f816b9d5eb4cd6aa0a4c/onnxruntime-1.26.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4eefd386a45202aefb7a5132b94f32df9d506c9edcc7faf2fc60d65183f4b183", size = 18197382, upload-time = "2026-05-08T19:07:46.965Z" },
+]
+
+[[package]]
 name = "openai"
 version = "2.28.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3383,6 +3420,55 @@ wheels = [
 ]
 
 [[package]]
+name = "pymupdf"
+version = "1.27.2.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/32/708bedc9dde7b328d45abbc076091769d44f2f24ad151ad92d56a6ec142b/pymupdf-1.27.2.3.tar.gz", hash = "sha256:7a92faa25129e8bbec5e50eeb9214f187665428c31b05c4ef6e36c58c0b1c6d2", size = 85759618, upload-time = "2026-04-24T14:13:14.42Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/09/ddbdfa7ee91fbabd6f63d7d744884cbdfe3e7ff9b8604749fb38bddf5c5d/pymupdf-1.27.2.3-cp310-abi3-macosx_10_9_x86_64.whl", hash = "sha256:fc1bc3cae6e9e150b0dbb0a9221bdfd411d65f0db2fe359eaa22467d7cc2a05f", size = 24002636, upload-time = "2026-04-24T14:09:17.459Z" },
+    { url = "https://files.pythonhosted.org/packages/01/89/3f8edd6c4f50ca370e2a2f2a3011face36f3760728ffe76dffec91c0fca0/pymupdf-1.27.2.3-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:660d93cb6da5bbddf11d3982ae27745dd3a9902d9f24cdb69adab83962294b5a", size = 23278238, upload-time = "2026-04-24T14:09:32.882Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/26/b7e5a70eb83bd189f8b5df87ec442746b992f2f632662839b288170d357d/pymupdf-1.27.2.3-cp310-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:1dd460a3ae4597a755f00a3bd9771f5ebf1531dc111f6a36bf05dd00a6b84425", size = 24333923, upload-time = "2026-04-24T14:09:47.341Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/a0/aa1ee2240f29481a04a827c313333b4ecd8a14d6ac3e15d3f41a30574781/pymupdf-1.27.2.3-cp310-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:857842b4888827bd6155a1131341b2822a7ebe9a8c15a975fd7d490d7a64a30c", size = 24963198, upload-time = "2026-04-24T14:10:07.408Z" },
+    { url = "https://files.pythonhosted.org/packages/69/49/4f742451f980840829fc00ba158bebb25d389c846d8f4f8c65936ee55de8/pymupdf-1.27.2.3-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:580983849c64a08d08344ca3d1580e87c01f046a8392421797bc850efd72a5b6", size = 25184609, upload-time = "2026-04-24T14:10:22.911Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/3f/3853d6608f394faf6eec2bd4e8ea9f6a00beea329b071abdb29f4164cc3d/pymupdf-1.27.2.3-cp310-abi3-win32.whl", hash = "sha256:a5c1088a87189891a4946ab314a14b7934ac4c5b6077f7e74ebee956f8906d0e", size = 18019286, upload-time = "2026-04-24T14:10:34.239Z" },
+    { url = "https://files.pythonhosted.org/packages/44/47/5fb10fe73f96b31253a41647c362ea9e0380920bddf16028414a051247fc/pymupdf-1.27.2.3-cp310-abi3-win_amd64.whl", hash = "sha256:d20f68ef15195e073071dbc4ae7455257c7889af7584e39df490c0a92728526e", size = 19249102, upload-time = "2026-04-24T14:10:46.72Z" },
+    { url = "https://files.pythonhosted.org/packages/53/a4/b9e91aac82293f9c954654c85581ee8212b5b05efadc534b581141241e6f/pymupdf-1.27.2.3-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:77691604c5d1d0233827139bbcdea61fd57879c84712b8e49b1f45520f7ab9c2", size = 25000393, upload-time = "2026-04-24T14:11:01.669Z" },
+]
+
+[[package]]
+name = "pymupdf-layout"
+version = "1.27.2.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "networkx" },
+    { name = "numpy" },
+    { name = "onnxruntime" },
+    { name = "pymupdf" },
+    { name = "pyyaml" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bc/ee/067726c3ee5574ad5c605d00d7419e264ef509d626a726f99388111f8216/pymupdf_layout-1.27.2.3-cp310-abi3-macosx_10_9_x86_64.whl", hash = "sha256:75c2ab3c0e8830ac2bc50cfd32d375a30768a2610dac72a02f08265336e0834f", size = 15799844, upload-time = "2026-04-24T14:11:13.177Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/ba/46a7a36474722f9280d885f6eec878561a257d9378e52590b43d32ffb96c/pymupdf_layout-1.27.2.3-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:5656b09669dcd7c51f539afb6fdaf853602bab4cbc20479ee5ee1a85a4e32b60", size = 15795220, upload-time = "2026-04-24T14:11:23.17Z" },
+    { url = "https://files.pythonhosted.org/packages/84/87/bfdcca67346052943a4549814f2009b38f4d15ec025798cdf7dfa5f57c84/pymupdf_layout-1.27.2.3-cp310-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:fcf03aa815cbceebdb3263dd6a190de4547c46b1d168928836ec38738afe127d", size = 15805240, upload-time = "2026-04-24T14:11:33.465Z" },
+    { url = "https://files.pythonhosted.org/packages/32/e9/7ce6eaf97cebd46c3808593282e9eb99a60cddd6183e25a636980d5c7986/pymupdf_layout-1.27.2.3-cp310-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:303b9414216dfaf711ec7d807b6f1e4c3e0a92bbb4569340fcedd9d5593d16ca", size = 15806269, upload-time = "2026-04-24T14:11:43.481Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/61/3b2417d8f2cdfaa0f4749cd9dafa3379cb5cdaddf4233165f1ff81953c30/pymupdf_layout-1.27.2.3-cp310-abi3-win_amd64.whl", hash = "sha256:503b64d9b6b31ea3af79ef85cf7d36950c5048af468cb297684d2953553c62ad", size = 15809163, upload-time = "2026-04-24T14:11:53.956Z" },
+]
+
+[[package]]
+name = "pymupdf4llm"
+version = "1.27.2.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pymupdf" },
+    { name = "pymupdf-layout" },
+    { name = "tabulate" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/87/c0/e3830452d82032c3d82a9879616c05bf0c51e0dea03c1d80d57b3a6ec0d1/pymupdf4llm-1.27.2.3.tar.gz", hash = "sha256:42ec1a47ddc62be3f4f40c116d27618611c6f9fa366719016d9ddc3f3a3dc22b", size = 1406297, upload-time = "2026-04-24T14:13:18.843Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e6/38/84bf29f4dd72e6c450546df6ca8f53021f764fd945ba67dcc235d39bc20e/pymupdf4llm-1.27.2.3-py3-none-any.whl", hash = "sha256:bd724b79fa3f06a5b28d7a65f7acfa8de56e04bdb603ac2d6dff315e0d151aaa", size = 77348, upload-time = "2026-04-24T14:11:04.305Z" },
+]
+
+[[package]]
 name = "pyparsing"
 version = "3.3.2"
 source = { registry = "https://pypi.org/simple" }
@@ -4121,6 +4207,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/83/d3/803453b36afefb7c2bb238361cd4ae6125a569b4db67cd9e79846ba2d68c/sympy-1.14.0.tar.gz", hash = "sha256:d3d3fe8df1e5a0b42f0e7bdf50541697dbe7d23746e894990c030e2b05e72517", size = 7793921, upload-time = "2025-04-27T18:05:01.611Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a2/09/77d55d46fd61b4a135c444fc97158ef34a095e5681d0a6c10b75bf356191/sympy-1.14.0-py3-none-any.whl", hash = "sha256:e091cc3e99d2141a0ba2847328f5479b05d94a6635cb96148ccb3f34671bd8f5", size = 6299353, upload-time = "2025-04-27T18:04:59.103Z" },
+]
+
+[[package]]
+name = "tabulate"
+version = "0.10.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/46/58/8c37dea7bbf769b20d58e7ace7e5edfe65b849442b00ffcdd56be88697c6/tabulate-0.10.0.tar.gz", hash = "sha256:e2cfde8f79420f6deeffdeda9aaec3b6bc5abce947655d17ac662b126e48a60d", size = 91754, upload-time = "2026-03-04T18:55:34.402Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/99/55/db07de81b5c630da5cbf5c7df646580ca26dfaefa593667fc6f2fe016d2e/tabulate-0.10.0-py3-none-any.whl", hash = "sha256:f0b0622e567335c8fabaaa659f1b33bcb6ddfe2e496071b743aa113f8774f2d3", size = 39814, upload-time = "2026-03-04T18:55:31.284Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
The single-paper assumption is gone: a project's local_index is now a corpus with one role:atlas paper plus zero or more role:subatlas references. PDFs join JATS as a first-class source (pymupdf4llm + Crossref metadata) so closed-access papers like Science/Nature articles can be ingested.

Fan-out no longer queries the local index by default — set corpus.use_in_fanout=true to opt in. Subatlas entries at status:needs_pdf are surfaced as a non-blocking warning during fan-out.

A subatlas_resolver runs the atlas-init waterfall: label_provenance.json → S2 candidate proposal (review step) → ASTA probe → JATS fetch → mark needs_pdf otherwise. Legacy single-paper layouts migrate automatically on first read (no flag).