### PR TITLE
Evidence source tagging: source_paper.role + retrieval_method (#12)

### DIFF
--- a/.claude/agents/citation-traverse.md
+++ b/.claude/agents/citation-traverse.md
@@ -1,3 +1,11 @@
+---
+name: citation-traverse
+description: Trace citation chains through the literature via ASTA snippet search, starting from the atlas paper. Produces per-snippet evidence summaries and a paper catalogue. Every evidence item is tagged with source_paper (role) and retrieval_method provenance.
+model: sonnet
+output:
+  schema: src/atlas_chat/atlas_chat/schemas/all_summaries.schema.json
+---
+
 # Subagent: Citation Traversal
 
 You trace citation chains through scientific literature using ASTA snippet search. Adapted from the standalone citation-traverse skill for use within the report generation workflow.
@@ -6,16 +14,38 @@ You trace citation chains through scientific literature using ASTA snippet searc
 
 You receive:
 - `seed_paper_id` — CorpusId, DOI, or PMID of the atlas paper
+- `seed_role` — the role of the seed paper: `atlas` (default) or `subatlas`
 - `query` — constructed from: `"{label} / {resolved_name} in {scope} {tissue}: location, structure, function, markers"`
 - `depth` — traversal depth (default 1, max 3)
 - `output_dir` — traversal output directory
+
+## Evidence provenance (required — issue #12)
+
+Every evidence item you write carries two **orthogonal** provenance fields.
+They are independent: role is about the *paper*, retrieval_method is about the
+*mechanism* — a non-source paper can be reached by traversal or by free search,
+so one cannot be derived from the other.
+
+- **`source_paper`** — `{ "corpus_id": "CorpusId:NNNN", "doi": "...", "role": ... }`.
+  At least one of `corpus_id` / `doi` must be present, and it must appear in
+  `paper_catalogue.json`. `role` is:
+  - `atlas` — the seed paper itself (only when `seed_role` is `atlas`).
+  - `subatlas` — the seed paper when `seed_role` is `subatlas`, or any other
+    corpus member you were told about.
+  - `external` — any paper reached by following a citation out of the corpus.
+- **`retrieval_method`** — the mechanism:
+  - `corpus_snippet` — snippet came from a snippet_search scoped to the seed/corpus paper (depth 0).
+  - `citation_traversal` — snippet came from a paper reached by following a reference (depth ≥ 1).
+  - `free_search` — snippet came from an unscoped search (only if you ran one).
 
 ## Procedure
 
 ### Depth 0: Search within seed papers
 
 1. Call `snippet_search(query="<query>", paper_ids="<seed_ids>", limit=20)`
-2. **Process each snippet** — produce a per-snippet summary:
+2. **Process each snippet** — produce a per-snippet summary. Depth-0 snippets
+   come from the seed paper, so `source_paper.role` = `seed_role` and
+   `retrieval_method` = `corpus_snippet`:
 
 ```json
 {
@@ -26,11 +56,15 @@ You receive:
   "summary": "1-3 sentence summary of content relevant to the query.",
   "quotes": ["exact quote from snippet"],
   "ref_corpus_ids": ["22612890", "46562341"],
-  "depth": 0
+  "depth": 0,
+  "source_paper": { "corpus_id": "CorpusId:2762329", "role": "atlas" },
+  "retrieval_method": "corpus_snippet"
 }
 ```
 
-3. Extract referenced CorpusIds directly from the ASTA snippet results (look for `corpusId` fields in the response metadata, and for CorpusId patterns in the snippet text).
+3. Extract referenced CorpusIds **and their citing sentences** from the ASTA
+   response `annotations` (see "Preserve ASTA annotations" below). Record each
+   referenced CorpusId in `ref_corpus_ids` for the next depth.
 4. Save:
    - `{output_dir}/depth_0_snippets.json` — raw snippet_search response
    - `{output_dir}/depth_0_summaries.json` — array of per-snippet summaries
@@ -41,25 +75,62 @@ You receive:
 6. Remove already-visited IDs (maintain visited set).
 7. If fewer than 3 new IDs, stop.
 8. Call `snippet_search(query="<query>", paper_ids="CorpusId:<new_ids>", limit=20)`
-9. Process each snippet, save files.
-10. Repeat until depth limit or no new IDs.
+9. Process each snippet. These papers were reached by following a citation, so:
+   - `source_paper.role` = `external` (unless you know the paper is a corpus member).
+   - `retrieval_method` = `citation_traversal`.
+   - Populate **`reached_from`** with the citing paper and the exact citing
+     sentence captured at the previous depth:
+
+```json
+{
+  "summary": "…export via ferroportin activity…",
+  "quotes": ["export via ferroportin activity"],
+  "depth": 1,
+  "source_paper": { "corpus_id": "CorpusId:252635104", "role": "external" },
+  "retrieval_method": "citation_traversal",
+  "reached_from": {
+    "corpus_id": "CorpusId:231699447",
+    "citation_context": "<the citing sentence from the depth-0 paper>"
+  }
+}
+```
+
+10. Save files. Repeat until depth limit or no new IDs.
 
 ### Final: Resolve metadata
 
-11. Collect ALL unique corpus IDs from all depths.
-12. Call `get_paper_batch(ids=[...], fields="title,authors,year,venue,publicationDate,url,isOpenAccess")`.
-13. Save to `{output_dir}/paper_catalogue.json`.
+11. Collect ALL unique corpus IDs from all depths (seed + every `source_paper`
+    and `reached_from`).
+12. Call `get_paper_batch(ids=[...], fields="title,authors,year,venue,publicationDate,url,isOpenAccess,externalIds")`.
+13. Save to `{output_dir}/paper_catalogue.json`, keyed by `CorpusId:NNNN`. Every
+    `source_paper` and `reached_from` you emit must have its CorpusId (or DOI)
+    present here.
 
 ## Output
 
-- `{output_dir}/all_summaries.json` — merged summaries from all depths
+- `{output_dir}/all_summaries.json` — merged summaries from all depths, conforming to
+  `src/atlas_chat/atlas_chat/schemas/all_summaries.schema.json`
 - `{output_dir}/paper_catalogue.json` — metadata for all discovered papers
+
+## Preserve ASTA annotations (issue #12)
+
+ASTA returns citation-context data alongside each snippet — do **not** discard it:
+
+- Each snippet result carries `annotations.refMentions`: spans in the snippet
+  text that cite another paper, each with a `matchedPaperCorpusId`.
+- `annotations.sentences` gives sentence spans over the same snippet text.
+- For each `refMention`, find the `sentences` span that **contains** the
+  refMention's character offsets — that sentence is the **citation context**.
+- Use `matchedPaperCorpusId` to populate `ref_corpus_ids` (the traversal
+  frontier) and, at the next depth, `reached_from.corpus_id`; use the containing
+  sentence as `reached_from.citation_context`.
 
 ## CorpusId Retrieval
 
 `snippet_search` is the canonical way to get CorpusIds via MCP:
 - Each snippet result includes `paper.corpusId` in its metadata.
-- For papers referenced within a snippet, check `matchedPaperCorpusId`.
+- For papers referenced within a snippet, check `matchedPaperCorpusId` (in
+  `annotations.refMentions`).
 - Do NOT attempt to get CorpusId from `get_paper` fields — it is not
   available there. Do NOT use `curl` or `WebFetch` to call the S2 API.
 
@@ -70,4 +141,5 @@ You receive:
 - **Maintain a visited set.** Never search the same corpus ID twice.
 - **Write files incrementally.** Each depth's results saved before next.
 - **Quotes must be exact substrings** of the snippet text.
-- Extract CorpusIds directly from ASTA snippet metadata.
+- **Every item must carry `source_paper` (with `role`) and `retrieval_method`.**
+- Extract CorpusIds and citation context directly from ASTA snippet `annotations`.

--- a/.claude/agents/resolve-name.md
+++ b/.claude/agents/resolve-name.md
@@ -1,3 +1,9 @@
+---
+name: resolve-name
+description: Resolve how atlas authors refer to a cell type annotation label, and identify which corpus paper (atlas or subatlas) the annotation actually comes from — establishing the source_paper/role used by all downstream evidence provenance.
+model: sonnet
+---
+
 # Subagent: Resolve Cell Type Name
 
 You resolve how atlas authors refer to a specific cell type annotation label.
@@ -7,6 +13,7 @@ You resolve how atlas authors refer to a specific cell type annotation label.
 You receive:
 - `cell_type_label` — the annotation label (e.g. "Iron-recycling macrophage", "LC_1", "moDC_3")
 - `atlas_doi` — DOI of the atlas paper
+- `atlas_corpus_id` — CorpusId of the atlas paper (if known)
 - `scope` — "adult", "fetal", or "organoid"
 - `supplementary_text` — already-fetched supplementary material text
 
@@ -21,6 +28,14 @@ You receive:
 3. If snippet search is insufficient, fall back to `get_europepmc_full_text`
    (max 2 attempts).
 4. Identify all names the authors use for this cell type.
+5. **Identify the source paper of the annotation.** Usually the annotation is
+   the atlas authors' own (`role: atlas`). But when the label was integrated
+   from an upstream study (e.g. adult annotations from a subatlas paper mapped
+   into the atlas), the annotation actually belongs to that **subatlas** paper.
+   Record which paper it is in `source_paper` — downstream steps
+   (scan-supplements, citation-traverse) use this to tag every piece of
+   evidence with the correct paper and role. See the source-tagging design in
+   issue #12.
 
 ## Shared Prompt
 
@@ -38,12 +53,24 @@ Write `{traversal_dir}/name_resolution.json`:
   "scope": "fetal",
   "tissue_context": "fetal skin",
   "confidence": "high",
-  "evidence": "Found in Extended Data Fig. 5 cluster annotations"
+  "evidence": "Found in Extended Data Fig. 5 cluster annotations",
+  "source_paper": {
+    "doi": "10.1038/s41586-024-08002-x",
+    "corpus_id": "CorpusId:2762329",
+    "role": "atlas"
+  }
 }
 ```
+
+`source_paper.role` is `atlas` when the annotation is the atlas authors' own, or
+`subatlas` when it was integrated from an upstream corpus paper. This object is
+handed to `scan-supplements` (as its `source_paper` input) and to
+`citation-traverse` (as `seed_role`), so the same paper/role labels flow through
+all evidence provenance.
 
 ## Rules
 
 - Return exact names as used by the authors — do not invent names.
 - If you cannot resolve the name, return the original label and set confidence to "low".
+- Always record `source_paper` (which corpus paper the annotation belongs to, and its role).
 - Always write the output file before returning.

--- a/.claude/agents/scan-supplements.md
+++ b/.claude/agents/scan-supplements.md
@@ -1,3 +1,11 @@
+---
+name: scan-supplements
+description: Scan an atlas (or subatlas) paper's supplementary material for markers and annotations about a cell type. Every finding records its explicit parent paper (source_paper) and supplement locator — the parent is no longer assumed to be the atlas.
+model: sonnet
+output:
+  schema: src/atlas_chat/atlas_chat/schemas/supplementary_findings.schema.json
+---
+
 # Subagent: Scan Supplementary Material
 
 You scan supplementary material from an atlas paper for information about a specific cell type.
@@ -7,8 +15,26 @@ You scan supplementary material from an atlas paper for information about a spec
 You receive:
 - `cell_type_label` — the annotation label
 - `resolved_names` — list of names from the resolve-name step
-- `pmcid` — PubMed Central ID of the atlas paper
+- `source_paper` — the paper the supplement belongs to:
+  `{ "doi": "...", "corpus_id": "CorpusId:NNNN", "role": "atlas" | "subatlas" }`.
+  This is usually the atlas paper, but when the cell type's annotations were
+  integrated from a subatlas paper, it is that subatlas paper (`role: subatlas`).
+- `pmcid` — PubMed Central ID of the source paper
 - `supplementary_text` — already-fetched supplementary material
+
+## Evidence provenance (required — issue #12)
+
+Every finding you emit (marker, other finding, evidence quote) carries:
+
+- **`source_paper`** — copy the `source_paper` you were given (`doi`/`corpus_id`
+  + `role`). Do **not** assume the atlas paper; a supplement belongs to whichever
+  corpus paper you were pointed at. `role` must be `atlas` or `subatlas` — a
+  supplement always belongs to a corpus member. This paper must appear in
+  `paper_catalogue.json`.
+- **`retrieval_method`** — always `"supplement"` for findings from this subagent.
+- **`supplement_ref`** — a locator `{ "file": "...", "sheet": "...", "table": "..." }`
+  (`file` required; `sheet`/`table` when known). This replaces the old free-text
+  `source_table` / `source_file` fields.
 
 ## Procedure
 
@@ -22,6 +48,7 @@ You receive:
    - **Spatial information** (location in tissue)
    - **Developmental trajectory** info
 4. Preserve exact quotes as evidence.
+5. Tag every finding with `source_paper`, `retrieval_method: "supplement"`, and `supplement_ref`.
 
 ## Shared Prompt
 
@@ -30,18 +57,37 @@ Follow the instructions in:
 
 ## Output
 
-Write `{traversal_dir}/supplementary_findings.json`:
+Write `{traversal_dir}/supplementary_findings.json`, conforming to
+`src/atlas_chat/atlas_chat/schemas/supplementary_findings.schema.json`:
 
 ```json
 {
   "markers": [
-    {"gene": "HRG", "evidence_type": "DE analysis", "source_table": "Supplementary Table 3"}
+    {
+      "gene": "HRG",
+      "evidence_type": "DE analysis",
+      "source_paper": { "doi": "10.1038/s41586-024-08002-x", "corpus_id": "CorpusId:2762329", "role": "atlas" },
+      "retrieval_method": "supplement",
+      "supplement_ref": { "file": "media-4.xlsx", "sheet": "B", "table": "Supplementary Table 3" }
+    }
   ],
   "other_findings": [
-    {"finding": "Involved in iron recycling from senescent erythrocytes", "category": "function", "source_table": "Extended Data Fig. 5"}
+    {
+      "finding": "Involved in iron recycling from senescent erythrocytes",
+      "category": "function",
+      "source_paper": { "doi": "10.1038/s41586-024-08002-x", "corpus_id": "CorpusId:2762329", "role": "atlas" },
+      "retrieval_method": "supplement",
+      "supplement_ref": { "file": "media-6.pdf", "table": "Extended Data Fig. 5" }
+    }
   ],
   "evidence_quotes": [
-    {"quote": "exact text from supplement", "source_file": "Supplementary Table 3", "context": "marker gene list"}
+    {
+      "quote": "exact text from supplement",
+      "context": "marker gene list",
+      "source_paper": { "doi": "10.1038/s41586-024-08002-x", "corpus_id": "CorpusId:2762329", "role": "atlas" },
+      "retrieval_method": "supplement",
+      "supplement_ref": { "file": "media-4.xlsx", "table": "Supplementary Table 3" }
+    }
   ]
 }
 ```
@@ -50,4 +96,6 @@ Write `{traversal_dir}/supplementary_findings.json`:
 
 - Quotes must be exact substrings of the supplementary text.
 - Do not hallucinate markers — only report what is explicitly stated.
-- Note which supplementary file/table each finding comes from.
+- Record the parent paper explicitly in `source_paper` (never assume the atlas).
+- `retrieval_method` is always `"supplement"`; `source_paper.role` is `atlas` or `subatlas`.
+- Every `source_paper` must resolve to an entry in `paper_catalogue.json`.

--- a/src/atlas_chat/atlas_chat/schemas/all_summaries.schema.json
+++ b/src/atlas_chat/atlas_chat/schemas/all_summaries.schema.json
@@ -1,0 +1,93 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "AllSummaries",
+  "description": "Citation-traversal evidence: an array of per-snippet summary items produced by the citation-traverse subagent and written to all_summaries.json. Every item carries explicit source-paper and retrieval-method provenance (see issue #12).",
+  "type": "array",
+  "items": { "$ref": "#/$defs/TraversalEvidenceItem" },
+  "$defs": {
+    "role": {
+      "type": "string",
+      "description": "What the source paper IS relative to the corpus, independent of how it was reached. 'atlas' = the primary atlas paper; 'subatlas' = an upstream study that contributed cell types and is a corpus member; 'external' = not a corpus member.",
+      "enum": ["atlas", "subatlas", "external"]
+    },
+    "retrieval_method": {
+      "type": "string",
+      "description": "The MECHANISM by which this evidence item was obtained. Orthogonal to source_paper.role. 'corpus_snippet' = snippet_search scoped to a corpus paper; 'supplement' = extracted from a supplementary file; 'citation_traversal' = reached by following a citation from another paper; 'free_search' = unscoped snippet/literature search.",
+      "enum": ["corpus_snippet", "supplement", "citation_traversal", "free_search"]
+    },
+    "SourcePaper": {
+      "type": "object",
+      "description": "The paper this evidence item came from. At least one of doi / corpus_id must be present, and it must resolve to an entry in paper_catalogue.json (enforced by report_checker).",
+      "properties": {
+        "doi": {
+          "type": "string",
+          "description": "DOI of the source paper, e.g. 10.1038/s41586-024-08002-x."
+        },
+        "corpus_id": {
+          "type": "string",
+          "description": "Semantic Scholar CorpusId, formatted 'CorpusId:NNNN'.",
+          "pattern": "^CorpusId:\\d+$"
+        },
+        "role": { "$ref": "#/$defs/role" }
+      },
+      "required": ["role"],
+      "anyOf": [
+        { "required": ["doi"] },
+        { "required": ["corpus_id"] }
+      ],
+      "additionalProperties": false
+    },
+    "ReachedFrom": {
+      "type": "object",
+      "description": "For citation_traversal items: the corpus paper from which this reference was reached, plus the sentence that cited it (from ASTA annotations.refMentions aligned to annotations.sentences).",
+      "properties": {
+        "doi": { "type": "string", "description": "DOI of the citing paper." },
+        "corpus_id": {
+          "type": "string",
+          "description": "CorpusId of the citing paper, formatted 'CorpusId:NNNN'.",
+          "pattern": "^CorpusId:\\d+$"
+        },
+        "citation_context": {
+          "type": "string",
+          "description": "The exact citing sentence from the citing paper (from ASTA annotations.sentences span containing the refMention)."
+        }
+      },
+      "required": ["citation_context"],
+      "anyOf": [
+        { "required": ["doi"] },
+        { "required": ["corpus_id"] }
+      ],
+      "additionalProperties": false
+    },
+    "TraversalEvidenceItem": {
+      "type": "object",
+      "description": "One per-snippet summary with provenance.",
+      "properties": {
+        "source_corpus_id": {
+          "type": "string",
+          "description": "CorpusId of the paper the snippet came from (bare numeric or 'CorpusId:NNNN')."
+        },
+        "source_title": { "type": "string", "description": "Title of the source paper." },
+        "section": { "type": "string", "description": "Section the snippet came from (e.g. Results)." },
+        "snippet_score": { "type": "number", "description": "ASTA relevance score for the snippet." },
+        "summary": { "type": "string", "description": "1-3 sentence summary of the snippet relevant to the query." },
+        "quotes": {
+          "type": "array",
+          "description": "Exact substring quotes from the snippet text.",
+          "items": { "type": "string" }
+        },
+        "ref_corpus_ids": {
+          "type": "array",
+          "description": "CorpusIds referenced within this snippet (candidates for the next traversal depth).",
+          "items": { "type": "string" }
+        },
+        "depth": { "type": "integer", "description": "Traversal depth at which this snippet was found (0 = seed).", "minimum": 0 },
+        "source_paper": { "$ref": "#/$defs/SourcePaper" },
+        "retrieval_method": { "$ref": "#/$defs/retrieval_method" },
+        "reached_from": { "$ref": "#/$defs/ReachedFrom" }
+      },
+      "required": ["source_paper", "retrieval_method", "summary", "quotes"],
+      "additionalProperties": false
+    }
+  }
+}

--- a/src/atlas_chat/atlas_chat/schemas/supplementary_findings.schema.json
+++ b/src/atlas_chat/atlas_chat/schemas/supplementary_findings.schema.json
@@ -1,0 +1,103 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "SupplementaryFindings",
+  "description": "Findings extracted from an atlas (or subatlas) paper's supplementary material by the scan-supplements subagent, written to supplementary_findings.json. Every finding carries an explicit source_paper (the parent paper is no longer assumed to be the atlas) and retrieval_method (see issue #12).",
+  "type": "object",
+  "properties": {
+    "markers": {
+      "type": "array",
+      "description": "Marker genes for the cell type with provenance.",
+      "items": { "$ref": "#/$defs/MarkerFinding" }
+    },
+    "other_findings": {
+      "type": "array",
+      "description": "Non-marker findings (function, spatial, trajectory, etc.) with provenance.",
+      "items": { "$ref": "#/$defs/OtherFinding" }
+    },
+    "evidence_quotes": {
+      "type": "array",
+      "description": "Exact-substring quotes from the supplementary material with provenance.",
+      "items": { "$ref": "#/$defs/EvidenceQuote" }
+    }
+  },
+  "required": ["markers", "other_findings", "evidence_quotes"],
+  "additionalProperties": false,
+  "$defs": {
+    "role": {
+      "type": "string",
+      "description": "What the source paper IS relative to the corpus. For supplement findings this MUST be 'atlas' or 'subatlas' — a supplement always belongs to a corpus member (enforced by report_checker).",
+      "enum": ["atlas", "subatlas", "external"]
+    },
+    "retrieval_method": {
+      "type": "string",
+      "description": "The MECHANISM by which this finding was obtained. Supplement findings are 'supplement'.",
+      "enum": ["corpus_snippet", "supplement", "citation_traversal", "free_search"]
+    },
+    "SourcePaper": {
+      "type": "object",
+      "description": "The paper the supplement belongs to. At least one of doi / corpus_id must be present, and it must resolve to a corpus member in paper_catalogue.json (enforced by report_checker).",
+      "properties": {
+        "doi": { "type": "string", "description": "DOI of the parent paper." },
+        "corpus_id": {
+          "type": "string",
+          "description": "Semantic Scholar CorpusId, formatted 'CorpusId:NNNN'.",
+          "pattern": "^CorpusId:\\d+$"
+        },
+        "role": { "$ref": "#/$defs/role" }
+      },
+      "required": ["role"],
+      "anyOf": [
+        { "required": ["doi"] },
+        { "required": ["corpus_id"] }
+      ],
+      "additionalProperties": false
+    },
+    "SupplementRef": {
+      "type": "object",
+      "description": "Locator for the supplementary source (replaces the old free-text source_table/source_file).",
+      "properties": {
+        "file": { "type": "string", "description": "Supplement file name, e.g. media-4.xlsx." },
+        "sheet": { "type": "string", "description": "Sheet/tab name within the file, if applicable." },
+        "table": { "type": "string", "description": "Human-readable table/figure label, e.g. 'Supplementary Table 2B'." }
+      },
+      "required": ["file"],
+      "additionalProperties": false
+    },
+    "MarkerFinding": {
+      "type": "object",
+      "properties": {
+        "gene": { "type": "string", "description": "Gene symbol." },
+        "evidence_type": { "type": "string", "description": "How the marker was derived (DE analysis, known markers, immunostaining, etc.)." },
+        "source_paper": { "$ref": "#/$defs/SourcePaper" },
+        "retrieval_method": { "$ref": "#/$defs/retrieval_method" },
+        "supplement_ref": { "$ref": "#/$defs/SupplementRef" }
+      },
+      "required": ["gene", "evidence_type", "source_paper", "retrieval_method"],
+      "additionalProperties": false
+    },
+    "OtherFinding": {
+      "type": "object",
+      "properties": {
+        "finding": { "type": "string", "description": "The finding text." },
+        "category": { "type": "string", "description": "Category (function, location, trajectory, morphology, etc.)." },
+        "source_paper": { "$ref": "#/$defs/SourcePaper" },
+        "retrieval_method": { "$ref": "#/$defs/retrieval_method" },
+        "supplement_ref": { "$ref": "#/$defs/SupplementRef" }
+      },
+      "required": ["finding", "category", "source_paper", "retrieval_method"],
+      "additionalProperties": false
+    },
+    "EvidenceQuote": {
+      "type": "object",
+      "properties": {
+        "quote": { "type": "string", "description": "Exact substring of the supplementary text." },
+        "context": { "type": "string", "description": "Brief note on what the quote covers." },
+        "source_paper": { "$ref": "#/$defs/SourcePaper" },
+        "retrieval_method": { "$ref": "#/$defs/retrieval_method" },
+        "supplement_ref": { "$ref": "#/$defs/SupplementRef" }
+      },
+      "required": ["quote", "source_paper", "retrieval_method"],
+      "additionalProperties": false
+    }
+  }
+}

--- a/src/atlas_chat/atlas_chat/validation/report_checker.py
+++ b/src/atlas_chat/atlas_chat/validation/report_checker.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import json
 import re
 from pathlib import Path
+from typing import Any
 
 
 def check_quotes(
@@ -165,6 +166,136 @@ def check_references(
     return errors
 
 
+VALID_ROLES = {"atlas", "subatlas", "external"}
+VALID_RETRIEVAL_METHODS = {
+    "corpus_snippet",
+    "supplement",
+    "citation_traversal",
+    "free_search",
+}
+SUPPLEMENT_ROLES = {"atlas", "subatlas"}
+
+
+def _catalogue_ids(catalogue: dict[str, object]) -> tuple[set[str], set[str]]:
+    """Return (known_dois, known_corpus_ids) drawn from a paper catalogue.
+
+    DOIs are lower-cased/stripped; CorpusIds are bare numeric strings (the
+    ``CorpusId:`` prefix removed) collected from both the catalogue keys and any
+    ``corpus_id`` values inside entries.
+    """
+    known_dois: set[str] = set()
+    known_corpus_ids: set[str] = set()
+    for key, entry in catalogue.items():
+        known_corpus_ids.add(str(key).replace("CorpusId:", "").strip())
+        if isinstance(entry, dict):
+            doi = entry.get("doi", "")
+            if isinstance(doi, str) and doi:
+                known_dois.add(doi.lower().strip())
+            cid = entry.get("corpus_id", "")
+            if isinstance(cid, str) and cid:
+                known_corpus_ids.add(cid.replace("CorpusId:", "").strip())
+    return known_dois, known_corpus_ids
+
+
+def _paper_ref_resolves(
+    ref: dict[str, object],
+    known_dois: set[str],
+    known_corpus_ids: set[str],
+) -> bool:
+    """True if a source_paper/reached_from ref points at a catalogue member."""
+    doi = ref.get("doi")
+    if isinstance(doi, str) and doi.lower().strip() in known_dois:
+        return True
+    cid = ref.get("corpus_id")
+    return isinstance(cid, str) and cid.replace("CorpusId:", "").strip() in known_corpus_ids
+
+
+def check_source_tags(
+    summaries: list[dict[str, object]],
+    supp_data: dict[str, object],
+    catalogue: dict[str, object],
+) -> list[str]:
+    """Return errors for evidence items with missing/invalid source provenance.
+
+    Enforces the source-tagging contract from issue #12 on every evidence item
+    across ``all_summaries.json`` and ``supplementary_findings.json``:
+
+    1. Each item has a ``source_paper`` object carrying a valid ``role`` and at
+       least one of ``doi`` / ``corpus_id``, plus a valid ``retrieval_method``.
+    2. ``supplement`` items resolve to an ``atlas`` / ``subatlas`` corpus member
+       (the implicit-atlas assumption is removed — the parent is now explicit).
+    3. Every ``source_paper`` (and any ``reached_from``) DOI/CorpusId appears in
+       ``paper_catalogue.json``.
+
+    Args:
+        summaries: Parsed ``all_summaries.json`` (list of evidence items).
+        supp_data: Parsed ``supplementary_findings.json`` (markers /
+            other_findings / evidence_quotes arrays).
+        catalogue: Parsed ``paper_catalogue.json``.
+
+    Returns:
+        List of error strings.  Empty means every item is correctly tagged.
+    """
+    errors: list[str] = []
+    known_dois, known_corpus_ids = _catalogue_ids(catalogue)
+
+    def _check_item(item: object, where: str) -> None:
+        if not isinstance(item, dict):
+            errors.append(f"{where}: evidence item is not an object")
+            return
+
+        method = item.get("retrieval_method")
+        if method not in VALID_RETRIEVAL_METHODS:
+            errors.append(
+                f"{where}: retrieval_method {method!r} missing or not one of "
+                f"{sorted(VALID_RETRIEVAL_METHODS)}"
+            )
+
+        sp = item.get("source_paper")
+        if not isinstance(sp, dict):
+            errors.append(f"{where}: missing required source_paper object")
+            return
+
+        role = sp.get("role")
+        if role not in VALID_ROLES:
+            errors.append(
+                f"{where}: source_paper.role {role!r} missing or not one of {sorted(VALID_ROLES)}"
+            )
+
+        if not (isinstance(sp.get("doi"), str) or isinstance(sp.get("corpus_id"), str)):
+            errors.append(f"{where}: source_paper must have at least one of doi / corpus_id")
+        elif not _paper_ref_resolves(sp, known_dois, known_corpus_ids):
+            ident = sp.get("doi") or sp.get("corpus_id")
+            errors.append(f"{where}: source_paper {ident!r} not found in paper_catalogue.json")
+
+        if method == "supplement" and role not in SUPPLEMENT_ROLES:
+            errors.append(
+                f"{where}: supplement finding must resolve to an atlas/subatlas "
+                f"paper, got role {role!r}"
+            )
+
+        reached = item.get("reached_from")
+        if isinstance(reached, dict):
+            if not (
+                isinstance(reached.get("doi"), str) or isinstance(reached.get("corpus_id"), str)
+            ):
+                errors.append(f"{where}: reached_from must have at least one of doi / corpus_id")
+            elif not _paper_ref_resolves(reached, known_dois, known_corpus_ids):
+                ident = reached.get("doi") or reached.get("corpus_id")
+                errors.append(f"{where}: reached_from {ident!r} not found in paper_catalogue.json")
+
+    for i, item in enumerate(summaries):
+        _check_item(item, f"all_summaries[{i}]")
+
+    for array_name in ("markers", "other_findings", "evidence_quotes"):
+        array = supp_data.get(array_name, [])
+        if isinstance(array, list):
+            for i, item in enumerate(array):
+                _check_item(item, f"supplementary_findings.{array_name}[{i}]")
+
+    return errors
+
+
 def validate_report(
     report_path: Path,
     traversal_dir: Path,
@@ -196,6 +327,7 @@ def validate_report(
 
     # Load any atlas snippets (supplementary findings have evidence_quotes)
     atlas_snippets: list[str] = []
+    supp_data: dict[str, Any] = {}
     supp_path = traversal_dir / "supplementary_findings.json"
     if supp_path.exists():
         supp_data = json.loads(supp_path.read_text())
@@ -213,5 +345,6 @@ def validate_report(
     errors: list[str] = []
     errors.extend(check_quotes(report_md, summaries, atlas_snippets))
     errors.extend(check_references(report_md, catalogue))
+    errors.extend(check_source_tags(summaries, supp_data, catalogue))
 
     return (len(errors) == 0, errors)

--- a/src/atlas_chat/atlas_chat/validation/report_checker.py
+++ b/src/atlas_chat/atlas_chat/validation/report_checker.py
@@ -12,6 +12,10 @@ import re
 from pathlib import Path
 from typing import Any
 
+from jsonschema import Draft202012Validator  # type: ignore[import-untyped]
+
+from ..schemas import load_schema
+
 
 def check_quotes(
     report_md: str,
@@ -166,14 +170,22 @@ def check_references(
     return errors
 
 
-VALID_ROLES = {"atlas", "subatlas", "external"}
-VALID_RETRIEVAL_METHODS = {
-    "corpus_snippet",
-    "supplement",
-    "citation_traversal",
-    "free_search",
-}
+# The JSON schemas are the single source of truth for structure, enums and
+# required fields (schema-first commandment). ``SUPPLEMENT_ROLES`` is the one
+# rule a *standalone* item schema cannot express — it couples retrieval_method
+# to source_paper.role across the item — so it is asserted here, not duplicated.
 SUPPLEMENT_ROLES = {"atlas", "subatlas"}
+
+
+def _schema_errors(instance: object, schema_name: str, label: str) -> list[str]:
+    """Validate *instance* against a bundled JSON schema; return path-tagged errors."""
+    validator = Draft202012Validator(load_schema(schema_name))
+    errors: list[str] = []
+    for err in sorted(validator.iter_errors(instance), key=lambda e: list(e.path)):
+        path = ".".join(str(p) for p in err.absolute_path)
+        loc = f"{label}.{path}" if path else label
+        errors.append(f"{loc}: {err.message}")
+    return errors
 
 
 def _catalogue_ids(catalogue: dict[str, object]) -> tuple[set[str], set[str]]:
@@ -218,80 +230,79 @@ def check_source_tags(
     """Return errors for evidence items with missing/invalid source provenance.
 
     Enforces the source-tagging contract from issue #12 on every evidence item
-    across ``all_summaries.json`` and ``supplementary_findings.json``:
+    across ``all_summaries.json`` and ``supplementary_findings.json``. The work
+    splits along what a schema can express:
 
-    1. Each item has a ``source_paper`` object carrying a valid ``role`` and at
-       least one of ``doi`` / ``corpus_id``, plus a valid ``retrieval_method``.
-    2. ``supplement`` items resolve to an ``atlas`` / ``subatlas`` corpus member
-       (the implicit-atlas assumption is removed — the parent is now explicit).
-    3. Every ``source_paper`` (and any ``reached_from``) DOI/CorpusId appears in
+    1. **Schema-derived** (structure, enums, required ``source_paper``/
+       ``retrieval_method``, at-least-one identifier): validated directly against
+       ``all_summaries.schema.json`` / ``supplementary_findings.schema.json`` —
+       the single source of truth, not re-declared here.
+    2. **Cross-cutting** (not expressible in a standalone item schema):
+       ``supplement`` items must resolve to an ``atlas``/``subatlas`` paper, and
+       every ``source_paper`` / ``reached_from`` identifier must appear in
        ``paper_catalogue.json``.
 
     Args:
         summaries: Parsed ``all_summaries.json`` (list of evidence items).
         supp_data: Parsed ``supplementary_findings.json`` (markers /
-            other_findings / evidence_quotes arrays).
+            other_findings / evidence_quotes arrays); empty when the file is absent.
         catalogue: Parsed ``paper_catalogue.json``.
 
     Returns:
         List of error strings.  Empty means every item is correctly tagged.
     """
     errors: list[str] = []
+
+    # 1. Structure / enums / presence — owned by the JSON schemas.
+    errors.extend(_schema_errors(summaries, "all_summaries.schema.json", "all_summaries"))
+    if supp_data:  # empty dict = no supplementary_findings.json to check
+        errors.extend(
+            _schema_errors(
+                supp_data, "supplementary_findings.schema.json", "supplementary_findings"
+            )
+        )
+
+    # 2. Cross-cutting rules the standalone schemas cannot express.
     known_dois, known_corpus_ids = _catalogue_ids(catalogue)
 
-    def _check_item(item: object, where: str) -> None:
+    def _check_cross(item: object, where: str) -> None:
         if not isinstance(item, dict):
-            errors.append(f"{where}: evidence item is not an object")
             return
-
-        method = item.get("retrieval_method")
-        if method not in VALID_RETRIEVAL_METHODS:
-            errors.append(
-                f"{where}: retrieval_method {method!r} missing or not one of "
-                f"{sorted(VALID_RETRIEVAL_METHODS)}"
-            )
 
         sp = item.get("source_paper")
-        if not isinstance(sp, dict):
-            errors.append(f"{where}: missing required source_paper object")
-            return
+        if isinstance(sp, dict):
+            # Only resolve when an identifier is present; the schema already
+            # flags a source_paper with neither doi nor corpus_id.
+            if (sp.get("doi") or sp.get("corpus_id")) and not _paper_ref_resolves(
+                sp, known_dois, known_corpus_ids
+            ):
+                ident = sp.get("doi") or sp.get("corpus_id")
+                errors.append(f"{where}: source_paper {ident!r} not found in paper_catalogue.json")
 
-        role = sp.get("role")
-        if role not in VALID_ROLES:
-            errors.append(
-                f"{where}: source_paper.role {role!r} missing or not one of {sorted(VALID_ROLES)}"
-            )
-
-        if not (isinstance(sp.get("doi"), str) or isinstance(sp.get("corpus_id"), str)):
-            errors.append(f"{where}: source_paper must have at least one of doi / corpus_id")
-        elif not _paper_ref_resolves(sp, known_dois, known_corpus_ids):
-            ident = sp.get("doi") or sp.get("corpus_id")
-            errors.append(f"{where}: source_paper {ident!r} not found in paper_catalogue.json")
-
-        if method == "supplement" and role not in SUPPLEMENT_ROLES:
-            errors.append(
-                f"{where}: supplement finding must resolve to an atlas/subatlas "
-                f"paper, got role {role!r}"
-            )
+            is_supplement = item.get("retrieval_method") == "supplement"
+            if is_supplement and sp.get("role") not in SUPPLEMENT_ROLES:
+                errors.append(
+                    f"{where}: supplement finding must resolve to an atlas/subatlas "
+                    f"paper, got role {sp.get('role')!r}"
+                )
 
         reached = item.get("reached_from")
-        if isinstance(reached, dict):
-            if not (
-                isinstance(reached.get("doi"), str) or isinstance(reached.get("corpus_id"), str)
-            ):
-                errors.append(f"{where}: reached_from must have at least one of doi / corpus_id")
-            elif not _paper_ref_resolves(reached, known_dois, known_corpus_ids):
-                ident = reached.get("doi") or reached.get("corpus_id")
-                errors.append(f"{where}: reached_from {ident!r} not found in paper_catalogue.json")
+        if (
+            isinstance(reached, dict)
+            and (reached.get("doi") or reached.get("corpus_id"))
+            and not _paper_ref_resolves(reached, known_dois, known_corpus_ids)
+        ):
+            ident = reached.get("doi") or reached.get("corpus_id")
+            errors.append(f"{where}: reached_from {ident!r} not found in paper_catalogue.json")
 
     for i, item in enumerate(summaries):
-        _check_item(item, f"all_summaries[{i}]")
+        _check_cross(item, f"all_summaries[{i}]")
 
     for array_name in ("markers", "other_findings", "evidence_quotes"):
         array = supp_data.get(array_name, [])
         if isinstance(array, list):
             for i, item in enumerate(array):
-                _check_item(item, f"supplementary_findings.{array_name}[{i}]")
+                _check_cross(item, f"supplementary_findings.{array_name}[{i}]")
 
     return errors
 

--- a/tests/unit/fixtures/evidence/all_summaries.good.json
+++ b/tests/unit/fixtures/evidence/all_summaries.good.json
@@ -1,0 +1,27 @@
+[
+  {
+    "source_corpus_id": "2762329",
+    "source_title": "A prenatal skin atlas",
+    "section": "Results",
+    "snippet_score": 0.57,
+    "summary": "Iron-recycling macrophages are one of four macrophage subsets in prenatal skin.",
+    "quotes": ["Iron-recycling macrophages express SLC40A1"],
+    "ref_corpus_ids": ["231699447"],
+    "depth": 0,
+    "source_paper": { "corpus_id": "CorpusId:2762329", "doi": "10.1038/s41586-024-08002-x", "role": "atlas" },
+    "retrieval_method": "corpus_snippet"
+  },
+  {
+    "source_title": "Ferroportin and iron export",
+    "snippet_score": 0.41,
+    "summary": "Iron is exported from macrophages via ferroportin activity.",
+    "quotes": ["export via ferroportin activity"],
+    "depth": 1,
+    "source_paper": { "corpus_id": "CorpusId:252635104", "role": "external" },
+    "retrieval_method": "citation_traversal",
+    "reached_from": {
+      "corpus_id": "CorpusId:231699447",
+      "citation_context": "Macrophages recycle iron and export it via ferroportin activity."
+    }
+  }
+]

--- a/tests/unit/fixtures/evidence/supplementary_findings.good.json
+++ b/tests/unit/fixtures/evidence/supplementary_findings.good.json
@@ -1,0 +1,29 @@
+{
+  "markers": [
+    {
+      "gene": "SLC40A1",
+      "evidence_type": "DE analysis",
+      "source_paper": { "doi": "10.1038/s41586-024-08002-x", "corpus_id": "CorpusId:2762329", "role": "atlas" },
+      "retrieval_method": "supplement",
+      "supplement_ref": { "file": "media-4.xlsx", "sheet": "B", "table": "Supplementary Table 3" }
+    }
+  ],
+  "other_findings": [
+    {
+      "finding": "Involved in iron recycling from senescent erythrocytes",
+      "category": "function",
+      "source_paper": { "doi": "10.1038/s41586-024-08002-x", "role": "atlas" },
+      "retrieval_method": "supplement",
+      "supplement_ref": { "file": "media-6.pdf", "table": "Extended Data Fig. 5" }
+    }
+  ],
+  "evidence_quotes": [
+    {
+      "quote": "Iron-recycling macrophages: CD5L, APOE, VCAM, TIMD4, SLC40A1",
+      "context": "marker gene list",
+      "source_paper": { "corpus_id": "CorpusId:2762329", "role": "atlas" },
+      "retrieval_method": "supplement",
+      "supplement_ref": { "file": "media-4.xlsx", "table": "Supplementary Table 3" }
+    }
+  ]
+}

--- a/tests/unit/test_evidence_provenance_schema.py
+++ b/tests/unit/test_evidence_provenance_schema.py
@@ -1,0 +1,132 @@
+"""Schema regression for evidence-provenance contracts (issue #12).
+
+Pins the shape of ``all_summaries.json`` and ``supplementary_findings.json``:
+every evidence item must carry a ``source_paper`` (with ``role``) and a
+``retrieval_method``. Good golden fixtures must validate; targeted mutations
+must be rejected.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+from pathlib import Path
+
+import jsonschema
+import pytest
+
+from atlas_chat.schemas import load_schema
+
+FIXTURES = Path(__file__).parent / "fixtures" / "evidence"
+
+
+def _load_fixture(name: str) -> object:
+    return json.loads((FIXTURES / name).read_text())
+
+
+def _validate(schema_name: str, data: object) -> list[str]:
+    schema = load_schema(schema_name)
+    validator = jsonschema.Draft202012Validator(schema)
+    return [e.message for e in validator.iter_errors(data)]
+
+
+# --- schemas are themselves well-formed -------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "schema_name",
+    ["all_summaries.schema.json", "supplementary_findings.schema.json"],
+)
+def test_schema_is_valid(schema_name: str) -> None:
+    jsonschema.Draft202012Validator.check_schema(load_schema(schema_name))
+
+
+# --- all_summaries -----------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_all_summaries_good_fixture_validates() -> None:
+    data = _load_fixture("all_summaries.good.json")
+    assert _validate("all_summaries.schema.json", data) == []
+
+
+@pytest.mark.unit
+def test_all_summaries_rejects_missing_source_paper() -> None:
+    data = _load_fixture("all_summaries.good.json")
+    del data[0]["source_paper"]
+    assert _validate("all_summaries.schema.json", data)
+
+
+@pytest.mark.unit
+def test_all_summaries_rejects_bad_retrieval_method() -> None:
+    data = _load_fixture("all_summaries.good.json")
+    data[0]["retrieval_method"] = "made_up"
+    assert _validate("all_summaries.schema.json", data)
+
+
+@pytest.mark.unit
+def test_all_summaries_rejects_source_paper_without_role() -> None:
+    data = _load_fixture("all_summaries.good.json")
+    del data[0]["source_paper"]["role"]
+    assert _validate("all_summaries.schema.json", data)
+
+
+@pytest.mark.unit
+def test_all_summaries_rejects_source_paper_without_identifier() -> None:
+    data = _load_fixture("all_summaries.good.json")
+    data[0]["source_paper"] = {"role": "atlas"}
+    assert _validate("all_summaries.schema.json", data)
+
+
+@pytest.mark.unit
+def test_all_summaries_rejects_extra_property() -> None:
+    data = _load_fixture("all_summaries.good.json")
+    data[0]["surprise"] = "not allowed"
+    assert _validate("all_summaries.schema.json", data)
+
+
+# --- supplementary_findings --------------------------------------------------
+
+
+@pytest.mark.unit
+def test_supplementary_findings_good_fixture_validates() -> None:
+    data = _load_fixture("supplementary_findings.good.json")
+    assert _validate("supplementary_findings.schema.json", data) == []
+
+
+@pytest.mark.unit
+def test_supplement_marker_requires_source_paper() -> None:
+    data = _load_fixture("supplementary_findings.good.json")
+    del data["markers"][0]["source_paper"]
+    assert _validate("supplementary_findings.schema.json", data)
+
+
+@pytest.mark.unit
+def test_supplement_quote_requires_retrieval_method() -> None:
+    data = _load_fixture("supplementary_findings.good.json")
+    del data["evidence_quotes"][0]["retrieval_method"]
+    assert _validate("supplementary_findings.schema.json", data)
+
+
+@pytest.mark.unit
+def test_supplement_ref_requires_file() -> None:
+    data = _load_fixture("supplementary_findings.good.json")
+    del data["markers"][0]["supplement_ref"]["file"]
+    assert _validate("supplementary_findings.schema.json", data)
+
+
+@pytest.mark.unit
+def test_supplementary_findings_rejects_extra_property() -> None:
+    data = _load_fixture("supplementary_findings.good.json")
+    data["markers"][0]["surprise"] = "nope"
+    assert _validate("supplementary_findings.schema.json", data)
+
+
+@pytest.mark.unit
+def test_good_fixtures_are_independent_copies() -> None:
+    # Guard: mutating a loaded fixture must not affect a fresh load.
+    a = _load_fixture("all_summaries.good.json")
+    b = copy.deepcopy(a)
+    a[0]["retrieval_method"] = "free_search"
+    assert b[0]["retrieval_method"] == "corpus_snippet"

--- a/tests/unit/test_report_checker_source_tags.py
+++ b/tests/unit/test_report_checker_source_tags.py
@@ -43,7 +43,8 @@ def test_missing_source_paper_flagged() -> None:
     summaries = _summaries()
     del summaries[0]["source_paper"]
     errors = check_source_tags(summaries, _supp(), CATALOGUE)
-    assert any("missing required source_paper" in e for e in errors)
+    # Schema-derived: "'source_paper' is a required property".
+    assert any("source_paper" in e and "required" in e for e in errors)
 
 
 @pytest.mark.unit
@@ -91,7 +92,8 @@ def test_source_paper_without_identifier_flagged() -> None:
     summaries = _summaries()
     summaries[0]["source_paper"] = {"role": "atlas"}
     errors = check_source_tags(summaries, _supp(), CATALOGUE)
-    assert any("at least one of doi / corpus_id" in e for e in errors)
+    # Schema-derived: source_paper fails the anyOf(doi|corpus_id) requirement.
+    assert any("source_paper" in e for e in errors)
 
 
 @pytest.mark.unit
@@ -109,4 +111,4 @@ def test_validate_report_runs_source_tag_checks(tmp_path: Path) -> None:
 
     passed, errors = validate_report(report, traversal)
     assert not passed
-    assert any("missing required source_paper" in e for e in errors)
+    assert any("source_paper" in e and "required" in e for e in errors)

--- a/tests/unit/test_report_checker_source_tags.py
+++ b/tests/unit/test_report_checker_source_tags.py
@@ -1,0 +1,112 @@
+"""Regression for the source-tagging checks in report_checker (issue #12).
+
+Covers ``check_source_tags`` directly and its integration into
+``validate_report``: every evidence item must carry a resolvable
+``source_paper`` + ``retrieval_method``; ``supplement`` items must resolve to an
+``atlas``/``subatlas`` corpus member; every referenced paper must appear in the
+catalogue.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from atlas_chat.validation.report_checker import check_source_tags, validate_report
+
+FIXTURES = Path(__file__).parent / "fixtures" / "evidence"
+
+# Catalogue containing every paper referenced by the good fixtures.
+CATALOGUE: dict[str, object] = {
+    "CorpusId:2762329": {"doi": "10.1038/s41586-024-08002-x", "title": "A prenatal skin atlas"},
+    "CorpusId:252635104": {"doi": "", "title": "Ferroportin and iron export"},
+    "CorpusId:231699447": {"doi": "", "title": "Citing paper"},
+}
+
+
+def _summaries() -> list[dict[str, object]]:
+    return json.loads((FIXTURES / "all_summaries.good.json").read_text())
+
+
+def _supp() -> dict[str, object]:
+    return json.loads((FIXTURES / "supplementary_findings.good.json").read_text())
+
+
+@pytest.mark.unit
+def test_good_fixtures_pass() -> None:
+    assert check_source_tags(_summaries(), _supp(), CATALOGUE) == []
+
+
+@pytest.mark.unit
+def test_missing_source_paper_flagged() -> None:
+    summaries = _summaries()
+    del summaries[0]["source_paper"]
+    errors = check_source_tags(summaries, _supp(), CATALOGUE)
+    assert any("missing required source_paper" in e for e in errors)
+
+
+@pytest.mark.unit
+def test_invalid_retrieval_method_flagged() -> None:
+    summaries = _summaries()
+    summaries[0]["retrieval_method"] = "guesswork"
+    errors = check_source_tags(summaries, _supp(), CATALOGUE)
+    assert any("retrieval_method" in e for e in errors)
+
+
+@pytest.mark.unit
+def test_supplement_with_external_role_flagged() -> None:
+    supp = _supp()
+    supp["markers"][0]["source_paper"]["role"] = "external"
+    errors = check_source_tags(_summaries(), supp, CATALOGUE)
+    assert any("atlas/subatlas" in e for e in errors)
+
+
+@pytest.mark.unit
+def test_source_paper_not_in_catalogue_flagged() -> None:
+    summaries = _summaries()
+    summaries[0]["source_paper"] = {"corpus_id": "CorpusId:99999999", "role": "atlas"}
+    errors = check_source_tags(summaries, _supp(), CATALOGUE)
+    assert any("not found in paper_catalogue" in e for e in errors)
+
+
+@pytest.mark.unit
+def test_source_paper_resolved_by_doi() -> None:
+    summaries = _summaries()
+    # Drop the corpus_id; the DOI alone must still resolve against the catalogue.
+    summaries[0]["source_paper"] = {"doi": "10.1038/s41586-024-08002-x", "role": "atlas"}
+    assert check_source_tags(summaries, _supp(), CATALOGUE) == []
+
+
+@pytest.mark.unit
+def test_reached_from_not_in_catalogue_flagged() -> None:
+    summaries = _summaries()
+    summaries[1]["reached_from"]["corpus_id"] = "CorpusId:88888888"
+    errors = check_source_tags(summaries, _supp(), CATALOGUE)
+    assert any("reached_from" in e and "not found" in e for e in errors)
+
+
+@pytest.mark.unit
+def test_source_paper_without_identifier_flagged() -> None:
+    summaries = _summaries()
+    summaries[0]["source_paper"] = {"role": "atlas"}
+    errors = check_source_tags(summaries, _supp(), CATALOGUE)
+    assert any("at least one of doi / corpus_id" in e for e in errors)
+
+
+@pytest.mark.unit
+def test_validate_report_runs_source_tag_checks(tmp_path: Path) -> None:
+    traversal = tmp_path
+    (traversal / "all_summaries.json").write_text(json.dumps(_summaries()))
+    (traversal / "paper_catalogue.json").write_text(json.dumps(CATALOGUE))
+    # Break one item so validate_report must surface a source-tag error.
+    supp = _supp()
+    del supp["markers"][0]["source_paper"]
+    (traversal / "supplementary_findings.json").write_text(json.dumps(supp))
+
+    report = tmp_path / "report.md"
+    report.write_text("# Report\n\nNo quotes, no DOIs.\n")
+
+    passed, errors = validate_report(report, traversal)
+    assert not passed
+    assert any("missing required source_paper" in e for e in errors)


### PR DESCRIPTION
Closes #12.

Tags every piece of evidence in the report pipeline with **where it came from** (`source_paper.role`) and **how it was obtained** (`retrieval_method`), the shared provenance foundation for the two follow-up tickets (true citation traversal; free-search control).

## What changed

### Schemas (source of truth) — `src/atlas_chat/atlas_chat/schemas/`
- **`all_summaries.schema.json`** — traversal evidence items; each **requires** `source_paper{doi,corpus_id,role}` + `retrieval_method`, with optional `reached_from{corpus_id, citation_context}` for `citation_traversal` items.
- **`supplementary_findings.schema.json`** — markers / other_findings / evidence_quotes; each **requires** `source_paper` + `retrieval_method`, with structured `supplement_ref{file,sheet,table}` replacing the old free-text `source_table`/`source_file`.
- `role` ∈ `atlas·subatlas·external`; `retrieval_method` ∈ `corpus_snippet·supplement·citation_traversal·free_search`. `additionalProperties:false`; `source_paper` requires `role` + at least one identifier. The two axes stay **orthogonal** (a non-source paper can be reached by traversal *or* free search).

### Subagent contracts (`.claude/agents/`)
- **`citation-traverse.md`** — adds `seed_role`, per-item `source_paper`/`retrieval_method`/`reached_from`, and a "Preserve ASTA annotations" section: extract `annotations.refMentions → matchedPaperCorpusId` aligned to `annotations.sentences` to populate `reached_from.citation_context`. Output-schema front-matter added.
- **`scan-supplements.md`** — takes an explicit `source_paper` input (removes the implicit-atlas assumption), tags findings `retrieval_method:"supplement"` + `supplement_ref`.
- **`resolve-name.md`** — emits `source_paper` (which corpus paper the annotation belongs to + role), feeding downstream provenance.

### Validator (`report_checker.py`)
- New `check_source_tags()` wired into `validate_report()`: every item has a valid `source_paper`+`retrieval_method`; `supplement` items resolve to `atlas`/`subatlas`; every `source_paper` (and `reached_from`) resolves to `paper_catalogue.json`.

### Tests
- `test_evidence_provenance_schema.py` (schema good/bad regression) + `test_report_checker_source_tags.py` (validator + end-to-end), with golden fixtures. **52 unit tests pass**, ruff clean, no new mypy errors.

## Scope note on issue item 3
Item 3 literally targets `AstaProvider._normalize_snippets`, which lives in the external `deep-research-client` dependency — the **deprecated** programmatic path (`CLAUDE_dev.md`: "do not extend"). Its intent is implemented here in the **agentic** `citation-traverse` contract (which uses the `snippet_search` MCP tool directly and now extracts the same `annotations` fields). If a patch to the upstream Python `AstaProvider` is also wanted, that belongs in `monarch-initiative/deep-research-client`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)