### PR TITLE
Add generate-cas skill + CAS+ config Step 1 (cas.json)

### DIFF
--- a/.claude/hooks/check_cas_annotation.py
+++ b/.claude/hooks/check_cas_annotation.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python
+"""Claude Code hook: validate a project's CAS+ document against JSON Schema.
+
+Fires as a PostToolUse hook on Write/Edit to a project's CAS+ config —
+``cas.json`` — validating against ``cas_annotation.schema.json``. The generate-cas
+skill produces this file (it is agent output), so schema compliance is enforced
+here.
+
+Exit codes:
+    0 — valid, or file is not a cas.json, or jsonschema unavailable
+    2 — validation failed (Claude sees stderr and self-corrects)
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+SCHEMA_PATH = Path("src/atlas_chat/atlas_chat/schemas/cas_annotation.schema.json")
+
+
+def _targets(file_path: str) -> bool:
+    return Path(file_path).name == "cas.json"
+
+
+def _errors(data: object, schema: dict) -> list[str]:
+    import jsonschema
+
+    validator = jsonschema.Draft202012Validator(schema)
+    errors: list[str] = []
+    for err in sorted(validator.iter_errors(data), key=lambda e: list(e.path)):
+        path = ".".join(str(p) for p in err.absolute_path)
+        errors.append(f"{path or '(root)'}: {err.message}")
+    return errors
+
+
+def main() -> int:
+    try:
+        hook_input = json.loads(sys.stdin.read())
+    except (json.JSONDecodeError, OSError):
+        return 0
+
+    tool_input = hook_input.get("tool_input", {})
+    file_path = tool_input.get("file_path", "")
+    if not file_path or not _targets(file_path):
+        return 0
+
+    content = tool_input.get("content", "")
+    if not content:
+        print(f"{Path(file_path).name} is empty", file=sys.stderr)
+        return 2
+
+    try:
+        data = json.loads(content)
+    except json.JSONDecodeError as exc:
+        print(f"{Path(file_path).name} is not valid JSON: {exc}", file=sys.stderr)
+        return 2
+
+    if not SCHEMA_PATH.exists():
+        return 0
+    try:
+        import jsonschema  # noqa: F401
+    except ImportError:
+        print("jsonschema not available — skipping cas_annotation check", file=sys.stderr)
+        return 0
+
+    errors = _errors(data, json.loads(SCHEMA_PATH.read_text()))
+    if not errors:
+        return 0
+
+    print("CAS_ANNOTATION VALIDATION FAILED", file=sys.stderr)
+    print(f"Fix these issues and rewrite {Path(file_path).name}:", file=sys.stderr)
+    for error in errors:
+        print(f"  - {error}", file=sys.stderr)
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -18,6 +18,10 @@
           },
           {
             "type": "command",
+            "command": "uv run python .claude/hooks/check_cas_annotation.py"
+          },
+          {
+            "type": "command",
             "command": "uv run python .claude/hooks/check_cl_mapping.py"
           },
           {

--- a/.claude/skills/generate-cas/SKILL.md
+++ b/.claude/skills/generate-cas/SKILL.md
@@ -33,22 +33,25 @@ Some fields are not derivable from the data — **ask the user** rather than gue
 
 ## Procedure (lightweight)
 
-1. Identify the source type and gather inputs; ask the user for anything missing or
-   ambiguous (DOI, organism, and the field roles above — label vs hierarchy tiers
-   vs context covariates vs ignore).
-2. Read the source with whatever python libraries fit (`pandas`/`openpyxl` for
-   tables; `anndata`/`zarr` for obs — obs only; a text list directly). Use only
-   **categorical** columns — both for the cell-type label and for the co-annotation
-   covariates. **Skip continuous / numeric columns** (QC metrics such as counts or
-   percent-mito, embeddings, per-cell floats): a distribution over a continuous
-   column is not a meaningful per-label category. Also **skip identifier-like /
-   high-cardinality categoricals** (cell barcodes, per-cell IDs, index-like columns):
-   a categorical whose distinct-value count approaches the number of cells is an
-   identifier, not a covariate, and would explode per-label distributions and
-   massively bloat `cas.json`. For each remaining categorical covariate, summarise
-   per label — near-constant → a scalar; otherwise keep the distribution
-   (`{author_value, share}`) — which maps onto CAS+ `composition`.
-3. Map to CAS+ (let the schema descriptions guide the exact shape):
+1. Identify the source(s) and **assay the available fields first** (`pandas`/
+   `openpyxl` for tables; `anndata`/`zarr` for obs — obs only, never the matrix; a
+   text list directly). For each column record its dtype (categorical vs
+   continuous), cardinality, and a few example values. Mark as **auto-excluded** the
+   **continuous / numeric** columns (QC metrics such as counts or percent-mito,
+   embeddings, per-cell floats) and the **identifier-like / high-cardinality
+   categoricals** (cell barcodes, per-cell IDs, index-like columns — distinct-value
+   count approaching the cell count): these are not per-label categories and would
+   massively bloat `cas.json`.
+2. **Present that field inventory to the user** — the candidate columns with their
+   dtype / cardinality / example values, and what was auto-excluded and why — and
+   **ask them to assign roles**: cell-type label(s), hierarchy / granularity tiers,
+   context covariates, or ignore; plus anything not derivable (DOI, organism).
+   Listing the actual fields lets the user choose from what is really there; confirm
+   the label column even when it looks obvious.
+3. For each chosen categorical covariate, summarise per label — near-constant → a
+   scalar; otherwise keep the distribution (`{author_value, share}`) — which maps
+   onto CAS+ `composition`.
+4. Map to CAS+ (let the schema descriptions guide the exact shape):
    - `source`: `{doi, title, ...}` (+ `organism`/`links` where known).
    - `labelsets`: one per cell-type column; set `rank` by granularity if known.
    - `annotations`: one per label, `cell_label` = the verbatim label, tied to its
@@ -60,7 +63,7 @@ Some fields are not derivable from the data — **ask the user** rather than gue
      unmapped author columns in `author_annotation_fields`.
    - Leave optional fields **absent** when unknown — downstream consumers are
      presence-aware.
-4. Write `projects/{project}/cas.json`. The `check_cas_annotation` PostToolUse hook
+5. Write `projects/{project}/cas.json`. The `check_cas_annotation` PostToolUse hook
    validates it against the schema; if it fails, read the errors and rewrite.
 
 ## Minimal case

--- a/.claude/skills/generate-cas/SKILL.md
+++ b/.claude/skills/generate-cas/SKILL.md
@@ -35,8 +35,12 @@ Some fields are not derivable from the data — **ask the user** rather than gue
    **categorical** columns — both for the cell-type label and for the co-annotation
    covariates. **Skip continuous / numeric columns** (QC metrics such as counts or
    percent-mito, embeddings, per-cell floats): a distribution over a continuous
-   column is not a meaningful per-label category. For each categorical covariate,
-   summarise per label — near-constant → a scalar; otherwise keep the distribution
+   column is not a meaningful per-label category. Also **skip identifier-like /
+   high-cardinality categoricals** (cell barcodes, per-cell IDs, index-like columns):
+   a categorical whose distinct-value count approaches the number of cells is an
+   identifier, not a covariate, and would explode per-label distributions and
+   massively bloat `cas.json`. For each remaining categorical covariate, summarise
+   per label — near-constant → a scalar; otherwise keep the distribution
    (`{author_value, share}`) — which maps onto CAS+ `composition`.
 3. Map to CAS+ (let the schema descriptions guide the exact shape):
    - `source`: `{doi, title, ...}` (+ `organism`/`links` where known).

--- a/.claude/skills/generate-cas/SKILL.md
+++ b/.claude/skills/generate-cas/SKILL.md
@@ -31,9 +31,13 @@ Some fields are not derivable from the data — **ask the user** rather than gue
 1. Identify the source type and gather inputs; ask the user for anything missing or
    ambiguous (DOI, organism, which column is the label).
 2. Read the source with whatever python libraries fit (`pandas`/`openpyxl` for
-   tables; `anndata`/`zarr` for obs — obs only; a text list directly). For per-label
-   covariates that are near-constant, summarise as a scalar; otherwise keep the
-   distribution (`{author_value, share}`) — this maps onto CAS+ `composition`.
+   tables; `anndata`/`zarr` for obs — obs only; a text list directly). Use only
+   **categorical** columns — both for the cell-type label and for the co-annotation
+   covariates. **Skip continuous / numeric columns** (QC metrics such as counts or
+   percent-mito, embeddings, per-cell floats): a distribution over a continuous
+   column is not a meaningful per-label category. For each categorical covariate,
+   summarise per label — near-constant → a scalar; otherwise keep the distribution
+   (`{author_value, share}`) — which maps onto CAS+ `composition`.
 3. Map to CAS+ (let the schema descriptions guide the exact shape):
    - `source`: `{doi, title, ...}` (+ `organism`/`links` where known).
    - `labelsets`: one per cell-type column; set `rank` by granularity if known.

--- a/.claude/skills/generate-cas/SKILL.md
+++ b/.claude/skills/generate-cas/SKILL.md
@@ -23,13 +23,19 @@ supplementary table.
 Some fields are not derivable from the data — **ask the user** rather than guess:
 - the atlas **DOI** (and title, if not in the source),
 - the **organism** (unless present as an obs/table column),
-- which column is the **cell-type label** (vs granularity/lineage/covariates), when
-  ambiguous.
+- **field roles** — which column(s) are the **cell-type label(s)**, which are coarser
+  **hierarchy / granularity tiers** (→ ranked labelsets), which are **context
+  covariates** (organism / developmental stage / tissue → `composition`), and which
+  to ignore. Confirm the label column even when it looks obvious.
+
+> A future obs-field classifier (in progress on `cxg-entrypoint-reader-discovery`)
+> will propose these field roles automatically; until it lands, ask the user.
 
 ## Procedure (lightweight)
 
 1. Identify the source type and gather inputs; ask the user for anything missing or
-   ambiguous (DOI, organism, which column is the label).
+   ambiguous (DOI, organism, and the field roles above — label vs hierarchy tiers
+   vs context covariates vs ignore).
 2. Read the source with whatever python libraries fit (`pandas`/`openpyxl` for
    tables; `anndata`/`zarr` for obs — obs only; a text list directly). Use only
    **categorical** columns — both for the cell-type label and for the co-annotation

--- a/.claude/skills/generate-cas/SKILL.md
+++ b/.claude/skills/generate-cas/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: generate-cas
+description: Generate a project's CAS+ config (projects/{project}/cas.json) from whatever source(s) are available — a bare list of cell-type labels, a spreadsheet/CSV, an AnnData h5ad/zarr obs, a CELLxGENE dataset, or a paper's supplementary table. Lifts any starting point up to the CAS+ contract so the rest of the workflow has one input shape. Deliberately lightweight; the schema is the spec.
+---
+
+# generate-cas
+
+Produce `projects/{project}/cas.json` conforming to
+`src/atlas_chat/atlas_chat/schemas/cas_annotation.schema.json`. That schema is the
+contract and is **self-documenting** — read its field descriptions and follow them;
+do not reproduce them here.
+
+Invoked from workflow Step 1 when a project has no valid `cas.json` yet. CAS+
+supersedes the legacy flat `cell_type_annotations.json`.
+
+## Inputs
+
+You are given a **project name** and one or more **sources**. Sources can be any of:
+a bare list of cell-type labels, a CSV/XLSX table, an AnnData `.h5ad`/`.zarr` store
+(read **obs only** — never the expression matrix), a CELLxGENE dataset, or a paper
+supplementary table.
+
+Some fields are not derivable from the data — **ask the user** rather than guess:
+- the atlas **DOI** (and title, if not in the source),
+- the **organism** (unless present as an obs/table column),
+- which column is the **cell-type label** (vs granularity/lineage/covariates), when
+  ambiguous.
+
+## Procedure (lightweight)
+
+1. Identify the source type and gather inputs; ask the user for anything missing or
+   ambiguous (DOI, organism, which column is the label).
+2. Read the source with whatever python libraries fit (`pandas`/`openpyxl` for
+   tables; `anndata`/`zarr` for obs — obs only; a text list directly). For per-label
+   covariates that are near-constant, summarise as a scalar; otherwise keep the
+   distribution (`{author_value, share}`) — this maps onto CAS+ `composition`.
+3. Map to CAS+ (let the schema descriptions guide the exact shape):
+   - `source`: `{doi, title, ...}` (+ `organism`/`links` where known).
+   - `labelsets`: one per cell-type column; set `rank` by granularity if known.
+   - `annotations`: one per label, `cell_label` = the verbatim label, tied to its
+     `labelset`. Carry hierarchy (`parent_cell_set_accession` / lineage), `synonyms`,
+     `marker_gene_evidence`, `cell_ontology_term_id` **only if the source already
+     provides them** — do not invent them (downstream steps resolve names, markers,
+     and ontology terms). Fold CxG-style context (organism / developmental stage /
+     tissue) into `composition` with ontology CURIEs where obvious; put remaining
+     unmapped author columns in `author_annotation_fields`.
+   - Leave optional fields **absent** when unknown — downstream consumers are
+     presence-aware.
+4. Write `projects/{project}/cas.json`. The `check_cas_annotation` PostToolUse hook
+   validates it against the schema; if it fails, read the errors and rewrite.
+
+## Minimal case
+
+A bare list of labels + a DOI is enough:
+
+```json
+{
+  "title": "<atlas title>",
+  "source": { "doi": "10.xxxx/..." },
+  "labelsets": [ { "name": "author_cell_type" } ],
+  "annotations": [ { "labelset": "author_cell_type", "cell_label": "<label>" }, ... ]
+}
+```
+
+## Rules
+
+- **obs only** — never download or read the expression matrix.
+- **Do not invent** markers, synonyms, or ontology terms. Carry them only if the
+  source states them; otherwise leave absent for downstream steps to fill.
+- Prefer asking the user over guessing DOI / organism / which column is the label.
+- Output is `projects/{project}/cas.json`; schema compliance is enforced by the hook.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,15 +51,31 @@ workflow and the programmatic Python graph.
 
 Given a **project name** and **cell type label**:
 
-### 1. Load Project Config
+### 1. Load Project Config (CAS+)
 
-Read `projects/{project}/cell_type_annotations.json`:
-- Extract atlas DOI, title
-- Validate the cell type label exists in annotations
-- Get scope and granularity for the cell type
-- **If scope indicates integrated external annotations** (e.g. adult annotations
-  from Reynolds integrated into Gopee), identify the source atlas early and
-  pivot supplementary fetching to that paper.
+The project config is a **CAS+** document at `projects/{project}/cas.json`
+(schema: `src/atlas_chat/atlas_chat/schemas/cas_annotation.schema.json`). CAS+
+supersedes the legacy flat `cell_type_annotations.json`.
+
+- **If `projects/{project}/cas.json` exists and validates**, load it and move on.
+- **Otherwise**, invoke the `generate-cas` skill
+  (`.claude/skills/generate-cas/SKILL.md`) to build it from the project's
+  source(s), asking the user for anything not derivable (DOI, organism, which
+  column is the cell-type label). The `check_cas_annotation` PostToolUse hook
+  enforces schema compliance on write.
+
+From the loaded CAS+ document:
+- Extract atlas DOI + title from `source`.
+- Validate the requested cell type label exists as an annotation `cell_label`.
+- Read its `labelset` (granularity) and context from `composition`
+  (e.g. developmental stage / organism / tissue).
+- **If an annotation's provenance points to an integrated subatlas** (via
+  `transferred_annotations[].subatlas_paper` / `source_taxonomy`), identify that
+  source paper early and pivot supplementary fetching to it.
+
+> Migration note: downstream steps below still reference the legacy `label` /
+> `scope` fields; their input contracts move to CAS+ `cell_label` / `composition`
+> as part of the query-decomposer work.
 
 ### 2. Fetch Supplementary Material
 

--- a/tests/unit/test_cas_annotation_hook.py
+++ b/tests/unit/test_cas_annotation_hook.py
@@ -1,0 +1,55 @@
+"""PostToolUse hook regression for check_cas_annotation.py.
+
+Drives the hook via subprocess (like the other hook regressions): a valid
+``cas.json`` exits 0, an invalid one exits 2, and a non-``cas.json`` file is
+ignored. Reuses the CAS fixtures from test_cas_annotation_schema.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+FIXTURES = Path(__file__).parent / "fixtures" / "cas"
+HOOK = REPO_ROOT / ".claude" / "hooks" / "check_cas_annotation.py"
+
+
+def _load(name: str) -> object:
+    return json.loads((FIXTURES / name).read_text())
+
+
+def _run_hook(file_path: str, payload: object) -> subprocess.CompletedProcess:
+    hook_input = json.dumps(
+        {"tool_input": {"file_path": file_path, "content": json.dumps(payload)}}
+    )
+    return subprocess.run(
+        [sys.executable, str(HOOK)],
+        input=hook_input,
+        capture_output=True,
+        text=True,
+        cwd=REPO_ROOT,
+    )
+
+
+@pytest.mark.unit
+def test_hook_accepts_valid_cas() -> None:
+    r = _run_hook("projects/x/cas.json", _load("cas_annotation.minimal.good.json"))
+    assert r.returncode == 0, r.stderr
+
+
+@pytest.mark.unit
+def test_hook_rejects_invalid_cas() -> None:
+    r = _run_hook("projects/x/cas.json", _load("cas_annotation.bad.json"))
+    assert r.returncode == 2
+    assert "VALIDATION FAILED" in r.stderr
+
+
+@pytest.mark.unit
+def test_hook_ignores_non_cas_files() -> None:
+    r = _run_hook("projects/x/notes.txt", {"anything": 1})
+    assert r.returncode == 0


### PR DESCRIPTION
Make the workflow consume CAS+ as its project config, lifting any starting point up to it rather than special-casing sources downstream.

- generate-cas skill (.claude/skills/generate-cas/SKILL.md): lightweight, agentic — builds projects/{project}/cas.json (conforming to cas_annotation.schema.json) from whatever source(s) exist (bare list, spreadsheet, h5ad/zarr obs, CELLxGENE, supp table); asks the user for non-derivable fields (DOI, organism, which column is the label). obs only; does not invent markers/synonyms/CL terms.
- CLAUDE.md Step 1 rewritten: cas.json is the config (CAS+ supersedes the flat cell_type_annotations.json). If it exists+validates, load it; else invoke generate-cas. Downstream label/scope handling migrates to cell_label/ composition with the query-decomposer work (noted inline).
- check_cas_annotation.py PostToolUse hook enforces schema compliance on cas.json writes (registered in settings.json) — the file is now agent output.
- Hook regression test (reuses the CAS fixtures). Full unit suite: 108 passed.