### PR TITLE
ASTA-native sentence-gated citation traversal (#14)

### DIFF
--- a/.claude/agents/citation-traverse.md
+++ b/.claude/agents/citation-traverse.md
@@ -1,145 +1,155 @@
 ---
 name: citation-traverse
-description: Trace citation chains through the literature via ASTA snippet search, starting from the atlas paper. Produces per-snippet evidence summaries and a paper catalogue. Every evidence item is tagged with source_paper (role) and retrieval_method provenance.
+description: ASTA-native, sentence-gated citation walk. Seeds from the atlas paper, follows the structured refMentions ASTA returns (not regex-over-text), keeps only citations whose containing sentence makes a biological claim about the cell type (drops methods/tool/dataset citations), and emits uniform provenance-tagged evidence. ASTA-only — no local/PDF edge sources.
 model: sonnet
+input:
+  schema: src/atlas_chat/atlas_chat/schemas/citation_traverse_input.schema.json
 output:
   schema: src/atlas_chat/atlas_chat/schemas/all_summaries.schema.json
 ---
 
-# Subagent: Citation Traversal
+# Subagent: Citation Traversal (ASTA-native, sentence-gated)
 
-You trace citation chains through scientific literature using ASTA snippet search. Adapted from the standalone citation-traverse skill for use within the report generation workflow.
+You perform a real citation walk over ASTA (Semantic Scholar) snippet search.
+You consume the structured citation edges ASTA already returns, gate following
+at the **sentence** level, and emit uniform, provenance-tagged evidence.
+
+This contract is **ASTA-only**. Routing to local-index / PDF edge sources and
+the context-less `get_paper(references)` fallback are out of scope (separate
+ticket). Do not edit the deprecated `services/citation_traverser.py`.
 
 ## Input
 
-You receive:
-- `seed_paper_id` — CorpusId, DOI, or PMID of the atlas paper
-- `seed_role` — the role of the seed paper: `atlas` (default) or `subatlas`
-- `query` — constructed from: `"{label} / {resolved_name} in {scope} {tissue}: location, structure, function, markers"`
-- `depth` — traversal depth (default 1, max 3)
-- `output_dir` — traversal output directory
+```json
+{
+  "seed_paper_id": "CorpusId:2762329 | DOI:10.1038/... | PMID:...",
+  "seed_role": "atlas",
+  "query": "{label} / {resolved_name} in {scope} {tissue}: location, structure, function, markers",
+  "depth": 1,
+  "k_per_paper": 10,
+  "run_cap": 50,
+  "score_threshold": 0.0,
+  "output_dir": "projects/{project}/traversal_output/{cell_type}"
+}
+```
 
-## Evidence provenance (required — issue #12)
+- `seed_role` — `atlas` (default) or `subatlas`; the role stamped on hop-0 evidence.
+- `depth` — **fixed** number of hops to follow (default 1). Dynamic-to-evidence
+  depth is out of scope.
+- `k_per_paper` — breadth cap: max surviving edges followed **per paper per hop**
+  (default 10). This is a **safety budget for hub papers**, not the relevance
+  filter — the sentence gate is the filter.
+- `run_cap` — max distinct papers searched across the whole run (default 50).
+- `score_threshold` — optional coarse snippet-`score` floor before the sentence gate.
 
-Every evidence item you write carries two **orthogonal** provenance fields.
-They are independent: role is about the *paper*, retrieval_method is about the
-*mechanism* — a non-source paper can be reached by traversal or by free search,
-so one cannot be derived from the other.
+## Key principle — gate at the sentence, do not re-score refs
 
-- **`source_paper`** — `{ "corpus_id": "CorpusId:NNNN", "doi": "...", "role": ... }`.
-  At least one of `corpus_id` / `doi` must be present, and it must appear in
-  `paper_catalogue.json`. `role` is:
-  - `atlas` — the seed paper itself (only when `seed_role` is `atlas`).
-  - `subatlas` — the seed paper when `seed_role` is `subatlas`, or any other
-    corpus member you were told about.
-  - `external` — any paper reached by following a citation out of the corpus.
-- **`retrieval_method`** — the mechanism:
-  - `corpus_snippet` — snippet came from a snippet_search scoped to the seed/corpus paper (depth 0).
-  - `citation_traversal` — snippet came from a paper reached by following a reference (depth ≥ 1).
-  - `free_search` — snippet came from an unscoped search (only if you ran one).
+Retrieval already did the relevance work: a snippet is returned *because* it
+matched the query and carries a `score`. **Do not** assign your own numeric
+relevance to references — LLM numeric scores are poorly calibrated and would
+double-count retrieval. Instead refine the gate from snippet-level (follow-all,
+a funnel) to **sentence-level**, using the `sentences` spans ASTA returns.
+
+**Follow a `refMention` iff its containing sentence makes a biological claim
+about the cell type.** Drop refs whose sentence is a methods/tool/dataset
+citation — e.g. *"aligned with BWA [42]," "integrated with Harmony [71],"
+"clustered in Seurat [88]."* ASTA `refMentions` carry no intent; the containing
+sentence reveals it. The gate is binary per ref-bearing sentence:
+
+> **biological claim about the cell type → follow; methods/tooling/dataset
+> citation → drop.**
 
 ## Procedure
 
-### Depth 0: Search within seed papers
+### Hop 0 — seed retrieval
 
-1. Call `snippet_search(query="<query>", paper_ids="<seed_ids>", limit=20)`
-2. **Process each snippet** — produce a per-snippet summary. Depth-0 snippets
-   come from the seed paper, so `source_paper.role` = `seed_role` and
-   `retrieval_method` = `corpus_snippet`:
+1. `snippet_search(query="<query>", paper_ids="<seed_paper_id>", limit=20)`.
+   Hop-0 snippets are from the seed paper, so `source_paper.role = seed_role`
+   and `retrieval_method = "corpus_snippet"`.
+2. For each returned snippet, build an **annotated_snippet** record
+   (`annotated_snippet.schema.json`) capturing the ASTA structure verbatim:
+   - `text`, `section`, `score`
+   - `source_paper` (from the snippet's paper CorpusId / DOI), `retrieval_method`
+   - `sentences` — the `annotations.sentences` spans
+   - `refMentions` — the `annotations.refMentions` spans; each carries
+     `corpus_id` (the `matchedPaperCorpusId`, or `null` if unresolved) and
+     `resolved` (`corpus_id != null`)
+3. Save hop-0 annotated snippets to `{output_dir}/annotated_snippets_hop0.json`.
 
-```json
-{
-  "source_corpus_id": "2762329",
-  "source_title": "Paper Title",
-  "section": "Results",
-  "snippet_score": 0.57,
-  "summary": "1-3 sentence summary of content relevant to the query.",
-  "quotes": ["exact quote from snippet"],
-  "ref_corpus_ids": ["22612890", "46562341"],
-  "depth": 0,
-  "source_paper": { "corpus_id": "CorpusId:2762329", "role": "atlas" },
-  "retrieval_method": "corpus_snippet"
-}
-```
+### Hop 0 — summarize (produce evidence)
 
-3. Extract referenced CorpusIds **and their citing sentences** from the ASTA
-   response `annotations` (see "Preserve ASTA annotations" below). Record each
-   referenced CorpusId in `ref_corpus_ids` for the next depth.
-4. Save:
-   - `{output_dir}/depth_0_snippets.json` — raw snippet_search response
-   - `{output_dir}/depth_0_summaries.json` — array of per-snippet summaries
+4. Distill each annotated_snippet into an **evidence_summary**
+   (`evidence_summary.schema.json`): `source_paper`, `retrieval_method`,
+   `section`, `score`, `summary` (1-3 sentences), and `quotes` (exact substrings
+   of `text`). Do **not** copy `sentences` / `refMentions` into the summary.
+   Hop-0 items have no `reached_from`.
 
-### Depth 1..N: Follow references
+### Hops 1..depth — sentence-gated follow
 
-5. Take unique corpus IDs from previous depth's refs.
-6. Remove already-visited IDs (maintain visited set).
-7. If fewer than 3 new IDs, stop.
-8. Call `snippet_search(query="<query>", paper_ids="CorpusId:<new_ids>", limit=20)`
-9. Process each snippet. These papers were reached by following a citation, so:
-   - `source_paper.role` = `external` (unless you know the paper is a corpus member).
-   - `retrieval_method` = `citation_traversal`.
-   - Populate **`reached_from`** with the citing paper and the exact citing
-     sentence captured at the previous depth:
+5. **Build the frontier** from the previous hop's annotated snippets. For each
+   `refMention`:
+   a. Find the `sentences` span that **contains** the refMention's `[start,end)`
+      offsets — that sentence is the **citation context**.
+   b. **Gate** the sentence (biological claim vs methods citation). Drop if methods.
+   c. If on-topic and `resolved` (has `corpus_id`): add
+      `(corpus_id, reached_from={corpus_id: <citing paper>, hop: <n>,
+      citation_context: <the sentence>})` to the frontier.
+   d. If on-topic but **`corpus_id` is null** (unresolved): **log** it to
+      `{output_dir}/unresolved_edges.json` (`{reached_from, citation_context,
+      snippet_ref}`) — a followable edge we cannot follow. Never silently drop.
+6. **Dedup + caps:** drop already-visited CorpusIds (maintain a visited set).
+   Apply `k_per_paper` per citing paper per hop; if a paper's surviving edges
+   exceed it, keep the highest-`score` snippets' edges and **log the overflow**
+   to `{output_dir}/overflow.json`. Stop adding once `run_cap` distinct papers
+   have been searched (log that the cap was hit).
+7. **Follow:** for each surviving CorpusId,
+   `snippet_search(query="<query>", paper_ids="CorpusId:<id>", limit=20)`.
+   These snippets were reached by following a citation, so:
+   - `source_paper.role = "external"` (unless known to be a corpus member),
+   - `retrieval_method = "citation_traversal"`,
+   - attach the `reached_from` (`corpus_id`, `hop`, `citation_context`) recorded in 5c.
+8. Save annotated snippets to `{output_dir}/annotated_snippets_hop<n>.json`,
+   then summarize (step 4) into evidence_summary items carrying `reached_from`.
+9. Repeat until `depth` hops are done or the frontier empties.
 
-```json
-{
-  "summary": "…export via ferroportin activity…",
-  "quotes": ["export via ferroportin activity"],
-  "depth": 1,
-  "source_paper": { "corpus_id": "CorpusId:252635104", "role": "external" },
-  "retrieval_method": "citation_traversal",
-  "reached_from": {
-    "corpus_id": "CorpusId:231699447",
-    "citation_context": "<the citing sentence from the depth-0 paper>"
-  }
-}
-```
+### Final — merge + catalogue
 
-10. Save files. Repeat until depth limit or no new IDs.
-
-### Final: Resolve metadata
-
-11. Collect ALL unique corpus IDs from all depths (seed + every `source_paper`
-    and `reached_from`).
-12. Call `get_paper_batch(ids=[...], fields="title,authors,year,venue,publicationDate,url,isOpenAccess,externalIds")`.
-13. Save to `{output_dir}/paper_catalogue.json`, keyed by `CorpusId:NNNN`. Every
-    `source_paper` and `reached_from` you emit must have its CorpusId (or DOI)
-    present here.
+10. Merge all hops' evidence_summary items into `{output_dir}/all_summaries.json`
+    (array conforming to `all_summaries.schema.json`).
+11. Collect every CorpusId seen (seed + `source_paper` + `reached_from`) and
+    `get_paper_batch(ids=[...], fields="title,authors,year,venue,publicationDate,url,isOpenAccess,externalIds")`;
+    write `{output_dir}/paper_catalogue.json`, keyed by `CorpusId:NNNN`. Every
+    `source_paper` / `reached_from` identifier you emit must appear here.
 
 ## Output
 
-- `{output_dir}/all_summaries.json` — merged summaries from all depths, conforming to
-  `src/atlas_chat/atlas_chat/schemas/all_summaries.schema.json`
-- `{output_dir}/paper_catalogue.json` — metadata for all discovered papers
+- `{output_dir}/all_summaries.json` — array of **evidence_summary** items
+  (`all_summaries.schema.json` / `evidence_summary.schema.json`).
+- `{output_dir}/annotated_snippets_hop<n>.json` — raw **annotated_snippet**
+  records per hop (`annotated_snippet.schema.json`).
+- `{output_dir}/paper_catalogue.json` — metadata for every paper referenced.
+- `{output_dir}/unresolved_edges.json` — on-topic edges with null CorpusId.
+- `{output_dir}/overflow.json` — edges dropped by `k_per_paper` / `run_cap`.
 
-## Preserve ASTA annotations (issue #12)
+## Edge extraction — use ASTA structure, not regex
 
-ASTA returns citation-context data alongside each snippet — do **not** discard it:
-
-- Each snippet result carries `annotations.refMentions`: spans in the snippet
-  text that cite another paper, each with a `matchedPaperCorpusId`.
-- `annotations.sentences` gives sentence spans over the same snippet text.
-- For each `refMention`, find the `sentences` span that **contains** the
-  refMention's character offsets — that sentence is the **citation context**.
-- Use `matchedPaperCorpusId` to populate `ref_corpus_ids` (the traversal
-  frontier) and, at the next depth, `reached_from.corpus_id`; use the containing
-  sentence as `reached_from.citation_context`.
-
-## CorpusId Retrieval
-
-`snippet_search` is the canonical way to get CorpusIds via MCP:
-- Each snippet result includes `paper.corpusId` in its metadata.
-- For papers referenced within a snippet, check `matchedPaperCorpusId` (in
-  `annotations.refMentions`).
-- Do NOT attempt to get CorpusId from `get_paper` fields — it is not
-  available there. Do NOT use `curl` or `WebFetch` to call the S2 API.
+- Take referenced papers from `annotations.refMentions[].matchedPaperCorpusId`.
+  **Do not** regex CorpusId patterns out of snippet text — that path is removed.
+- Build `citation_context` from the `annotations.sentences` span that contains
+  the refMention offsets — never fabricate or paraphrase the sentence.
+- `matchedPaperCorpusId == null` → `resolved: false`; log if on-topic (5d).
+- Do NOT use `curl` / `WebFetch` for the S2 API; do NOT read CorpusId from
+  `get_paper` fields.
 
 ## Rules
 
-- **Summarize each snippet as it is returned.** Do not batch.
-- **Never search for seeds.** Only traverse from what you're given.
-- **Maintain a visited set.** Never search the same corpus ID twice.
-- **Write files incrementally.** Each depth's results saved before next.
-- **Quotes must be exact substrings** of the snippet text.
-- **Every item must carry `source_paper` (with `role`) and `retrieval_method`.**
-- Extract CorpusIds and citation context directly from ASTA snippet `annotations`.
+- **Sentence-gated, not follow-all.** Every followed edge has an on-topic
+  containing sentence; methods/tool/dataset citations are dropped.
+- **Never re-score references numerically.** Reuse ASTA `score`; gate is binary.
+- **Never search a seed you weren't given; never revisit a CorpusId.**
+- **Write incrementally** — each hop's annotated snippets before summarizing.
+- **Quotes are exact substrings** of the snippet `text`.
+- **Every evidence item carries `source_paper` (+`role`) and `retrieval_method`;**
+  traversed items also carry `reached_from` (`corpus_id`/`doi`, `hop`,
+  `citation_context`).
+- **Log, don't silently drop:** unresolved on-topic edges and cap overflow.

--- a/.claude/agents/citation-traverse.md
+++ b/.claude/agents/citation-traverse.md
@@ -1,6 +1,6 @@
 ---
 name: citation-traverse
-description: ASTA-native, sentence-gated citation walk. Seeds from the atlas paper, follows the structured refMentions ASTA returns (not regex-over-text), keeps only citations whose containing sentence makes a biological claim about the cell type (drops methods/tool/dataset citations), and emits uniform provenance-tagged evidence. ASTA-only — no local/PDF edge sources.
+description: Given a query and a seed paper, search ASTA snippets, keep the snippet sentences relevant to the query, follow the references those sentences cite, and return provenance-tagged evidence carrying the citing sentence as context.
 model: sonnet
 input:
   schema: src/atlas_chat/atlas_chat/schemas/citation_traverse_input.schema.json
@@ -8,15 +8,14 @@ output:
   schema: src/atlas_chat/atlas_chat/schemas/all_summaries.schema.json
 ---
 
-# Subagent: Citation Traversal (ASTA-native, sentence-gated)
+# Subagent: Citation Traversal
 
-You perform a real citation walk over ASTA (Semantic Scholar) snippet search.
-You consume the structured citation edges ASTA already returns, gate following
-at the **sentence** level, and emit uniform, provenance-tagged evidence.
+Walk citations over ASTA (Semantic Scholar) snippet search. Given a **query**
+and a **seed paper**, you: retrieve snippets, keep the sentences relevant to the
+query, follow the references those sentences cite, and emit uniform,
+provenance-tagged evidence that carries the citing sentence as context.
 
-This contract is **ASTA-only**. Routing to local-index / PDF edge sources and
-the context-less `get_paper(references)` fallback are out of scope (separate
-ticket). Do not edit the deprecated `services/citation_traverser.py`.
+The query defines relevance — it is passed in, not defined here.
 
 ## Input
 
@@ -24,92 +23,77 @@ ticket). Do not edit the deprecated `services/citation_traverser.py`.
 {
   "seed_paper_id": "CorpusId:2762329 | DOI:10.1038/... | PMID:...",
   "seed_role": "atlas",
-  "query": "{label} / {resolved_name} in {scope} {tissue}: location, structure, function, markers",
+  "query": "<the search query to gather evidence for>",
   "depth": 1,
   "k_per_paper": 10,
   "run_cap": 50,
   "score_threshold": 0.0,
-  "output_dir": "projects/{project}/traversal_output/{cell_type}"
+  "output_dir": "<traversal output directory>"
 }
 ```
 
-- `seed_role` — `atlas` (default) or `subatlas`; the role stamped on hop-0 evidence.
-- `depth` — **fixed** number of hops to follow (default 1). Dynamic-to-evidence
-  depth is out of scope.
-- `k_per_paper` — breadth cap: max surviving edges followed **per paper per hop**
-  (default 10). This is a **safety budget for hub papers**, not the relevance
-  filter — the sentence gate is the filter.
-- `run_cap` — max distinct papers searched across the whole run (default 50).
-- `score_threshold` — optional coarse snippet-`score` floor before the sentence gate.
+- `seed_role` — the provenance role stamped on hop-0 evidence (`atlas` or `subatlas`).
+- `depth` — number of citation hops to follow (default 1).
+- `k_per_paper` — max references followed per paper per hop (safety cap for hub papers).
+- `run_cap` — max distinct papers searched across the run.
+- `score_threshold` — optional snippet-`score` floor applied before the sentence gate.
 
-## Key principle — gate at the sentence, do not re-score refs
+## Relevance gate — at the sentence, using the ASTA score
 
-Retrieval already did the relevance work: a snippet is returned *because* it
-matched the query and carries a `score`. **Do not** assign your own numeric
-relevance to references — LLM numeric scores are poorly calibrated and would
-double-count retrieval. Instead refine the gate from snippet-level (follow-all,
-a funnel) to **sentence-level**, using the `sentences` spans ASTA returns.
-
-**Follow a `refMention` iff its containing sentence makes a biological claim
-about the cell type.** Drop refs whose sentence is a methods/tool/dataset
-citation — e.g. *"aligned with BWA [42]," "integrated with Harmony [71],"
-"clustered in Seurat [88]."* ASTA `refMentions` carry no intent; the containing
-sentence reveals it. The gate is binary per ref-bearing sentence:
-
-> **biological claim about the cell type → follow; methods/tooling/dataset
-> citation → drop.**
+- Use the ASTA snippet `score` as the retrieval relevance signal. Do **not**
+  assign your own numeric relevance to references.
+- For each reference mention, make one binary decision: **is the sentence
+  containing it relevant to the query?** Follow references in relevant
+  sentences; drop references in sentences incidental to the query (for example
+  methods, tool, or dataset citations).
 
 ## Procedure
 
 ### Hop 0 — seed retrieval
 
 1. `snippet_search(query="<query>", paper_ids="<seed_paper_id>", limit=20)`.
-   Hop-0 snippets are from the seed paper, so `source_paper.role = seed_role`
-   and `retrieval_method = "corpus_snippet"`.
-2. For each returned snippet, build an **annotated_snippet** record
+   Hop-0 snippets come from the seed paper: `source_paper.role = seed_role`,
+   `retrieval_method = "corpus_snippet"`.
+2. For each snippet, build an **annotated_snippet** record
    (`annotated_snippet.schema.json`) capturing the ASTA structure verbatim:
-   - `text`, `section`, `score`
-   - `source_paper` (from the snippet's paper CorpusId / DOI), `retrieval_method`
+   - `text`, `section`, `score`, `source_paper`, `retrieval_method`
    - `sentences` — the `annotations.sentences` spans
    - `refMentions` — the `annotations.refMentions` spans; each carries
      `corpus_id` (the `matchedPaperCorpusId`, or `null` if unresolved) and
      `resolved` (`corpus_id != null`)
 3. Save hop-0 annotated snippets to `{output_dir}/annotated_snippets_hop0.json`.
 
-### Hop 0 — summarize (produce evidence)
+### Hop 0 — summarize
 
 4. Distill each annotated_snippet into an **evidence_summary**
    (`evidence_summary.schema.json`): `source_paper`, `retrieval_method`,
-   `section`, `score`, `summary` (1-3 sentences), and `quotes` (exact substrings
-   of `text`). Do **not** copy `sentences` / `refMentions` into the summary.
-   Hop-0 items have no `reached_from`.
+   `section`, `score`, `summary` (1-3 sentences), `quotes` (exact substrings of
+   `text`). Do not copy `sentences` / `refMentions` into the summary. Hop-0
+   items have no `reached_from`.
 
-### Hops 1..depth — sentence-gated follow
+### Hops 1..depth — follow relevant references
 
-5. **Build the frontier** from the previous hop's annotated snippets. For each
+5. Build the frontier from the previous hop's annotated snippets. For each
    `refMention`:
    a. Find the `sentences` span that **contains** the refMention's `[start,end)`
       offsets — that sentence is the **citation context**.
-   b. **Gate** the sentence (biological claim vs methods citation). Drop if methods.
-   c. If on-topic and `resolved` (has `corpus_id`): add
-      `(corpus_id, reached_from={corpus_id: <citing paper>, hop: <n>,
-      citation_context: <the sentence>})` to the frontier.
-   d. If on-topic but **`corpus_id` is null** (unresolved): **log** it to
-      `{output_dir}/unresolved_edges.json` (`{reached_from, citation_context,
-      snippet_ref}`) — a followable edge we cannot follow. Never silently drop.
-6. **Dedup + caps:** drop already-visited CorpusIds (maintain a visited set).
-   Apply `k_per_paper` per citing paper per hop; if a paper's surviving edges
-   exceed it, keep the highest-`score` snippets' edges and **log the overflow**
-   to `{output_dir}/overflow.json`. Stop adding once `run_cap` distinct papers
-   have been searched (log that the cap was hit).
-7. **Follow:** for each surviving CorpusId,
-   `snippet_search(query="<query>", paper_ids="CorpusId:<id>", limit=20)`.
-   These snippets were reached by following a citation, so:
-   - `source_paper.role = "external"` (unless known to be a corpus member),
-   - `retrieval_method = "citation_traversal"`,
-   - attach the `reached_from` (`corpus_id`, `hop`, `citation_context`) recorded in 5c.
-8. Save annotated snippets to `{output_dir}/annotated_snippets_hop<n>.json`,
-   then summarize (step 4) into evidence_summary items carrying `reached_from`.
+   b. **Gate** the sentence for relevance to the query. Drop if incidental.
+   c. If relevant and `resolved` (has `corpus_id`): add the reference to the
+      frontier with `reached_from = {corpus_id: <citing paper>, hop: <n>,
+      citation_context: <the sentence>}`.
+   d. If relevant but `corpus_id` is `null` (unresolved): **log** it to
+      `{output_dir}/unresolved_edges.json` — a followable edge that cannot be
+      followed. Never silently drop.
+6. Dedup against a visited set. Apply `k_per_paper` per citing paper per hop; if
+   a paper exceeds it, keep the highest-`score` snippets' references and **log
+   the overflow** to `{output_dir}/overflow.json`. Stop adding once `run_cap`
+   distinct papers have been searched (log that the cap was hit).
+7. Follow each surviving reference:
+   `snippet_search(query="<query>", paper_ids="CorpusId:<id>", limit=20)`, with
+   `source_paper.role = "external"` (unless known to be a corpus member),
+   `retrieval_method = "citation_traversal"`, and the `reached_from` recorded in 5c.
+8. Save annotated snippets to `{output_dir}/annotated_snippets_hop<n>.json`, then
+   summarize (step 4) into evidence_summary items carrying `reached_from`.
 9. Repeat until `depth` hops are done or the frontier empties.
 
 ### Final — merge + catalogue
@@ -123,33 +107,28 @@ sentence reveals it. The gate is binary per ref-bearing sentence:
 
 ## Output
 
-- `{output_dir}/all_summaries.json` — array of **evidence_summary** items
-  (`all_summaries.schema.json` / `evidence_summary.schema.json`).
-- `{output_dir}/annotated_snippets_hop<n>.json` — raw **annotated_snippet**
-  records per hop (`annotated_snippet.schema.json`).
+- `{output_dir}/all_summaries.json` — array of **evidence_summary** items.
+- `{output_dir}/annotated_snippets_hop<n>.json` — raw **annotated_snippet** records per hop.
 - `{output_dir}/paper_catalogue.json` — metadata for every paper referenced.
-- `{output_dir}/unresolved_edges.json` — on-topic edges with null CorpusId.
-- `{output_dir}/overflow.json` — edges dropped by `k_per_paper` / `run_cap`.
+- `{output_dir}/unresolved_edges.json` — relevant edges with a null CorpusId.
+- `{output_dir}/overflow.json` — references dropped by `k_per_paper` / `run_cap`.
 
-## Edge extraction — use ASTA structure, not regex
+## Edge extraction — use ASTA structure
 
 - Take referenced papers from `annotations.refMentions[].matchedPaperCorpusId`.
-  **Do not** regex CorpusId patterns out of snippet text — that path is removed.
 - Build `citation_context` from the `annotations.sentences` span that contains
   the refMention offsets — never fabricate or paraphrase the sentence.
-- `matchedPaperCorpusId == null` → `resolved: false`; log if on-topic (5d).
-- Do NOT use `curl` / `WebFetch` for the S2 API; do NOT read CorpusId from
-  `get_paper` fields.
+- `matchedPaperCorpusId == null` → `resolved: false`; log if the sentence is relevant (5d).
+- Do NOT use `curl` / `WebFetch` for the S2 API; do NOT read CorpusId from `get_paper` fields.
 
 ## Rules
 
-- **Sentence-gated, not follow-all.** Every followed edge has an on-topic
-  containing sentence; methods/tool/dataset citations are dropped.
-- **Never re-score references numerically.** Reuse ASTA `score`; gate is binary.
-- **Never search a seed you weren't given; never revisit a CorpusId.**
-- **Write incrementally** — each hop's annotated snippets before summarizing.
-- **Quotes are exact substrings** of the snippet `text`.
-- **Every evidence item carries `source_paper` (+`role`) and `retrieval_method`;**
-  traversed items also carry `reached_from` (`corpus_id`/`doi`, `hop`,
-  `citation_context`).
-- **Log, don't silently drop:** unresolved on-topic edges and cap overflow.
+- Gate at the sentence: follow only references whose containing sentence is
+  relevant to the query.
+- Reuse the ASTA `score`; never assign your own numeric relevance to references.
+- Never search a seed you weren't given; never revisit a CorpusId.
+- Write incrementally — each hop's annotated snippets before summarizing.
+- Quotes are exact substrings of the snippet `text`.
+- Every evidence item carries `source_paper` (+`role`) and `retrieval_method`;
+  followed items also carry `reached_from` (`corpus_id`/`doi`, `hop`, `citation_context`).
+- Log, don't silently drop: unresolved relevant edges and cap overflow.

--- a/.claude/agents/citation-traverse.md
+++ b/.claude/agents/citation-traverse.md
@@ -1,6 +1,6 @@
 ---
 name: citation-traverse
-description: Given a query and a seed paper, search ASTA snippets, keep the snippet sentences relevant to the query, follow the references those sentences cite, and return provenance-tagged evidence carrying the citing sentence as context.
+description: Given a query and a seed paper, walk citations over ASTA snippet search. Retrieval, reference splicing, and follow-set resolution run programmatically (raw JSON never enters your context); you gate sentences on the spliced text and propose which citations to follow.
 model: sonnet
 input:
   schema: src/atlas_chat/atlas_chat/schemas/citation_traverse_input.schema.json
@@ -10,10 +10,16 @@ output:
 
 # Subagent: Citation Traversal
 
-Walk citations over ASTA (Semantic Scholar) snippet search. Given a **query**
-and a **seed paper**, you: retrieve snippets, keep the sentences relevant to the
-query, follow the references those sentences cite, and emit uniform,
-provenance-tagged evidence that carries the citing sentence as context.
+Walk citations over ASTA (Semantic Scholar) snippet search. Given a **query** and a
+**seed paper**, you retrieve snippets, keep the sentences relevant to the query,
+follow the references those sentences cite, and emit uniform, provenance-tagged
+evidence.
+
+Retrieval and reference handling are **programmatic** — the `atlas_chat.cli_annotate`
+CLI fetches from ASTA, splices each citation into the snippet text as an inline
+`[CorpusId:NNNN]` token, and writes slim records to disk. You never see the raw
+snippet payload. Your judgement is applied at one place: deciding which sentences
+answer the query and which citations to follow.
 
 The query defines relevance — it is passed in, not defined here.
 
@@ -21,114 +27,114 @@ The query defines relevance — it is passed in, not defined here.
 
 ```json
 {
-  "seed_paper_id": "CorpusId:2762329 | DOI:10.1038/... | PMID:...",
+  "seed_paper_id": "CorpusId:NNNN | DOI:10.1038/... | PMID:...",
   "seed_role": "atlas",
   "query": "<the search query to gather evidence for>",
   "depth": 1,
-  "k_per_paper": 10,
-  "run_cap": 50,
-  "score_threshold": 0.0,
   "output_dir": "<traversal output directory>"
 }
 ```
 
 - `seed_role` — the provenance role stamped on hop-0 evidence (`atlas` or `subatlas`).
 - `depth` — number of citation hops to follow (default 1).
-- `k_per_paper` — max references followed per paper per hop (safety cap for hub papers).
-- `run_cap` — max distinct papers searched across the run.
-- `score_threshold` — optional snippet-`score` floor applied before the sentence gate.
-
-## Relevance gate — at the sentence, using the ASTA score
-
-- Use the ASTA snippet `score` as the retrieval relevance signal. Do **not**
-  assign your own numeric relevance to references.
-- For each reference mention, make one binary decision: **is the sentence
-  containing it relevant to the query?** Follow references in relevant
-  sentences; drop references in sentences incidental to the query (for example
-  methods, tool, or dataset citations).
 
 ## Procedure
 
-### Hop 0 — seed retrieval
+### Hop 0 — retrieve (programmatic)
 
-1. `snippet_search(query="<query>", paper_ids="<seed_paper_id>", limit=20)`.
-   Hop-0 snippets come from the seed paper: `source_paper.role = seed_role`,
-   `retrieval_method = "corpus_snippet"`.
-2. For each snippet, build an **annotated_snippet** record
-   (`annotated_snippet.schema.json`) capturing the ASTA structure verbatim:
-   - `text`, `section`, `score`, `source_paper`, `retrieval_method`
-   - `sentences` — the `annotations.sentences` spans
-   - `refMentions` — the `annotations.refMentions` spans; each carries
-     `corpus_id` (the `matchedPaperCorpusId`, or `null` if unresolved) and
-     `resolved` (`corpus_id != null`)
-3. Save hop-0 annotated snippets to `{output_dir}/annotated_snippets_hop0.json`.
+Run:
+
+```
+python -m atlas_chat.cli_annotate fetch \
+  --query "<query>" --paper-ids "<seed_paper_id>" --limit 20 \
+  --role <seed_role> --retrieval-method corpus_snippet --hop 0 \
+  --out <output_dir>/annotated_snippets_hop0.json
+```
+
+Then read the slim records. Each has:
+- `text` — verbatim snippet text (the exact-substring quote source).
+- `annotated_text` — the same text with citations shown inline as `[CorpusId:NNNN]`
+  (resolved) or `[CorpusId:unresolved]` (ASTA could not resolve the citation).
+- `section`, `score`, `sentences`, `refMentions`.
+
+Use the CLI's `show` subcommand if you prefer to read `annotated_text` record by
+record rather than opening the file.
+
+### Gate + propose (read `annotated_text`)
+
+For each snippet, decide which sentences are relevant to the query. Propose the
+citations relevant to the query — the `[CorpusId:NNNN]` tokens that carry a
+query-relevant claim — drawn from each relevant sentence **and its immediately
+adjacent sentences**. Look to the adjacent sentence because a claim's supporting
+reference often sits just outside the sentence stating it (the claim sentence may
+carry no citation of its own). Narrow within the sentence too: a sentence may cite
+several papers — propose only the citations that bear on the query, not every token
+present. A `[CorpusId:unresolved]` token marks a citation ASTA could not resolve —
+record it in `<output_dir>/unresolved_edges.json` (with the citing sentence); it
+cannot be followed. Quote only from `text`, never from `annotated_text`.
 
 ### Hop 0 — summarize
 
-4. Distill each annotated_snippet into an **evidence_summary**
-   (`evidence_summary.schema.json`): `source_paper`, `retrieval_method`,
-   `section`, `score`, `summary` (1-3 sentences), `quotes` (exact substrings of
-   `text`). Do not copy `sentences` / `refMentions` into the summary. Hop-0
-   items have no `reached_from`.
+Distill each relevant snippet into an **evidence_summary**
+(`evidence_summary.schema.json`): `source_paper`, `retrieval_method`, `section`,
+`score`, `summary` (1-3 sentences), `quotes` (exact substrings of `text`). Do not
+copy `sentences` / `refMentions` / `annotated_text` into the summary. Hop-0 items
+have no `reached_from`.
 
 ### Hops 1..depth — follow relevant references
 
-5. Build the frontier from the previous hop's annotated snippets. For each
-   `refMention`:
-   a. Find the `sentences` span that **contains** the refMention's `[start,end)`
-      offsets — that sentence is the **citation context**.
-   b. **Gate** the sentence for relevance to the query. Drop if incidental.
-   c. If relevant and `resolved` (has `corpus_id`): add the reference to the
-      frontier with `reached_from = {corpus_id: <citing paper>, hop: <n>,
-      citation_context: <the sentence>}`.
-   d. If relevant but `corpus_id` is `null` (unresolved): **log** it to
-      `{output_dir}/unresolved_edges.json` — a followable edge that cannot be
-      followed. Never silently drop.
-6. Dedup against a visited set. Apply `k_per_paper` per citing paper per hop; if
-   a paper exceeds it, keep the highest-`score` snippets' references and **log
-   the overflow** to `{output_dir}/overflow.json`. Stop adding once `run_cap`
-   distinct papers have been searched (log that the cap was hit).
-7. Follow each surviving reference:
-   `snippet_search(query="<query>", paper_ids="CorpusId:<id>", limit=20)`, with
-   `source_paper.role = "external"` (unless known to be a corpus member),
-   `retrieval_method = "citation_traversal"`, and the `reached_from` recorded in 5c.
-8. Save annotated snippets to `{output_dir}/annotated_snippets_hop<n>.json`, then
-   summarize (step 4) into evidence_summary items carrying `reached_from`.
-9. Repeat until `depth` hops are done or the frontier empties.
+1. Resolve the follow-set programmatically (anti-hallucination check):
+
+   ```
+   python -m atlas_chat.cli_annotate follow-set \
+     --snippets <output_dir>/annotated_snippets_hop<n>.json \
+     --proposed CorpusId:... [--proposed CorpusId:...] --hop <n+1> \
+     --out <output_dir>/follow_set_hop<n+1>.json
+   ```
+
+   Follow only the returned `follow_set` (deduped; any proposed id not present in the
+   snippets' references is dropped to `rejected`).
+
+2. For each id in `follow_set`, retrieve its snippets — pass the citing sentence as
+   `reached_from` so followed evidence carries its provenance:
+
+   ```
+   python -m atlas_chat.cli_annotate fetch \
+     --query "<query>" --paper-ids CorpusId:<id> --limit 20 \
+     --role external --retrieval-method citation_traversal --hop <n> \
+     --reached-from '{"corpus_id":"<citing paper>","hop":<n>,"citation_context":"<citing sentence>"}' \
+     --out <output_dir>/annotated_snippets_hop<n>.json
+   ```
+
+3. Gate + propose + summarize as above. Never revisit a CorpusId already searched.
+   Repeat until `depth` hops are done or the follow-set is empty.
 
 ### Final — merge + catalogue
 
-10. Merge all hops' evidence_summary items into `{output_dir}/all_summaries.json`
-    (array conforming to `all_summaries.schema.json`).
-11. Collect every CorpusId seen (seed + `source_paper` + `reached_from`) and
-    `get_paper_batch(ids=[...], fields="title,authors,year,venue,publicationDate,url,isOpenAccess,externalIds")`;
-    write `{output_dir}/paper_catalogue.json`, keyed by `CorpusId:NNNN`. Every
-    `source_paper` / `reached_from` identifier you emit must appear here.
+- Merge all hops' evidence_summary items into `<output_dir>/all_summaries.json`
+  (array conforming to `all_summaries.schema.json`).
+- Collect every CorpusId seen (seed + `source_paper` + `reached_from`) and call the
+  `get_paper_batch` MCP tool
+  (`fields="title,authors,year,venue,publicationDate,url,isOpenAccess,externalIds"`);
+  write `<output_dir>/paper_catalogue.json`, keyed by `CorpusId:NNNN`. Every
+  `source_paper` / `reached_from` identifier you emit must appear here.
 
 ## Output
 
-- `{output_dir}/all_summaries.json` — array of **evidence_summary** items.
-- `{output_dir}/annotated_snippets_hop<n>.json` — raw **annotated_snippet** records per hop.
-- `{output_dir}/paper_catalogue.json` — metadata for every paper referenced.
-- `{output_dir}/unresolved_edges.json` — relevant edges with a null CorpusId.
-- `{output_dir}/overflow.json` — references dropped by `k_per_paper` / `run_cap`.
-
-## Edge extraction — use ASTA structure
-
-- Take referenced papers from `annotations.refMentions[].matchedPaperCorpusId`.
-- Build `citation_context` from the `annotations.sentences` span that contains
-  the refMention offsets — never fabricate or paraphrase the sentence.
-- `matchedPaperCorpusId == null` → `resolved: false`; log if the sentence is relevant (5d).
-- Do NOT use `curl` / `WebFetch` for the S2 API; do NOT read CorpusId from `get_paper` fields.
+- `<output_dir>/annotated_snippets_hop<n>.json` — slim records with `annotated_text` (from the CLI).
+- `<output_dir>/follow_set_hop<n>.json` — the deduped follow-set + rejects (from the CLI).
+- `<output_dir>/all_summaries.json` — array of evidence_summary items.
+- `<output_dir>/paper_catalogue.json` — metadata for every paper referenced.
+- `<output_dir>/unresolved_edges.json` — relevant citations with `[CorpusId:unresolved]`.
 
 ## Rules
 
-- Gate at the sentence: follow only references whose containing sentence is
-  relevant to the query.
-- Reuse the ASTA `score`; never assign your own numeric relevance to references.
+- Do not call the ASTA `snippet_search` MCP tool — retrieval goes through the CLI so
+  raw JSON never enters your context. `get_paper_batch` for the catalogue is fine.
+- Gate at the sentence: follow only citations whose claim is relevant to the query.
+- Follow only ids returned in the CLI `follow_set`; never invent or hand-edit ids.
 - Never search a seed you weren't given; never revisit a CorpusId.
-- Write incrementally — each hop's annotated snippets before summarizing.
-- Quotes are exact substrings of the snippet `text`.
+- Quotes are exact substrings of `text`.
 - Every evidence item carries `source_paper` (+`role`) and `retrieval_method`;
   followed items also carry `reached_from` (`corpus_id`/`doi`, `hop`, `citation_context`).
-- Log, don't silently drop: unresolved relevant edges and cap overflow.
+- Log, don't silently drop: unresolved relevant citations (`unresolved_edges.json`).

--- a/.claude/hooks/check_annotated_snippet.py
+++ b/.claude/hooks/check_annotated_snippet.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python
+"""Claude Code hook: validate annotated_snippet output against JSON Schema.
+
+Fires as a PostToolUse hook on Write/Edit to the raw traversal records —
+``annotated_snippets_hop<n>.json`` (an array) or any ``*annotated_snippet.json``
+(a single record). Validates against ``annotated_snippet.schema.json`` (issue #14).
+
+Exit codes:
+    0 — valid, or file is not an annotated-snippet file, or jsonschema unavailable
+    2 — validation failed (Claude sees stderr and self-corrects)
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+SCHEMA_PATH = Path("src/atlas_chat/atlas_chat/schemas/annotated_snippet.schema.json")
+
+
+def _targets(file_path: str) -> bool:
+    name = Path(file_path).name
+    return name.startswith("annotated_snippets_hop") or name.endswith("annotated_snippet.json")
+
+
+def _errors(data: object, schema: dict) -> list[str]:
+    import jsonschema
+
+    validator = jsonschema.Draft202012Validator(schema)
+    items = data if isinstance(data, list) else [data]
+    errors: list[str] = []
+    for i, item in enumerate(items):
+        prefix = f"[{i}]" if isinstance(data, list) else ""
+        for err in sorted(validator.iter_errors(item), key=lambda e: list(e.path)):
+            path = ".".join(str(p) for p in err.absolute_path)
+            loc = f"{prefix}.{path}" if path else (prefix or "(root)")
+            errors.append(f"{loc}: {err.message}")
+    return errors
+
+
+def main() -> int:
+    try:
+        hook_input = json.loads(sys.stdin.read())
+    except (json.JSONDecodeError, OSError):
+        return 0
+
+    tool_input = hook_input.get("tool_input", {})
+    file_path = tool_input.get("file_path", "")
+    if not file_path or not _targets(file_path):
+        return 0
+
+    content = tool_input.get("content", "")
+    if not content:
+        print(f"{Path(file_path).name} is empty", file=sys.stderr)
+        return 2
+
+    try:
+        data = json.loads(content)
+    except json.JSONDecodeError as exc:
+        print(f"{Path(file_path).name} is not valid JSON: {exc}", file=sys.stderr)
+        return 2
+
+    if not SCHEMA_PATH.exists():
+        return 0
+    try:
+        import jsonschema  # noqa: F401
+    except ImportError:
+        print("jsonschema not available — skipping annotated_snippet check", file=sys.stderr)
+        return 0
+
+    errors = _errors(data, json.loads(SCHEMA_PATH.read_text()))
+    if not errors:
+        return 0
+
+    print("ANNOTATED_SNIPPET VALIDATION FAILED", file=sys.stderr)
+    print(f"Fix these issues and rewrite {Path(file_path).name}:", file=sys.stderr)
+    for error in errors:
+        print(f"  - {error}", file=sys.stderr)
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/hooks/check_annotated_snippet.py
+++ b/.claude/hooks/check_annotated_snippet.py
@@ -3,7 +3,7 @@
 
 Fires as a PostToolUse hook on Write/Edit to the raw traversal records —
 ``annotated_snippets_hop<n>.json`` (an array) or any ``*annotated_snippet.json``
-(a single record). Validates against ``annotated_snippet.schema.json`` (issue #14).
+(a single record). Validates against ``annotated_snippet.schema.json``.
 
 Exit codes:
     0 — valid, or file is not an annotated-snippet file, or jsonschema unavailable

--- a/.claude/hooks/check_evidence_summary.py
+++ b/.claude/hooks/check_evidence_summary.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python
+"""Claude Code hook: validate evidence_summary output against JSON Schema.
+
+Fires as a PostToolUse hook on Write/Edit to ``all_summaries.json`` (an array of
+evidence_summary items) or any ``*evidence_summary.json`` (a single item).
+Validates against ``evidence_summary.schema.json`` (issue #14).
+
+Exit codes:
+    0 — valid, or file is not an evidence-summary file, or jsonschema unavailable
+    2 — validation failed (Claude sees stderr and self-corrects)
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+SCHEMA_PATH = Path("src/atlas_chat/atlas_chat/schemas/evidence_summary.schema.json")
+
+
+def _targets(file_path: str) -> bool:
+    name = Path(file_path).name
+    return name == "all_summaries.json" or name.endswith("evidence_summary.json")
+
+
+def _errors(data: object, schema: dict) -> list[str]:
+    import jsonschema
+
+    validator = jsonschema.Draft202012Validator(schema)
+    # all_summaries.json is an array of items; a lone evidence_summary is an object.
+    items = data if isinstance(data, list) else [data]
+    errors: list[str] = []
+    for i, item in enumerate(items):
+        prefix = f"[{i}]" if isinstance(data, list) else ""
+        for err in sorted(validator.iter_errors(item), key=lambda e: list(e.path)):
+            path = ".".join(str(p) for p in err.absolute_path)
+            loc = f"{prefix}.{path}" if path else (prefix or "(root)")
+            errors.append(f"{loc}: {err.message}")
+    return errors
+
+
+def main() -> int:
+    try:
+        hook_input = json.loads(sys.stdin.read())
+    except (json.JSONDecodeError, OSError):
+        return 0
+
+    tool_input = hook_input.get("tool_input", {})
+    file_path = tool_input.get("file_path", "")
+    if not file_path or not _targets(file_path):
+        return 0
+
+    content = tool_input.get("content", "")
+    if not content:
+        print(f"{Path(file_path).name} is empty", file=sys.stderr)
+        return 2
+
+    try:
+        data = json.loads(content)
+    except json.JSONDecodeError as exc:
+        print(f"{Path(file_path).name} is not valid JSON: {exc}", file=sys.stderr)
+        return 2
+
+    if not SCHEMA_PATH.exists():
+        return 0
+    try:
+        import jsonschema  # noqa: F401
+    except ImportError:
+        print("jsonschema not available — skipping evidence_summary check", file=sys.stderr)
+        return 0
+
+    errors = _errors(data, json.loads(SCHEMA_PATH.read_text()))
+    if not errors:
+        return 0
+
+    print("EVIDENCE_SUMMARY VALIDATION FAILED", file=sys.stderr)
+    print(f"Fix these issues and rewrite {Path(file_path).name}:", file=sys.stderr)
+    for error in errors:
+        print(f"  - {error}", file=sys.stderr)
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/hooks/check_evidence_summary.py
+++ b/.claude/hooks/check_evidence_summary.py
@@ -3,7 +3,7 @@
 
 Fires as a PostToolUse hook on Write/Edit to ``all_summaries.json`` (an array of
 evidence_summary items) or any ``*evidence_summary.json`` (a single item).
-Validates against ``evidence_summary.schema.json`` (issue #14).
+Validates against ``evidence_summary.schema.json``.
 
 Exit codes:
     0 — valid, or file is not an evidence-summary file, or jsonschema unavailable

--- a/.claude/hooks/check_follow_set.py
+++ b/.claude/hooks/check_follow_set.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python
+"""Claude Code hook: validate follow_set output against JSON Schema.
+
+Fires as a PostToolUse hook on Write/Edit to the follow-set records —
+``follow_set_hop<n>.json`` — validating against ``follow_set.schema.json``. This
+checks the *shape* only; the intersection correctness (proposed ∩ real refMentions)
+is guaranteed by ``services.snippet_annotator.resolve_follow_set``.
+
+Exit codes:
+    0 — valid, or file is not a follow-set file, or jsonschema unavailable
+    2 — validation failed (Claude sees stderr and self-corrects)
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+SCHEMA_PATH = Path("src/atlas_chat/atlas_chat/schemas/follow_set.schema.json")
+
+
+def _targets(file_path: str) -> bool:
+    name = Path(file_path).name
+    return name.startswith("follow_set_hop") or name.endswith("follow_set.json")
+
+
+def _errors(data: object, schema: dict) -> list[str]:
+    import jsonschema
+
+    validator = jsonschema.Draft202012Validator(schema)
+    errors: list[str] = []
+    for err in sorted(validator.iter_errors(data), key=lambda e: list(e.path)):
+        path = ".".join(str(p) for p in err.absolute_path)
+        errors.append(f"{path or '(root)'}: {err.message}")
+    return errors
+
+
+def main() -> int:
+    try:
+        hook_input = json.loads(sys.stdin.read())
+    except (json.JSONDecodeError, OSError):
+        return 0
+
+    tool_input = hook_input.get("tool_input", {})
+    file_path = tool_input.get("file_path", "")
+    if not file_path or not _targets(file_path):
+        return 0
+
+    content = tool_input.get("content", "")
+    if not content:
+        print(f"{Path(file_path).name} is empty", file=sys.stderr)
+        return 2
+
+    try:
+        data = json.loads(content)
+    except json.JSONDecodeError as exc:
+        print(f"{Path(file_path).name} is not valid JSON: {exc}", file=sys.stderr)
+        return 2
+
+    if not SCHEMA_PATH.exists():
+        return 0
+    try:
+        import jsonschema  # noqa: F401
+    except ImportError:
+        print("jsonschema not available — skipping follow_set check", file=sys.stderr)
+        return 0
+
+    errors = _errors(data, json.loads(SCHEMA_PATH.read_text()))
+    if not errors:
+        return 0
+
+    print("FOLLOW_SET VALIDATION FAILED", file=sys.stderr)
+    print(f"Fix these issues and rewrite {Path(file_path).name}:", file=sys.stderr)
+    for error in errors:
+        print(f"  - {error}", file=sys.stderr)
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -14,6 +14,10 @@
           },
           {
             "type": "command",
+            "command": "uv run python .claude/hooks/check_follow_set.py"
+          },
+          {
+            "type": "command",
             "command": "uv run python .claude/hooks/check_cl_mapping.py"
           },
           {

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,31 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "uv run python .claude/hooks/check_annotated_snippet.py"
+          },
+          {
+            "type": "command",
+            "command": "uv run python .claude/hooks/check_evidence_summary.py"
+          },
+          {
+            "type": "command",
+            "command": "uv run python .claude/hooks/check_cl_mapping.py"
+          },
+          {
+            "type": "command",
+            "command": "uv run python .claude/hooks/check_cl_term_request.py"
+          },
+          {
+            "type": "command",
+            "command": "uv run python .claude/hooks/check_report_refs.py"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@ __pycache__/
 .ruff_cache/
 .mypy_cache/
 .pytest_cache/
+.coverage
+coverage.xml
 dist/
 build/
 docs/_build/

--- a/src/atlas_chat/atlas_chat/cli_annotate.py
+++ b/src/atlas_chat/atlas_chat/cli_annotate.py
@@ -1,0 +1,180 @@
+"""Agent-facing CLI for programmatic citation traversal.
+
+Keeps raw ASTA snippet payloads out of the agent's context. Three subcommands:
+
+- ``fetch``: call ASTA ``snippet_search`` (via the project's ``AstaProvider``),
+  splice reference tokens, and write slim ``annotated_snippet`` records to disk.
+  Prints only a tiny summary (counts + path) to stdout.
+- ``follow-set``: intersect the agent's proposed CorpusIds with the ids the
+  annotator emitted, writing the deduped follow-set + rejects.
+- ``show``: print a record's ``annotated_text`` (+ sentence spans) so the agent can
+  read slim content without opening the raw file.
+
+The agent never calls the ASTA MCP tool directly — this service is the sanctioned
+programmatic boundary (same layer as ``services.citation_traverser``), so raw JSON
+never enters the model context regardless of response size.
+
+Examples::
+
+    python -m atlas_chat.cli_annotate fetch \\
+        --query "TML macrophages: location, function, markers" \\
+        --paper-ids CorpusId:273400864 --limit 20 \\
+        --role atlas --retrieval-method corpus_snippet --hop 0 \\
+        --out out/annotated_snippets_hop0.json
+
+    python -m atlas_chat.cli_annotate follow-set \\
+        --snippets out/annotated_snippets_hop0.json \\
+        --proposed CorpusId:248122197 --proposed CorpusId:260956290 \\
+        --hop 1 --out out/follow_set_hop1.json
+
+    python -m atlas_chat.cli_annotate show \\
+        --snippets out/annotated_snippets_hop0.json --index 0
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+from atlas_chat.services import snippet_annotator
+
+ROLES = ("atlas", "subatlas", "external")
+RETRIEVAL_METHODS = ("corpus_snippet", "supplement", "citation_traversal", "free_search")
+
+
+async def _fetch_raw(query: str, paper_ids: str, limit: int) -> Any:
+    """Call ASTA ``snippet_search`` and return the raw normalized payload."""
+    import httpx
+
+    from atlas_chat.services.citation_traverser import _make_provider
+
+    provider = _make_provider()
+    arguments: dict[str, Any] = {"query": query, "limit": limit}
+    if paper_ids:
+        arguments["paper_ids"] = paper_ids
+    async with httpx.AsyncClient(timeout=180) as http_client:
+        return await provider._call_tool(http_client, "snippet_search", arguments)
+
+
+def _fallback_source_id(paper_ids: str) -> dict[str, str]:
+    """Derive a source-paper id from the first --paper-ids token (fallback only)."""
+    first = paper_ids.split(",")[0].strip() if paper_ids else ""
+    if first.startswith("DOI:"):
+        return {"doi": first[len("DOI:") :]}
+    if first.startswith("CorpusId:") and first[len("CorpusId:") :].isdigit():
+        return {"corpus_id": first}
+    return {}
+
+
+def _apply_id_fallback(records: list[dict[str, Any]], fallback: dict[str, str]) -> None:
+    """Ensure every record's source_paper carries an id (ASTA usually supplies one)."""
+    for record in records:
+        source = record["source_paper"]
+        if "corpus_id" not in source and "doi" not in source:
+            source.update(fallback)
+
+
+def _write_json(path: Path, data: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, indent=2, ensure_ascii=False), encoding="utf-8")
+
+
+def _cmd_fetch(args: argparse.Namespace) -> int:
+    raw = asyncio.run(_fetch_raw(args.query, args.paper_ids, args.limit))
+
+    reached_from: dict[str, Any] | None = None
+    if args.reached_from:
+        try:
+            reached_from = json.loads(args.reached_from)
+        except json.JSONDecodeError as exc:
+            print(f"--reached-from is not valid JSON: {exc}", file=sys.stderr)
+            return 2
+
+    records = snippet_annotator.project_response(
+        raw,
+        source_paper={"role": args.role},
+        retrieval_method=args.retrieval_method,
+        reached_from=reached_from,
+        score_threshold=args.score_threshold,
+    )
+    _apply_id_fallback(records, _fallback_source_id(args.paper_ids))
+
+    out = Path(args.out)
+    _write_json(out, records)
+    n_refs = sum(len(r.get("refMentions", [])) for r in records)
+    n_resolved = sum(1 for r in records for m in r.get("refMentions", []) if m.get("resolved"))
+    print(f"fetch: {len(records)} snippets, {n_refs} refMentions ({n_resolved} resolved) -> {out}")
+    return 0
+
+
+def _cmd_follow_set(args: argparse.Namespace) -> int:
+    snippets = json.loads(Path(args.snippets).read_text(encoding="utf-8"))
+    result = snippet_annotator.resolve_follow_set(snippets, args.proposed, hop=args.hop)
+    out = Path(args.out)
+    _write_json(out, result)
+    print(
+        f"follow-set: {len(result['follow_set'])} to follow, "
+        f"{len(result['rejected'])} rejected -> {out}"
+    )
+    return 0
+
+
+def _cmd_show(args: argparse.Namespace) -> int:
+    snippets = json.loads(Path(args.snippets).read_text(encoding="utf-8"))
+    indices = [args.index] if args.index is not None else range(len(snippets))
+    for i in indices:
+        record = snippets[i]
+        print(f"--- [{i}] section={record.get('section', '')} score={record.get('score')}")
+        print(record.get("annotated_text", record.get("text", "")))
+        print(f"sentences: {record.get('sentences', [])}")
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="atlas_chat.cli_annotate", description=__doc__)
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    fetch = sub.add_parser("fetch", help="ASTA snippet_search -> slim annotated records")
+    fetch.add_argument("--query", required=True)
+    fetch.add_argument("--paper-ids", default="", help="comma-separated seed ids (CorpusId:/DOI:)")
+    fetch.add_argument("--limit", type=int, default=20)
+    fetch.add_argument("--role", choices=ROLES, required=True)
+    fetch.add_argument("--retrieval-method", choices=RETRIEVAL_METHODS, required=True)
+    fetch.add_argument(
+        "--hop", type=int, default=0, help="informational; used for the --out filename"
+    )
+    fetch.add_argument(
+        "--reached-from", default="", help="JSON object stamped on every record (hop>=1)"
+    )
+    fetch.add_argument("--score-threshold", type=float, default=0.0)
+    fetch.add_argument("--out", required=True)
+    fetch.set_defaults(func=_cmd_fetch)
+
+    fs = sub.add_parser("follow-set", help="proposed ∩ real refMentions (anti-hallucination)")
+    fs.add_argument("--snippets", required=True, help="annotated_snippets_hop<n>.json")
+    fs.add_argument(
+        "--proposed", action="append", default=[], help="a proposed CorpusId (repeatable)"
+    )
+    fs.add_argument("--hop", type=int, default=None)
+    fs.add_argument("--out", required=True)
+    fs.set_defaults(func=_cmd_follow_set)
+
+    show = sub.add_parser("show", help="print slim annotated_text for a record")
+    show.add_argument("--snippets", required=True)
+    show.add_argument("--index", type=int, default=None)
+    show.set_defaults(func=_cmd_show)
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    return int(args.func(args))
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/atlas_chat/atlas_chat/schemas/all_summaries.schema.json
+++ b/src/atlas_chat/atlas_chat/schemas/all_summaries.schema.json
@@ -12,7 +12,7 @@
     },
     "retrieval_method": {
       "type": "string",
-      "description": "The MECHANISM by which this item was obtained. Orthogonal to source_paper.role.",
+      "description": "The MECHANISM by which this item was obtained. Orthogonal to source_paper.role. 'corpus_snippet' = snippet_search scoped to a corpus paper; 'supplement' = extracted from a supplementary file; 'citation_traversal' = reached by following a citation from another paper; 'free_search' = unscoped snippet/literature search.",
       "enum": ["corpus_snippet", "supplement", "citation_traversal", "free_search"]
     },
     "SourcePaper": {

--- a/src/atlas_chat/atlas_chat/schemas/annotated_snippet.schema.json
+++ b/src/atlas_chat/atlas_chat/schemas/annotated_snippet.schema.json
@@ -6,7 +6,11 @@
   "properties": {
     "text": {
       "type": "string",
-      "description": "The snippet text returned by ASTA snippet_search."
+      "description": "The snippet text returned by ASTA snippet_search. Verbatim; the exact-substring quote source for downstream evidence."
+    },
+    "annotated_text": {
+      "type": "string",
+      "description": "Copy of `text` with each refMention span replaced in place by a standardized inline citation token: '[CorpusId:NNNN]' when resolved, '[CorpusId:unresolved]' when ASTA returned no matchedPaperCorpusId. Produced deterministically right-to-left over descending offsets so `text` is never mutated. Agent-facing input for the sentence gate and follow-id proposal; never quote from this field."
     },
     "section": {
       "type": "string",

--- a/src/atlas_chat/atlas_chat/schemas/annotated_snippet.schema.json
+++ b/src/atlas_chat/atlas_chat/schemas/annotated_snippet.schema.json
@@ -1,0 +1,118 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "AnnotatedSnippet",
+  "description": "Raw retrieval record produced by the ASTA producer during citation traversal (issue #14). Carries the structured citation edges ASTA returns (refMentions + sentences) used to gate following and build citation_context. Builds on issue #12 provenance (source_paper / retrieval_method). Distilled downstream into an evidence_summary; refMentions / sentences do not leak past the summarizer.",
+  "type": "object",
+  "properties": {
+    "text": {
+      "type": "string",
+      "description": "The snippet text returned by ASTA snippet_search."
+    },
+    "section": {
+      "type": "string",
+      "description": "Section the snippet came from (e.g. Results)."
+    },
+    "score": {
+      "type": "number",
+      "description": "ASTA retrieval relevance score (used as the coarse gate; carried through unchanged)."
+    },
+    "source_paper": { "$ref": "#/$defs/SourcePaper" },
+    "retrieval_method": { "$ref": "#/$defs/retrieval_method" },
+    "sentences": {
+      "type": "array",
+      "description": "Sentence spans over `text` (ASTA annotations.sentences). Used to find the sentence containing each refMention.",
+      "items": { "$ref": "#/$defs/Span" }
+    },
+    "refMentions": {
+      "type": "array",
+      "description": "Citation mentions in `text` (ASTA annotations.refMentions). Each carries the matched paper's CorpusId (null when ASTA could not resolve it) and a resolved flag. Off-topic (methods) mentions are filtered by the sentence-level gate.",
+      "items": { "$ref": "#/$defs/RefMention" }
+    },
+    "reached_from": { "$ref": "#/$defs/ReachedFrom" }
+  },
+  "required": ["text", "score", "source_paper", "retrieval_method"],
+  "additionalProperties": false,
+  "$defs": {
+    "role": {
+      "type": "string",
+      "description": "What the source paper IS relative to the corpus, independent of how it was reached.",
+      "enum": ["atlas", "subatlas", "external"]
+    },
+    "retrieval_method": {
+      "type": "string",
+      "description": "The MECHANISM by which this snippet was obtained. Orthogonal to source_paper.role.",
+      "enum": ["corpus_snippet", "supplement", "citation_traversal", "free_search"]
+    },
+    "SourcePaper": {
+      "type": "object",
+      "description": "The paper this snippet came from. At least one of doi / corpus_id must be present.",
+      "properties": {
+        "doi": { "type": "string", "description": "DOI of the source paper." },
+        "corpus_id": {
+          "type": "string",
+          "description": "Semantic Scholar CorpusId, formatted 'CorpusId:NNNN'.",
+          "pattern": "^CorpusId:\\d+$"
+        },
+        "role": { "$ref": "#/$defs/role" }
+      },
+      "required": ["role"],
+      "anyOf": [{ "required": ["doi"] }, { "required": ["corpus_id"] }],
+      "additionalProperties": false
+    },
+    "Span": {
+      "type": "object",
+      "description": "A character span [start, end) over the snippet text.",
+      "properties": {
+        "start": { "type": "integer", "minimum": 0 },
+        "end": { "type": "integer", "minimum": 0 }
+      },
+      "required": ["start", "end"],
+      "additionalProperties": false
+    },
+    "RefMention": {
+      "type": "object",
+      "description": "A citation mention span with its matched paper. corpus_id is null when ASTA returned no matchedPaperCorpusId — a followable edge we cannot resolve (log, don't drop, when on-topic).",
+      "properties": {
+        "start": { "type": "integer", "minimum": 0 },
+        "end": { "type": "integer", "minimum": 0 },
+        "corpus_id": {
+          "description": "Matched paper CorpusId ('CorpusId:NNNN'), or null if unresolved.",
+          "oneOf": [
+            { "type": "string", "pattern": "^CorpusId:\\d+$" },
+            { "type": "null" }
+          ]
+        },
+        "resolved": {
+          "type": "boolean",
+          "description": "True iff corpus_id is non-null (ASTA resolved the mention to a paper)."
+        }
+      },
+      "required": ["start", "end", "corpus_id", "resolved"],
+      "additionalProperties": false
+    },
+    "ReachedFrom": {
+      "type": "object",
+      "description": "For citation_traversal snippets: the corpus paper this reference was reached from, the hop, and the citing sentence.",
+      "properties": {
+        "doi": { "type": "string", "description": "DOI of the citing paper." },
+        "corpus_id": {
+          "type": "string",
+          "description": "CorpusId of the citing paper, formatted 'CorpusId:NNNN'.",
+          "pattern": "^CorpusId:\\d+$"
+        },
+        "hop": {
+          "type": "integer",
+          "description": "Traversal hop at which this reference was reached (seed = 0).",
+          "minimum": 1
+        },
+        "citation_context": {
+          "type": "string",
+          "description": "The exact citing sentence containing the refMention."
+        }
+      },
+      "required": ["hop", "citation_context"],
+      "anyOf": [{ "required": ["doi"] }, { "required": ["corpus_id"] }],
+      "additionalProperties": false
+    }
+  }
+}

--- a/src/atlas_chat/atlas_chat/schemas/annotated_snippet.schema.json
+++ b/src/atlas_chat/atlas_chat/schemas/annotated_snippet.schema.json
@@ -44,7 +44,7 @@
     },
     "retrieval_method": {
       "type": "string",
-      "description": "The MECHANISM by which this snippet was obtained. Orthogonal to source_paper.role.",
+      "description": "The MECHANISM by which this snippet was obtained. Orthogonal to source_paper.role. 'corpus_snippet' = snippet_search scoped to a corpus paper; 'supplement' = extracted from a supplementary file; 'citation_traversal' = reached by following a citation from another paper; 'free_search' = unscoped snippet/literature search.",
       "enum": ["corpus_snippet", "supplement", "citation_traversal", "free_search"]
     },
     "SourcePaper": {

--- a/src/atlas_chat/atlas_chat/schemas/annotated_snippet.schema.json
+++ b/src/atlas_chat/atlas_chat/schemas/annotated_snippet.schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "AnnotatedSnippet",
-  "description": "Raw retrieval record produced by the ASTA producer during citation traversal (issue #14). Carries the structured citation edges ASTA returns (refMentions + sentences) used to gate following and build citation_context. Builds on issue #12 provenance (source_paper / retrieval_method). Distilled downstream into an evidence_summary; refMentions / sentences do not leak past the summarizer.",
+  "description": "Raw retrieval record produced during citation traversal. Carries the structured citation edges ASTA returns (refMentions + sentences), used to gate following and build citation_context, plus source_paper / retrieval_method provenance. Distilled downstream into an evidence_summary; refMentions / sentences do not leak past the summarizer.",
   "type": "object",
   "properties": {
     "text": {

--- a/src/atlas_chat/atlas_chat/schemas/citation_traverse_input.schema.json
+++ b/src/atlas_chat/atlas_chat/schemas/citation_traverse_input.schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "CitationTraverseInput",
-  "description": "Input parameters for the ASTA-native, sentence-gated citation-traverse subagent (issue #14).",
+  "description": "Input parameters for the citation-traverse subagent: a query, a seed paper, and traversal limits.",
   "type": "object",
   "properties": {
     "seed_paper_id": {
@@ -16,17 +16,17 @@
     },
     "query": {
       "type": "string",
-      "description": "Retrieval query, e.g. '{label} / {resolved_name} in {scope} {tissue}: location, structure, function, markers'."
+      "description": "The search query that defines relevance for this traversal."
     },
     "depth": {
       "type": "integer",
-      "description": "Fixed number of hops to follow (0 = seed only). Dynamic-to-evidence depth is out of scope.",
+      "description": "Number of citation hops to follow (0 = seed only).",
       "minimum": 0,
       "default": 1
     },
     "k_per_paper": {
       "type": "integer",
-      "description": "Breadth cap: max surviving edges followed per paper per hop (safety budget for hub papers, not the relevance filter).",
+      "description": "Max references followed per paper per hop (safety cap for hub papers, not the relevance filter).",
       "minimum": 1,
       "default": 10
     },
@@ -43,7 +43,7 @@
     },
     "output_dir": {
       "type": "string",
-      "description": "Traversal output directory, e.g. projects/{project}/traversal_output/{cell_type}."
+      "description": "Directory to write traversal output files to."
     }
   },
   "required": ["seed_paper_id", "query", "output_dir"],

--- a/src/atlas_chat/atlas_chat/schemas/citation_traverse_input.schema.json
+++ b/src/atlas_chat/atlas_chat/schemas/citation_traverse_input.schema.json
@@ -1,0 +1,51 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "CitationTraverseInput",
+  "description": "Input parameters for the ASTA-native, sentence-gated citation-traverse subagent (issue #14).",
+  "type": "object",
+  "properties": {
+    "seed_paper_id": {
+      "type": "string",
+      "description": "Seed paper identifier: 'CorpusId:NNNN', 'DOI:10.xxxx/...', or 'PMID:...'."
+    },
+    "seed_role": {
+      "type": "string",
+      "description": "Role stamped on hop-0 (seed) evidence.",
+      "enum": ["atlas", "subatlas"],
+      "default": "atlas"
+    },
+    "query": {
+      "type": "string",
+      "description": "Retrieval query, e.g. '{label} / {resolved_name} in {scope} {tissue}: location, structure, function, markers'."
+    },
+    "depth": {
+      "type": "integer",
+      "description": "Fixed number of hops to follow (0 = seed only). Dynamic-to-evidence depth is out of scope.",
+      "minimum": 0,
+      "default": 1
+    },
+    "k_per_paper": {
+      "type": "integer",
+      "description": "Breadth cap: max surviving edges followed per paper per hop (safety budget for hub papers, not the relevance filter).",
+      "minimum": 1,
+      "default": 10
+    },
+    "run_cap": {
+      "type": "integer",
+      "description": "Max distinct papers searched across the whole run.",
+      "minimum": 1,
+      "default": 50
+    },
+    "score_threshold": {
+      "type": "number",
+      "description": "Optional coarse snippet-score floor applied before the sentence-level gate.",
+      "default": 0.0
+    },
+    "output_dir": {
+      "type": "string",
+      "description": "Traversal output directory, e.g. projects/{project}/traversal_output/{cell_type}."
+    }
+  },
+  "required": ["seed_paper_id", "query", "output_dir"],
+  "additionalProperties": false
+}

--- a/src/atlas_chat/atlas_chat/schemas/evidence_summary.schema.json
+++ b/src/atlas_chat/atlas_chat/schemas/evidence_summary.schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "EvidenceSummary",
-  "description": "The distilled evidence item the report synthesizer reads (one element of all_summaries.json). Produced by the snippet-summarizer from an annotated_snippet. Traversal machinery (refMentions / sentences) does NOT leak here; provenance (source_paper / retrieval_method / reached_from) does. Builds on the provenance fields from issue #12; adds ASTA-native traversal fields from issue #14.",
+  "description": "The distilled evidence item the report synthesizer reads (one element of all_summaries.json). Produced by the snippet-summarizer from an annotated_snippet. Traversal machinery (refMentions / sentences) does NOT leak here; provenance (source_paper / retrieval_method / reached_from) does.",
   "type": "object",
   "properties": {
     "source_paper": { "$ref": "#/$defs/SourcePaper" },

--- a/src/atlas_chat/atlas_chat/schemas/evidence_summary.schema.json
+++ b/src/atlas_chat/atlas_chat/schemas/evidence_summary.schema.json
@@ -39,7 +39,7 @@
     },
     "retrieval_method": {
       "type": "string",
-      "description": "The MECHANISM by which this item was obtained. Orthogonal to source_paper.role.",
+      "description": "The MECHANISM by which this item was obtained. Orthogonal to source_paper.role. 'corpus_snippet' = snippet_search scoped to a corpus paper; 'supplement' = extracted from a supplementary file; 'citation_traversal' = reached by following a citation from another paper; 'free_search' = unscoped snippet/literature search.",
       "enum": ["corpus_snippet", "supplement", "citation_traversal", "free_search"]
     },
     "SourcePaper": {

--- a/src/atlas_chat/atlas_chat/schemas/evidence_summary.schema.json
+++ b/src/atlas_chat/atlas_chat/schemas/evidence_summary.schema.json
@@ -1,9 +1,36 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "title": "AllSummaries",
-  "description": "Citation-traversal evidence written to all_summaries.json: an array of evidence_summary items. The item shape is the canonical EvidenceSummary (evidence_summary.schema.json) — inlined here because the standalone PostToolUse hook validators cannot resolve cross-file $ref. Keep the two in sync; the schema regression test asserts they agree.",
-  "type": "array",
-  "items": { "$ref": "#/$defs/EvidenceSummary" },
+  "title": "EvidenceSummary",
+  "description": "The distilled evidence item the report synthesizer reads (one element of all_summaries.json). Produced by the snippet-summarizer from an annotated_snippet. Traversal machinery (refMentions / sentences) does NOT leak here; provenance (source_paper / retrieval_method / reached_from) does. Builds on the provenance fields from issue #12; adds ASTA-native traversal fields from issue #14.",
+  "type": "object",
+  "properties": {
+    "source_paper": { "$ref": "#/$defs/SourcePaper" },
+    "retrieval_method": { "$ref": "#/$defs/retrieval_method" },
+    "reached_from": { "$ref": "#/$defs/ReachedFrom" },
+    "source_title": {
+      "type": "string",
+      "description": "Title of the source paper (convenience for the synthesizer's inline citations)."
+    },
+    "section": {
+      "type": "string",
+      "description": "Section the snippet came from (e.g. Results)."
+    },
+    "score": {
+      "type": "number",
+      "description": "ASTA retrieval relevance score for the source snippet (carried through unchanged — not an LLM re-score)."
+    },
+    "summary": {
+      "type": "string",
+      "description": "1-3 sentence summary of the snippet content relevant to the query."
+    },
+    "quotes": {
+      "type": "array",
+      "description": "Exact-substring quotes from the snippet text. Pre-verified so the synthesizer's blockquote rule and report_checker's quote-substring check hold.",
+      "items": { "type": "string" }
+    }
+  },
+  "required": ["source_paper", "retrieval_method", "summary", "quotes"],
+  "additionalProperties": false,
   "$defs": {
     "role": {
       "type": "string",
@@ -53,35 +80,6 @@
       },
       "required": ["hop", "citation_context"],
       "anyOf": [{ "required": ["doi"] }, { "required": ["corpus_id"] }],
-      "additionalProperties": false
-    },
-    "EvidenceSummary": {
-      "type": "object",
-      "description": "One distilled evidence item (mirror of evidence_summary.schema.json).",
-      "properties": {
-        "source_paper": { "$ref": "#/$defs/SourcePaper" },
-        "retrieval_method": { "$ref": "#/$defs/retrieval_method" },
-        "reached_from": { "$ref": "#/$defs/ReachedFrom" },
-        "source_title": {
-          "type": "string",
-          "description": "Title of the source paper (convenience for the synthesizer's inline citations)."
-        },
-        "section": { "type": "string", "description": "Section the snippet came from (e.g. Results)." },
-        "score": {
-          "type": "number",
-          "description": "ASTA retrieval relevance score for the source snippet (carried through unchanged)."
-        },
-        "summary": {
-          "type": "string",
-          "description": "1-3 sentence summary of the snippet content relevant to the query."
-        },
-        "quotes": {
-          "type": "array",
-          "description": "Exact-substring quotes from the snippet text.",
-          "items": { "type": "string" }
-        }
-      },
-      "required": ["source_paper", "retrieval_method", "summary", "quotes"],
       "additionalProperties": false
     }
   }

--- a/src/atlas_chat/atlas_chat/schemas/follow_set.schema.json
+++ b/src/atlas_chat/atlas_chat/schemas/follow_set.schema.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "FollowSet",
+  "description": "Result of the programmatic follow-set resolution for one hop: the deduped CorpusIds to search next (proposed ∩ the real refMention corpus ids the annotator emitted) and the rejected proposals. The intersection is computed by services.snippet_annotator.resolve_follow_set, not by the agent — proposed ids the annotator never emitted are dropped here, so a hallucinated or mistranscribed id can never be followed.",
+  "type": "object",
+  "properties": {
+    "hop": {
+      "type": "integer",
+      "description": "Traversal hop these references will be searched at (seed = 0, so the first followed hop is 1).",
+      "minimum": 1
+    },
+    "follow_set": {
+      "type": "array",
+      "description": "Deduped, order-preserving CorpusIds to follow next: every id appears in the annotated snippets' refMentions.",
+      "items": { "type": "string", "pattern": "^CorpusId:\\d+$" }
+    },
+    "rejected": {
+      "type": "array",
+      "description": "Proposed ids that were not followed, each with the reason.",
+      "items": { "$ref": "#/$defs/Rejected" }
+    }
+  },
+  "required": ["follow_set", "rejected"],
+  "additionalProperties": false,
+  "$defs": {
+    "Rejected": {
+      "type": "object",
+      "properties": {
+        "corpus_id": {
+          "type": "string",
+          "description": "The proposed id (as received) that was rejected."
+        },
+        "reason": {
+          "type": "string",
+          "description": "Why it was dropped: 'not_in_refmentions' = well-formed but absent from the annotated snippets' refMentions (hallucinated / mistranscribed); 'malformed' = not a 'CorpusId:NNNN' string.",
+          "enum": ["not_in_refmentions", "malformed"]
+        }
+      },
+      "required": ["corpus_id", "reason"],
+      "additionalProperties": false
+    }
+  }
+}

--- a/src/atlas_chat/atlas_chat/services/citation_traverser.py
+++ b/src/atlas_chat/atlas_chat/services/citation_traverser.py
@@ -187,6 +187,55 @@ async def traverse(
     return await _search_depth(provider, query, seed_ids, depth)
 
 
+async def traverse_annotated(
+    query: str,
+    paper_id: str,
+    *,
+    role: str = "atlas",
+    retrieval_method: str = "corpus_snippet",
+    reached_from: dict[str, Any] | None = None,
+    limit: int = 20,
+    score_threshold: float = 0.0,
+) -> list[dict[str, Any]]:
+    """Fetch one paper's snippets and return slim annotated_snippet records.
+
+    Shares ``services.snippet_annotator`` with the agentic ``cli_annotate`` path:
+    calls ASTA ``snippet_search`` for ``paper_id``, splices reference tokens inline,
+    and returns records whose ``text`` is verbatim and ``annotated_text`` carries the
+    ``[CorpusId:NNNN]`` / ``[CorpusId:unresolved]`` tokens. Raw JSON is confined to
+    this function.
+
+    Args:
+        query: The relevance query.
+        paper_id: A single seed/target id (``CorpusId:NNNN`` or ``DOI:...``).
+        role: ``source_paper.role`` for the emitted records.
+        retrieval_method: One of the ``retrieval_method`` enum values.
+        reached_from: Citation provenance for followed (hop >= 1) records.
+        limit: Snippet limit passed to ASTA.
+        score_threshold: Coarse score floor applied before the sentence gate.
+
+    Returns:
+        A list of ``annotated_snippet`` dicts.
+    """
+    import httpx
+
+    from atlas_chat.services import snippet_annotator
+
+    provider = _make_provider()
+    arguments: dict[str, Any] = {"query": query, "limit": limit}
+    if paper_id:
+        arguments["paper_ids"] = paper_id
+    async with httpx.AsyncClient(timeout=180) as http_client:
+        raw = await provider._call_tool(http_client, "snippet_search", arguments)
+    return snippet_annotator.project_response(
+        raw,
+        source_paper={"role": role},
+        retrieval_method=retrieval_method,
+        reached_from=reached_from,
+        score_threshold=score_threshold,
+    )
+
+
 async def traverse_local(
     query: str,
     project_dir: Path,

--- a/src/atlas_chat/atlas_chat/services/snippet_annotator.py
+++ b/src/atlas_chat/atlas_chat/services/snippet_annotator.py
@@ -1,0 +1,275 @@
+"""Programmatic ASTA snippet annotation and follow-set resolution.
+
+This module keeps citation-traversal reference handling out of the agent's
+context. It does two deterministic jobs, both pure (stdlib only) so they unit-test
+offline:
+
+1. **Projection + inline ref splicing** (:func:`project_snippet`,
+   :func:`project_response`): turn a raw ASTA ``snippet_search`` response into slim
+   ``annotated_snippet`` records. Each record keeps ``text`` verbatim (the
+   exact-substring quote source) and adds ``annotated_text`` — the same text with
+   every ``refMention`` span replaced *in place* by a standardized inline token
+   (``[CorpusId:NNNN]`` or ``[CorpusId:unresolved]``). The agent reads
+   ``annotated_text`` to gate sentences and propose ids; it never sees the raw
+   payload.
+
+2. **Follow-set resolution** (:func:`resolve_follow_set`): intersect the agent's
+   proposed CorpusIds with the ids the annotator actually emitted, deduped. A
+   proposed id the annotator never emitted (hallucinated or mistranscribed) is
+   dropped to ``rejected`` — the agent is never the source of truth for an id.
+
+The record shape matches ``schemas/annotated_snippet.schema.json``; the follow-set
+shape matches ``schemas/follow_set.schema.json``.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+UNRESOLVED_TOKEN = "[CorpusId:unresolved]"
+"""Inline token spliced in place of a refMention ASTA could not resolve."""
+
+_CORPUS_ID_RE = re.compile(r"^CorpusId:\d+$")
+
+
+def _normalize_corpus_id(matched: str | int | None) -> str | None:
+    """Coerce an ASTA ``matchedPaperCorpusId`` to canonical ``CorpusId:NNNN`` form.
+
+    Lenient — accepts what ASTA emits (bare integers) as well as already-prefixed
+    strings. Use this for *response* data, not for agent-proposed ids (those are
+    validated strictly in :func:`resolve_follow_set`).
+
+    Args:
+        matched: ``234484741``, ``"234484741"``, ``"CorpusId:234484741"``, or None.
+
+    Returns:
+        ``"CorpusId:NNNN"``, or None when the input is empty/None or not numeric.
+    """
+    if matched is None:
+        return None
+    text = str(matched).strip()
+    if text.startswith("CorpusId:"):
+        text = text[len("CorpusId:") :]
+    if not text.isdigit():
+        return None
+    return f"CorpusId:{text}"
+
+
+def _corpus_token(matched: str | int | None) -> str:
+    """Return the inline token for a matched corpus id (or the unresolved token)."""
+    corpus_id = _normalize_corpus_id(matched)
+    return f"[{corpus_id}]" if corpus_id else UNRESOLVED_TOKEN
+
+
+def _raw_matched(raw_rm: dict[str, Any]) -> str | int | None:
+    """Read the matched corpus id from a refMention in either ASTA or schema shape."""
+    if "matchedPaperCorpusId" in raw_rm:
+        return raw_rm.get("matchedPaperCorpusId")
+    return raw_rm.get("corpus_id")
+
+
+def _splice_refs(text: str, ref_mentions: list[dict[str, Any]]) -> str:
+    """Splice inline citation tokens into ``text`` at each refMention span.
+
+    Replacement is deterministic and right-to-left: spans are processed by
+    descending ``(start, end)`` so replacing one never shifts the offsets of those
+    not yet processed. Only the ``[start, end)`` spans are replaced — any
+    inter-mention punctuation (e.g. the commas in ``"6,7,8,9"``) is preserved.
+
+    Args:
+        text: The verbatim snippet text.
+        ref_mentions: Raw ASTA refMentions (``start``/``end`` +
+            ``matchedPaperCorpusId``) or schema refMentions (``corpus_id``).
+
+    Returns:
+        ``text`` with each refMention span replaced by its inline token. Equal to
+        ``text`` when ``ref_mentions`` is empty.
+    """
+    ordered = sorted(
+        (r for r in ref_mentions if "start" in r and "end" in r),
+        key=lambda r: (int(r["start"]), int(r["end"])),
+        reverse=True,
+    )
+    out = text
+    for ref in ordered:
+        start, end = int(ref["start"]), int(ref["end"])
+        out = out[:start] + _corpus_token(_raw_matched(ref)) + out[end:]
+    return out
+
+
+def _to_ref_mention(raw_rm: dict[str, Any]) -> dict[str, Any]:
+    """Map a raw ASTA refMention to the schema ``RefMention`` shape."""
+    corpus_id = _normalize_corpus_id(_raw_matched(raw_rm))
+    return {
+        "start": int(raw_rm["start"]),
+        "end": int(raw_rm["end"]),
+        "corpus_id": corpus_id,
+        "resolved": corpus_id is not None,
+    }
+
+
+def project_snippet(
+    raw_item: dict[str, Any],
+    *,
+    source_paper: dict[str, Any],
+    retrieval_method: str,
+    reached_from: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build one slim ``annotated_snippet`` record from a raw ASTA data item.
+
+    ``text`` is copied verbatim (quote integrity); ``annotated_text`` is the spliced
+    copy. ``source_paper.role`` comes from the caller; the record's ``corpus_id`` is
+    taken from the raw item's own ``paper.corpusId`` when present (so a multi-paper
+    response tags each snippet with the paper it actually came from), otherwise from
+    the caller's ``source_paper``.
+
+    Args:
+        raw_item: One element of the ASTA ``result.data`` array.
+        source_paper: ``{"role": ..., "corpus_id"/"doi": ...}`` provenance; the role
+            is authoritative, ids are a fallback.
+        retrieval_method: One of the ``retrieval_method`` enum values.
+        reached_from: Optional citation provenance for followed (hop >= 1) snippets.
+
+    Returns:
+        A dict validating against ``annotated_snippet.schema.json``.
+    """
+    snippet = raw_item.get("snippet", {}) or {}
+    text = snippet.get("text", "") or ""
+    annotations = snippet.get("annotations") or {}
+    raw_refs = annotations.get("refMentions") or []
+    raw_sentences = annotations.get("sentences") or []
+
+    resolved_source = dict(source_paper)
+    per_item_cid = _normalize_corpus_id((raw_item.get("paper") or {}).get("corpusId"))
+    if per_item_cid and "doi" not in resolved_source:
+        resolved_source["corpus_id"] = per_item_cid
+
+    record: dict[str, Any] = {
+        "text": text,
+        "annotated_text": _splice_refs(text, raw_refs),
+        "score": raw_item.get("score", 0.0),
+        "source_paper": resolved_source,
+        "retrieval_method": retrieval_method,
+        "sentences": [{"start": int(s["start"]), "end": int(s["end"])} for s in raw_sentences],
+        "refMentions": [_to_ref_mention(r) for r in raw_refs],
+    }
+    section = snippet.get("section")
+    if section:
+        record["section"] = section
+    if reached_from is not None:
+        record["reached_from"] = reached_from
+    return record
+
+
+def _coerce_data_list(response: Any) -> list[dict[str, Any]]:
+    """Return the ``data`` array from any of the three ASTA payload nestings."""
+    if isinstance(response, list):
+        return response
+    if isinstance(response, dict):
+        result = response.get("result")
+        if isinstance(result, dict):
+            return result.get("data") or []
+        if "data" in response:
+            return response.get("data") or []
+    return []
+
+
+def project_response(
+    response: Any,
+    *,
+    source_paper: dict[str, Any],
+    retrieval_method: str,
+    reached_from: dict[str, Any] | None = None,
+    score_threshold: float = 0.0,
+) -> list[dict[str, Any]]:
+    """Project a full ASTA ``snippet_search`` response into slim records.
+
+    Tolerates the three payload nestings the provider may return:
+    ``{"result": {"data": [...]}}``, ``{"data": [...]}``, or ``[...]``. Items with
+    ``score`` below ``score_threshold`` are dropped.
+
+    Args:
+        response: The raw ASTA response.
+        source_paper: Provenance passed to :func:`project_snippet`.
+        retrieval_method: One of the ``retrieval_method`` enum values.
+        reached_from: Optional citation provenance for followed snippets.
+        score_threshold: Coarse score floor applied before the sentence gate.
+
+    Returns:
+        A list of ``annotated_snippet`` dicts.
+    """
+    records: list[dict[str, Any]] = []
+    for item in _coerce_data_list(response):
+        if item.get("score", 0.0) < score_threshold:
+            continue
+        records.append(
+            project_snippet(
+                item,
+                source_paper=source_paper,
+                retrieval_method=retrieval_method,
+                reached_from=reached_from,
+            )
+        )
+    return records
+
+
+def _real_corpus_ids(snippets: list[dict[str, Any]]) -> set[str]:
+    """Union of every non-null ``refMentions[].corpus_id`` across the snippets.
+
+    This is the ground truth of what ASTA actually returned inline — the only ids
+    that may be followed.
+    """
+    ids: set[str] = set()
+    for snippet in snippets:
+        for ref in snippet.get("refMentions") or []:
+            corpus_id = ref.get("corpus_id")
+            if corpus_id:
+                ids.add(corpus_id)
+    return ids
+
+
+def resolve_follow_set(
+    snippets: list[dict[str, Any]],
+    proposed_ids: list[str],
+    *,
+    hop: int | None = None,
+) -> dict[str, Any]:
+    """Compute the deduped follow-set as ``proposed ∩ real``, logging the rest.
+
+    Anti-hallucination gate: the agent proposes CorpusIds it read inline; this
+    intersects them with the ids the annotator emitted for these snippets. A
+    proposal that is not a well-formed ``CorpusId:NNNN`` is rejected as
+    ``malformed``; a well-formed proposal absent from the snippets' refMentions is
+    rejected as ``not_in_refmentions``. Deduplication preserves first-seen order.
+
+    Args:
+        snippets: The projected ``annotated_snippet`` records (source of truth).
+        proposed_ids: The agent's proposed CorpusIds to follow.
+        hop: Optional hop number stamped on the output.
+
+    Returns:
+        A dict validating against ``follow_set.schema.json``:
+        ``{"hop"?, "follow_set": [...], "rejected": [{"corpus_id", "reason"}]}``.
+    """
+    real = _real_corpus_ids(snippets)
+    follow_set: list[str] = []
+    rejected: list[dict[str, str]] = []
+    seen: set[str] = set()
+    for proposed in proposed_ids:
+        candidate = str(proposed).strip()
+        if not _CORPUS_ID_RE.match(candidate):
+            rejected.append({"corpus_id": candidate, "reason": "malformed"})
+            continue
+        if candidate not in real:
+            rejected.append({"corpus_id": candidate, "reason": "not_in_refmentions"})
+            continue
+        if candidate in seen:
+            continue
+        seen.add(candidate)
+        follow_set.append(candidate)
+
+    result: dict[str, Any] = {"follow_set": follow_set, "rejected": rejected}
+    if hop is not None:
+        result["hop"] = hop
+    return result

--- a/src/atlas_chat/atlas_chat/validation/report_checker.py
+++ b/src/atlas_chat/atlas_chat/validation/report_checker.py
@@ -234,9 +234,11 @@ def check_source_tags(
     splits along what a schema can express:
 
     1. **Schema-derived** (structure, enums, required ``source_paper``/
-       ``retrieval_method``, at-least-one identifier): validated directly against
-       ``all_summaries.schema.json`` / ``supplementary_findings.schema.json`` —
-       the single source of truth, not re-declared here.
+       ``retrieval_method``, at-least-one identifier): each all_summaries item is
+       validated against ``evidence_summary.schema.json`` (the canonical item
+       schema) and supplementary findings against
+       ``supplementary_findings.schema.json`` — the single source of truth, not
+       re-declared here.
     2. **Cross-cutting** (not expressible in a standalone item schema):
        ``supplement`` items must resolve to an ``atlas``/``subatlas`` paper, and
        every ``source_paper`` / ``reached_from`` identifier must appear in
@@ -253,8 +255,10 @@ def check_source_tags(
     """
     errors: list[str] = []
 
-    # 1. Structure / enums / presence — owned by the JSON schemas.
-    errors.extend(_schema_errors(summaries, "all_summaries.schema.json", "all_summaries"))
+    # 1. Structure / enums / presence — owned by the JSON schemas. Each
+    # all_summaries item is an evidence_summary (the canonical item schema).
+    for i, item in enumerate(summaries):
+        errors.extend(_schema_errors(item, "evidence_summary.schema.json", f"all_summaries[{i}]"))
     if supp_data:  # empty dict = no supplementary_findings.json to check
         errors.extend(
             _schema_errors(

--- a/tests/integration/test_snippet_annotator_live.py
+++ b/tests/integration/test_snippet_annotator_live.py
@@ -1,0 +1,44 @@
+"""Integration test: live ASTA snippet_search -> annotate -> follow-set.
+
+Hits the real ASTA MCP endpoint. Fails hard (not skips) if ASTA_API_KEY is
+missing, per the project's integration-test policy.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import re
+
+import pytest
+from atlas_chat.cli_annotate import _fetch_raw
+
+from atlas_chat.services import snippet_annotator as sa
+
+SEED = "CorpusId:273400864"  # Gopee et al. 2024 prenatal skin atlas
+TOKEN_RE = re.compile(r"\[CorpusId:(\d+)\]")
+
+
+@pytest.mark.integration
+def test_live_snippet_search_annotates_and_gates_follow_set() -> None:
+    assert os.getenv("ASTA_API_KEY"), "ASTA_API_KEY must be set for integration tests"
+
+    raw = asyncio.run(
+        _fetch_raw("TREM2 microglia-like macrophages markers location function", SEED, 10)
+    )
+    records = sa.project_response(
+        raw, source_paper={"role": "atlas"}, retrieval_method="corpus_snippet"
+    )
+    assert records, "expected at least one snippet from the seed paper"
+
+    for record in records:
+        assert record["text"], "text must be present and verbatim"
+        real = {m["corpus_id"] for m in record["refMentions"] if m["corpus_id"]}
+        # Every inline token in annotated_text corresponds to a real refMention id.
+        for corpus_num in TOKEN_RE.findall(record["annotated_text"]):
+            assert f"CorpusId:{corpus_num}" in real
+
+    # An injected fake id is never followed.
+    result = sa.resolve_follow_set(records, ["CorpusId:99999999"])
+    assert result["follow_set"] == []
+    assert result["rejected"][0]["reason"] == "not_in_refmentions"

--- a/tests/unit/fixtures/evidence/annotated_snippet.good.json
+++ b/tests/unit/fixtures/evidence/annotated_snippet.good.json
@@ -1,0 +1,32 @@
+[
+  {
+    "text": "Iron-recycling macrophages express SLC40A1, aligned with BWA [42].",
+    "section": "Results",
+    "score": 0.577,
+    "source_paper": { "corpus_id": "CorpusId:2762329", "doi": "10.1038/s41586-024-08002-x", "role": "atlas" },
+    "retrieval_method": "corpus_snippet",
+    "sentences": [
+      { "start": 0, "end": 43 },
+      { "start": 44, "end": 66 }
+    ],
+    "refMentions": [
+      { "start": 61, "end": 65, "corpus_id": "CorpusId:41350702", "resolved": true }
+    ]
+  },
+  {
+    "text": "Ferroportin activity exports macrophage iron [7].",
+    "section": "Discussion",
+    "score": 0.41,
+    "source_paper": { "corpus_id": "CorpusId:252635104", "role": "external" },
+    "retrieval_method": "citation_traversal",
+    "sentences": [{ "start": 0, "end": 49 }],
+    "refMentions": [
+      { "start": 45, "end": 48, "corpus_id": null, "resolved": false }
+    ],
+    "reached_from": {
+      "corpus_id": "CorpusId:231699447",
+      "hop": 1,
+      "citation_context": "Macrophages recycle iron and export it via ferroportin activity."
+    }
+  }
+]

--- a/tests/unit/fixtures/evidence/annotated_snippet_with_annotated_text.good.json
+++ b/tests/unit/fixtures/evidence/annotated_snippet_with_annotated_text.good.json
@@ -1,0 +1,19 @@
+[
+  {
+    "text": "TML macrophages support angiogenesis 3. They also guide axons 4,5.",
+    "annotated_text": "TML macrophages support angiogenesis [CorpusId:234484741]. They also guide axons [CorpusId:41350702],[CorpusId:unresolved].",
+    "section": "Results",
+    "score": 0.61,
+    "source_paper": { "corpus_id": "CorpusId:252635104", "role": "external" },
+    "retrieval_method": "citation_traversal",
+    "sentences": [
+      { "start": 0, "end": 39 },
+      { "start": 39, "end": 66 }
+    ],
+    "refMentions": [
+      { "start": 37, "end": 38, "corpus_id": "CorpusId:234484741", "resolved": true },
+      { "start": 62, "end": 63, "corpus_id": "CorpusId:41350702", "resolved": true },
+      { "start": 64, "end": 65, "corpus_id": null, "resolved": false }
+    ]
+  }
+]

--- a/tests/unit/fixtures/evidence/asta_snippet_search.raw.json
+++ b/tests/unit/fixtures/evidence/asta_snippet_search.raw.json
@@ -1,0 +1,27 @@
+{
+  "result": {
+    "data": [
+      {
+        "score": 0.61,
+        "paper": { "corpusId": "252635104", "title": "Fetal skin macrophages" },
+        "snippet": {
+          "text": "TML macrophages support angiogenesis 3. They also guide axons 4,5.",
+          "snippetKind": "body",
+          "section": "Results",
+          "snippetOffset": { "start": 4021, "end": 4087 },
+          "annotations": {
+            "sentences": [
+              { "start": 0, "end": 39 },
+              { "start": 39, "end": 66 }
+            ],
+            "refMentions": [
+              { "start": 37, "end": 38, "matchedPaperCorpusId": "234484741" },
+              { "start": 62, "end": 63, "matchedPaperCorpusId": "41350702" },
+              { "start": 64, "end": 65, "matchedPaperCorpusId": null }
+            ]
+          }
+        }
+      }
+    ]
+  }
+}

--- a/tests/unit/fixtures/evidence/evidence_summary.good.json
+++ b/tests/unit/fixtures/evidence/evidence_summary.good.json
@@ -1,25 +1,24 @@
 [
   {
+    "source_paper": { "corpus_id": "CorpusId:2762329", "doi": "10.1038/s41586-024-08002-x", "role": "atlas" },
+    "retrieval_method": "corpus_snippet",
     "source_title": "A prenatal skin atlas",
     "section": "Results",
-    "score": 0.57,
+    "score": 0.577,
     "summary": "Iron-recycling macrophages are one of four macrophage subsets in prenatal skin.",
-    "quotes": ["Iron-recycling macrophages express SLC40A1"],
-    "source_paper": { "corpus_id": "CorpusId:2762329", "doi": "10.1038/s41586-024-08002-x", "role": "atlas" },
-    "retrieval_method": "corpus_snippet"
+    "quotes": ["Iron-recycling macrophages express SLC40A1"]
   },
   {
-    "source_title": "Ferroportin and iron export",
-    "section": "Results",
-    "score": 0.41,
-    "summary": "Iron is exported from macrophages via ferroportin activity.",
-    "quotes": ["export via ferroportin activity"],
     "source_paper": { "corpus_id": "CorpusId:252635104", "role": "external" },
     "retrieval_method": "citation_traversal",
     "reached_from": {
       "corpus_id": "CorpusId:231699447",
       "hop": 1,
       "citation_context": "Macrophages recycle iron and export it via ferroportin activity."
-    }
+    },
+    "section": "Discussion",
+    "score": 0.41,
+    "summary": "Ferroportin exports macrophage iron following erythrophagocytosis.",
+    "quotes": ["The gene transcript of ferroportin (Slc40a1) was upregulated by erythrophagocytosis"]
   }
 ]

--- a/tests/unit/fixtures/evidence/follow_set.bad.json
+++ b/tests/unit/fixtures/evidence/follow_set.bad.json
@@ -1,0 +1,6 @@
+{
+  "follow_set": ["234484741"],
+  "rejected": [
+    { "corpus_id": "CorpusId:12", "reason": "hallucinated" }
+  ]
+}

--- a/tests/unit/fixtures/evidence/follow_set.good.json
+++ b/tests/unit/fixtures/evidence/follow_set.good.json
@@ -1,0 +1,7 @@
+{
+  "hop": 1,
+  "follow_set": ["CorpusId:234484741", "CorpusId:41350702"],
+  "rejected": [
+    { "corpus_id": "CorpusId:999999", "reason": "not_in_refmentions" }
+  ]
+}

--- a/tests/unit/test_snippet_annotator.py
+++ b/tests/unit/test_snippet_annotator.py
@@ -1,0 +1,192 @@
+"""Unit tests for services.snippet_annotator (splice + follow-set).
+
+Covers the deterministic core the agent relies on: right-to-left ref splicing,
+quote integrity, unresolved tokens, id normalisation, payload nesting, schema
+conformance, and the follow-set intersection / anti-hallucination check.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import jsonschema
+import pytest
+
+from atlas_chat.schemas import load_schema
+from atlas_chat.services import snippet_annotator as sa
+
+FIXTURES = Path(__file__).parent / "fixtures" / "evidence"
+SOURCE = {"role": "external"}
+
+EXPECTED_ANNOTATED = (
+    "TML macrophages support angiogenesis [CorpusId:234484741]. "
+    "They also guide axons [CorpusId:41350702],[CorpusId:unresolved]."
+)
+
+
+def _raw() -> dict:
+    return json.loads((FIXTURES / "asta_snippet_search.raw.json").read_text())
+
+
+def _records() -> list[dict]:
+    return sa.project_response(_raw(), source_paper=SOURCE, retrieval_method="citation_traversal")
+
+
+# --- splicing ----------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_splice_right_to_left_and_unresolved_token() -> None:
+    text = "TML macrophages support angiogenesis 3. They also guide axons 4,5."
+    refs = [
+        {"start": 37, "end": 38, "matchedPaperCorpusId": "234484741"},
+        {"start": 62, "end": 63, "matchedPaperCorpusId": "41350702"},
+        {"start": 64, "end": 65, "matchedPaperCorpusId": None},
+    ]
+    assert sa._splice_refs(text, refs) == EXPECTED_ANNOTATED
+
+
+@pytest.mark.unit
+def test_splice_adjacent_run_preserves_separators() -> None:
+    text = "effect 6,7,8,9 end"
+    refs = [
+        {"start": 7, "end": 8, "matchedPaperCorpusId": "100"},
+        {"start": 9, "end": 10, "matchedPaperCorpusId": "200"},
+        {"start": 11, "end": 12, "matchedPaperCorpusId": "300"},
+        {"start": 13, "end": 14, "matchedPaperCorpusId": "400"},
+    ]
+    assert sa._splice_refs(text, refs) == (
+        "effect [CorpusId:100],[CorpusId:200],[CorpusId:300],[CorpusId:400] end"
+    )
+
+
+@pytest.mark.unit
+def test_splice_no_refs_returns_text_unchanged() -> None:
+    assert sa._splice_refs("plain text with no cites", []) == "plain text with no cites"
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("234484741", "[CorpusId:234484741]"),
+        (234484741, "[CorpusId:234484741]"),
+        ("CorpusId:234484741", "[CorpusId:234484741]"),
+        (None, sa.UNRESOLVED_TOKEN),
+        ("", sa.UNRESOLVED_TOKEN),
+        ("not-a-number", sa.UNRESOLVED_TOKEN),
+    ],
+)
+def test_corpus_token_normalisation(value: object, expected: str) -> None:
+    assert sa._corpus_token(value) == expected  # type: ignore[arg-type]
+
+
+# --- projection --------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_project_snippet_preserves_text_verbatim() -> None:
+    raw_item = _raw()["result"]["data"][0]
+    record = sa.project_snippet(
+        raw_item, source_paper=SOURCE, retrieval_method="citation_traversal"
+    )
+    assert record["text"] == raw_item["snippet"]["text"]
+    assert record["annotated_text"] == EXPECTED_ANNOTATED
+    assert record["annotated_text"] != record["text"]
+
+
+@pytest.mark.unit
+def test_project_snippet_maps_provenance_and_refmentions() -> None:
+    record = _records()[0]
+    assert record["source_paper"] == {"role": "external", "corpus_id": "CorpusId:252635104"}
+    assert record["retrieval_method"] == "citation_traversal"
+    assert record["refMentions"][0] == {
+        "start": 37,
+        "end": 38,
+        "corpus_id": "CorpusId:234484741",
+        "resolved": True,
+    }
+    assert record["refMentions"][2] == {
+        "start": 64,
+        "end": 65,
+        "corpus_id": None,
+        "resolved": False,
+    }
+
+
+@pytest.mark.unit
+def test_project_response_payload_nesting_tolerance() -> None:
+    full = _raw()
+    data = full["result"]["data"]
+    a = sa.project_response(full, source_paper=SOURCE, retrieval_method="citation_traversal")
+    b = sa.project_response(
+        {"data": data}, source_paper=SOURCE, retrieval_method="citation_traversal"
+    )
+    c = sa.project_response(data, source_paper=SOURCE, retrieval_method="citation_traversal")
+    assert a == b == c
+    assert len(a) == 1
+
+
+@pytest.mark.unit
+def test_project_response_score_threshold_drops_low_scores() -> None:
+    assert (
+        sa.project_response(
+            _raw(),
+            source_paper=SOURCE,
+            retrieval_method="citation_traversal",
+            score_threshold=0.9,
+        )
+        == []
+    )
+
+
+@pytest.mark.unit
+def test_projected_records_validate_against_schema() -> None:
+    validator = jsonschema.Draft202012Validator(load_schema("annotated_snippet.schema.json"))
+    for record in _records():
+        assert list(validator.iter_errors(record)) == []
+
+
+# --- follow-set --------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_follow_set_drops_hallucinated_id() -> None:
+    result = sa.resolve_follow_set(_records(), ["CorpusId:234484741", "CorpusId:999999"], hop=1)
+    assert result["follow_set"] == ["CorpusId:234484741"]
+    assert result["rejected"] == [{"corpus_id": "CorpusId:999999", "reason": "not_in_refmentions"}]
+    assert result["hop"] == 1
+
+
+@pytest.mark.unit
+def test_follow_set_dedup_preserves_order() -> None:
+    result = sa.resolve_follow_set(
+        _records(),
+        ["CorpusId:41350702", "CorpusId:41350702", "CorpusId:234484741"],
+    )
+    assert result["follow_set"] == ["CorpusId:41350702", "CorpusId:234484741"]
+    assert "hop" not in result
+
+
+@pytest.mark.unit
+def test_follow_set_rejects_malformed_id() -> None:
+    result = sa.resolve_follow_set(_records(), ["12345"])
+    assert result["follow_set"] == []
+    assert result["rejected"] == [{"corpus_id": "12345", "reason": "malformed"}]
+
+
+@pytest.mark.unit
+def test_unresolved_mention_is_not_a_real_target() -> None:
+    # The null-corpus refMention contributes no followable id.
+    assert sa._real_corpus_ids(_records()) == {
+        "CorpusId:234484741",
+        "CorpusId:41350702",
+    }
+
+
+@pytest.mark.unit
+def test_follow_set_output_validates_against_schema() -> None:
+    result = sa.resolve_follow_set(_records(), ["CorpusId:234484741", "CorpusId:999999"], hop=1)
+    validator = jsonschema.Draft202012Validator(load_schema("follow_set.schema.json"))
+    assert list(validator.iter_errors(result)) == []

--- a/tests/unit/test_traversal_schema.py
+++ b/tests/unit/test_traversal_schema.py
@@ -1,0 +1,196 @@
+"""Schema + hook regression for ASTA-native citation traversal (issue #14).
+
+Pins the two pipeline schemas (annotated_snippet -> evidence_summary), the
+sentence-gated traversal fields (reached_from.hop, refMention.corpus_id nullable),
+the all_summaries <-> evidence_summary mirror, and the PostToolUse validator hooks.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import jsonschema
+import pytest
+
+from atlas_chat.schemas import load_schema
+
+FIXTURES = Path(__file__).parent / "fixtures" / "evidence"
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _load_fixture(name: str) -> object:
+    return json.loads((FIXTURES / name).read_text())
+
+
+def _errors(schema_name: str, data: object) -> list[str]:
+    validator = jsonschema.Draft202012Validator(load_schema(schema_name))
+    return [e.message for e in validator.iter_errors(data)]
+
+
+def _item_errors(schema_name: str, items: list) -> list[str]:
+    validator = jsonschema.Draft202012Validator(load_schema(schema_name))
+    out: list[str] = []
+    for item in items:
+        out += [e.message for e in validator.iter_errors(item)]
+    return out
+
+
+# --- schemas well-formed -----------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "schema_name",
+    [
+        "annotated_snippet.schema.json",
+        "evidence_summary.schema.json",
+        "citation_traverse_input.schema.json",
+    ],
+)
+def test_schema_is_valid(schema_name: str) -> None:
+    jsonschema.Draft202012Validator.check_schema(load_schema(schema_name))
+
+
+# --- all_summaries mirrors evidence_summary ----------------------------------
+
+
+@pytest.mark.unit
+def test_all_summaries_item_mirrors_evidence_summary() -> None:
+    es = load_schema("evidence_summary.schema.json")
+    item = load_schema("all_summaries.schema.json")["$defs"]["EvidenceSummary"]
+    assert set(item["properties"]) == set(es["properties"])
+    assert set(item["required"]) == set(es["required"])
+
+
+# --- evidence_summary --------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_evidence_summary_good_fixture_validates() -> None:
+    assert (
+        _item_errors("evidence_summary.schema.json", _load_fixture("evidence_summary.good.json"))
+        == []
+    )
+
+
+@pytest.mark.unit
+def test_evidence_summary_reached_from_requires_hop() -> None:
+    data = _load_fixture("evidence_summary.good.json")
+    del data[1]["reached_from"]["hop"]
+    assert _item_errors("evidence_summary.schema.json", data)
+
+
+@pytest.mark.unit
+def test_evidence_summary_rejects_traversal_machinery() -> None:
+    # refMentions / sentences must not leak into the distilled item.
+    data = _load_fixture("evidence_summary.good.json")
+    data[0]["refMentions"] = []
+    assert _item_errors("evidence_summary.schema.json", data)
+
+
+@pytest.mark.unit
+def test_evidence_summary_requires_quotes() -> None:
+    data = _load_fixture("evidence_summary.good.json")
+    del data[0]["quotes"]
+    assert _item_errors("evidence_summary.schema.json", data)
+
+
+# --- annotated_snippet -------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_annotated_snippet_good_fixture_validates() -> None:
+    assert (
+        _item_errors("annotated_snippet.schema.json", _load_fixture("annotated_snippet.good.json"))
+        == []
+    )
+
+
+@pytest.mark.unit
+def test_annotated_snippet_allows_null_refmention_corpus_id() -> None:
+    # An on-topic-but-unresolved edge (null CorpusId) is valid — logged, not dropped.
+    data = _load_fixture("annotated_snippet.good.json")
+    assert data[1]["refMentions"][0]["corpus_id"] is None
+    assert _item_errors("annotated_snippet.schema.json", data) == []
+
+
+@pytest.mark.unit
+def test_annotated_snippet_rejects_bad_refmention_corpus_id() -> None:
+    data = _load_fixture("annotated_snippet.good.json")
+    data[0]["refMentions"][0]["corpus_id"] = "41350702"  # missing CorpusId: prefix
+    assert _item_errors("annotated_snippet.schema.json", data)
+
+
+@pytest.mark.unit
+def test_annotated_snippet_requires_text_and_score() -> None:
+    data = _load_fixture("annotated_snippet.good.json")
+    del data[0]["text"]
+    del data[0]["score"]
+    assert len(_item_errors("annotated_snippet.schema.json", data)) >= 2
+
+
+# --- PostToolUse hooks -------------------------------------------------------
+
+
+def _run_hook(hook: str, file_path: str, payload: object) -> subprocess.CompletedProcess:
+    hook_input = json.dumps(
+        {"tool_input": {"file_path": file_path, "content": json.dumps(payload)}}
+    )
+    return subprocess.run(
+        [sys.executable, str(REPO_ROOT / ".claude" / "hooks" / hook)],
+        input=hook_input,
+        capture_output=True,
+        text=True,
+        cwd=REPO_ROOT,
+    )
+
+
+@pytest.mark.unit
+def test_evidence_summary_hook_accepts_good_all_summaries() -> None:
+    r = _run_hook(
+        "check_evidence_summary.py",
+        "projects/x/traversal_output/ct/all_summaries.json",
+        _load_fixture("evidence_summary.good.json"),
+    )
+    assert r.returncode == 0, r.stderr
+
+
+@pytest.mark.unit
+def test_evidence_summary_hook_rejects_bad_item() -> None:
+    r = _run_hook(
+        "check_evidence_summary.py",
+        "projects/x/traversal_output/ct/all_summaries.json",
+        [{"source_paper": {"role": "external"}, "retrieval_method": "nope", "summary": "x"}],
+    )
+    assert r.returncode == 2
+    assert "VALIDATION FAILED" in r.stderr
+
+
+@pytest.mark.unit
+def test_evidence_summary_hook_ignores_other_files() -> None:
+    r = _run_hook("check_evidence_summary.py", "projects/x/notes.txt", {"anything": 1})
+    assert r.returncode == 0
+
+
+@pytest.mark.unit
+def test_annotated_snippet_hook_accepts_good_and_null_edge() -> None:
+    r = _run_hook(
+        "check_annotated_snippet.py",
+        "projects/x/traversal_output/ct/annotated_snippets_hop1.json",
+        _load_fixture("annotated_snippet.good.json"),
+    )
+    assert r.returncode == 0, r.stderr
+
+
+@pytest.mark.unit
+def test_annotated_snippet_hook_rejects_bad_record() -> None:
+    r = _run_hook(
+        "check_annotated_snippet.py",
+        "projects/x/traversal_output/ct/annotated_snippets_hop0.json",
+        [{"section": "Results", "source_paper": {"role": "atlas"}}],
+    )
+    assert r.returncode == 2
+    assert "VALIDATION FAILED" in r.stderr

--- a/tests/unit/test_traversal_schema.py
+++ b/tests/unit/test_traversal_schema.py
@@ -48,6 +48,7 @@ def _item_errors(schema_name: str, items: list) -> list[str]:
         "annotated_snippet.schema.json",
         "evidence_summary.schema.json",
         "citation_traverse_input.schema.json",
+        "follow_set.schema.json",
     ],
 )
 def test_schema_is_valid(schema_name: str) -> None:
@@ -132,6 +133,36 @@ def test_annotated_snippet_requires_text_and_score() -> None:
     assert len(_item_errors("annotated_snippet.schema.json", data)) >= 2
 
 
+@pytest.mark.unit
+def test_annotated_snippet_with_annotated_text_validates() -> None:
+    # The spliced record (with annotated_text) is valid...
+    data = _load_fixture("annotated_snippet_with_annotated_text.good.json")
+    assert "annotated_text" in data[0]
+    assert _item_errors("annotated_snippet.schema.json", data) == []
+
+
+@pytest.mark.unit
+def test_annotated_snippet_annotated_text_is_optional() -> None:
+    # ...and legacy records without annotated_text still validate (back-compat).
+    legacy = _load_fixture("annotated_snippet.good.json")
+    assert all("annotated_text" not in item for item in legacy)
+    assert _item_errors("annotated_snippet.schema.json", legacy) == []
+
+
+# --- follow_set --------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_follow_set_good_fixture_validates() -> None:
+    assert _errors("follow_set.schema.json", _load_fixture("follow_set.good.json")) == []
+
+
+@pytest.mark.unit
+def test_follow_set_bad_fixture_rejected() -> None:
+    # Bare id in follow_set (missing CorpusId: prefix) + bad rejected reason enum.
+    assert _errors("follow_set.schema.json", _load_fixture("follow_set.bad.json"))
+
+
 # --- PostToolUse hooks -------------------------------------------------------
 
 
@@ -194,3 +225,30 @@ def test_annotated_snippet_hook_rejects_bad_record() -> None:
     )
     assert r.returncode == 2
     assert "VALIDATION FAILED" in r.stderr
+
+
+@pytest.mark.unit
+def test_follow_set_hook_accepts_good() -> None:
+    r = _run_hook(
+        "check_follow_set.py",
+        "projects/x/traversal_output/ct/follow_set_hop1.json",
+        _load_fixture("follow_set.good.json"),
+    )
+    assert r.returncode == 0, r.stderr
+
+
+@pytest.mark.unit
+def test_follow_set_hook_rejects_bad() -> None:
+    r = _run_hook(
+        "check_follow_set.py",
+        "projects/x/traversal_output/ct/follow_set_hop1.json",
+        _load_fixture("follow_set.bad.json"),
+    )
+    assert r.returncode == 2
+    assert "VALIDATION FAILED" in r.stderr
+
+
+@pytest.mark.unit
+def test_follow_set_hook_ignores_other_files() -> None:
+    r = _run_hook("check_follow_set.py", "projects/x/notes.txt", {"anything": 1})
+    assert r.returncode == 0


### PR DESCRIPTION
Closes #14. Builds on #12's provenance fields (now merged).

Replaces the "traverse-shaped" citation logic with a real, **sentence-gated** walk over ASTA that consumes the structured citation edges ASTA already returns and emits uniform, provenance-tagged evidence. **ASTA-only** — routing to local/PDF edge sources and the `get_paper(references)` fallback stay deferred to the follow-up ticket.

## Schemas (schema-first; two schemas, one pipeline)
- **`annotated_snippet.schema.json`** — raw retrieval record: `text`, `section`, `score`, `source_paper`, `retrieval_method`, optional `sentences[]` + `refMentions[{start,end,corpus_id(nullable),resolved}]`, `reached_from`.
- **`evidence_summary.schema.json`** — canonical distilled item the synthesizer reads: provenance + `reached_from{hop}` + `section`/`score`/`summary`/`quotes`. `refMentions`/`sentences` do **not** leak here, so the synthesizer's blockquote rule and `report_checker`'s quote-substring check keep working against a pre-verified `quotes` array.
- **`all_summaries.schema.json`** — reworked to an array of the **inlined** evidence_summary item (standalone PostToolUse validators can't resolve cross-file `$ref`; a mirror test asserts the inline copy tracks the canonical schema).
- **`citation_traverse_input.schema.json`** — traversal params for the subagent `input:` contract.

## Contract — `citation-traverse.md` (rewritten)
- Edge extraction from `refMentions → matchedPaperCorpusId` + containing `sentences` span as `citation_context` — **regex-over-text path removed**.
- **Sentence-level gate:** follow a ref iff its containing sentence makes a biological claim about the cell type; drop methods/tool/dataset citations. No LLM re-scoring of refs (reuses ASTA `score`).
- On-topic-but-unresolved (`null` CorpusId) edges **logged, not dropped**.
- `reached_from{corpus_id,hop,citation_context}`; breadth cap `k_per_paper` + `run_cap` with overflow logged; fixed `depth` arg.
- `input:`/`output:` front-matter referencing the schemas.

## Validators + tests
- PostToolUse hooks `check_annotated_snippet.py` / `check_evidence_summary.py` (validate array files), registered in a **new tracked `.claude/settings.json`** alongside the existing CL/report hooks.
- `report_checker.py` validates each `all_summaries` item against `evidence_summary.schema.json`.
- `test_traversal_schema.py`: schema well-formedness, `reached_from.hop` required, null-`corpus_id` edge accepted, no-machinery-leak, all_summaries↔evidence_summary mirror, and hook subprocess regression. Good goldens for both schemas; #12 fixtures migrated to the new item shape.
- **69 unit tests pass**, ruff check + format clean.

## Acceptance mapping
- Sentence-gated (methods citations dropped), not follow-all ✅
- Every traversed item carries `reached_from` + provenance, validates against the schemas ✅
- Relevant-but-unresolved edges logged ✅
- Depth tunable; breadth/run caps enforced with overflow logged ✅
- ASTA-only, no dependency on #13 or the routing ticket ✅

## Reviewer notes (in-scope decisions)
- The `all_summaries` item is a **duplicated inline copy** of `evidence_summary` (cross-file `$ref` doesn't resolve in the standalone hooks) — `test_all_summaries_item_mirrors_evidence_summary` guards drift.
- Hooks run via `uv run python` in settings.json so `jsonschema`/the package are importable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)