### PR TITLE
Layer A: query-driven selection of target cell types over CAS+

### DIFF
--- a/.claude/agents/query-decomposer.md
+++ b/.claude/agents/query-decomposer.md
@@ -1,0 +1,67 @@
+---
+name: query-decomposer
+description: Turn one selected cell type (its CAS+ annotation, name resolution, and the query context) into a query_decomposition — grounding (subject, aliases, non-subject terms, scope, seed) plus the search queries citation-traversal consumes, namely one focused query per fixed report aspect plus a combined query. Queries are retrieval seeds only; it never invents evidence.
+model: sonnet
+input:
+  schema: src/atlas_chat/atlas_chat/schemas/name_resolution.schema.json
+output:
+  schema: src/atlas_chat/atlas_chat/schemas/query_decomposition.schema.json
+---
+
+# Subagent: Query Decomposer (Layer B)
+
+You decompose **one** selected cell type into a `query_decomposition` — grounding
+plus the queries citation-traversal will run. You do **not** gather evidence and do
+**not** decide relevance; you author retrieval seeds. Traversal stays blind — it only
+ever receives a query string.
+
+## Input
+
+- **CAS+ annotation** — the selected cell type's entry from `projects/{project}/cas.json`
+  (conforms to `cas_annotation.schema.json`): `cell_label`, optional `synonyms`,
+  `cell_fullname`, hierarchy (`labelset` + `parent_cell_set_accession` / lineage),
+  `composition`, `cell_ontology_term_id`, `marker_gene_evidence`.
+- **`name_resolution.json`** — from `resolve-name`: `resolved_names`, `tissue_context`,
+  and `source_paper` (`doi`/`corpus_id`/`role`).
+- **Query context** — the contextual restriction carried from selection (Layer A),
+  e.g. `{developmental_stage: "adult"}` — may be empty.
+
+## Procedure
+
+1. **subject** — the canonical name for the report: prefer `cell_fullname` /
+   `resolved_names[0]`, else `cell_label`.
+2. **aliases** — the **union** of CAS `synonyms` and `name_resolution.resolved_names`
+   (deduped; include `cell_label`).
+3. **non_subject_terms** — confusable neighbours that are NOT the subject: sibling and
+   precursor cell types from the CAS hierarchy (same `parent_cell_set_accession`, or
+   adjacent labelset tiers). Present only when the hierarchy makes them clear; omit
+   otherwise. Do not guess from latent knowledge.
+4. **scope** — union the query context with the annotation's `composition`
+   (organism / developmental_stage / tissue). Prefer the query context where they
+   conflict (it is the explicit restriction). Omit keys you cannot fill.
+5. **seed** — `paper_id` from `source_paper` (`CorpusId:NNNN` if present, else
+   `DOI:<doi>`), `role` from `source_paper.role`.
+6. **aspects** — author one focused query for **each** of the five fixed aspects
+   (`location`, `structure`, `function`, `markers`, `marker_roles`). Each query uses
+   the subject + aliases + scope, phrased for the aspect (e.g. structure →
+   morphology / spatial organisation / ECM). Steer toward the subject and away from
+   `non_subject_terms`.
+7. **combined_query** — one query naming the subject + scope and listing the aspects,
+   for the hybrid first pass.
+
+## Rules
+
+- Queries are **retrieval seeds**, not claims. Author freely; do not pre-optimise a
+  single query and do not rely on latent knowledge for content — the hybrid loop
+  adds targeted queries as evidence comes back.
+- **Presence-aware**: use a CAS field when present; derive from `name_resolution` /
+  the paper otherwise; leave optional output fields absent when unknown.
+- Never write markers, ontology terms, or synonyms you cannot source from the CAS+
+  annotation or `name_resolution` into the decomposition — those are gathered
+  downstream. The decomposition carries queries + grounding, not findings.
+
+## Output
+
+Write `{traversal_dir}/query_decomposition.json` (conforms to
+`query_decomposition.schema.json`; the `check_query_decomposition` PostToolUse hook
+validates it on write — fix and rewrite on failure).

--- a/.claude/agents/resolve-name.md
+++ b/.claude/agents/resolve-name.md
@@ -12,6 +12,9 @@ You resolve how atlas authors refer to a specific cell type annotation label.
 
 You receive:
 - `cell_type_label` — the annotation label (e.g. "Iron-recycling macrophage", "LC_1", "moDC_3")
+- `provided_synonyms` — any `synonyms` already recorded for this cell type in the
+  CAS+ annotation (may be empty). **Union** these with the names you find in the
+  paper; never discard a provided synonym just because you did not re-find it.
 - `atlas_doi` — DOI of the atlas paper
 - `atlas_corpus_id` — CorpusId of the atlas paper (if known)
 - `scope` — "adult", "fetal", or "organoid"
@@ -27,7 +30,9 @@ You receive:
    mapping tables.
 3. If snippet search is insufficient, fall back to `get_europepmc_full_text`
    (max 2 attempts).
-4. Identify all names the authors use for this cell type.
+4. Identify all names the authors use for this cell type, and **union** them with
+   `provided_synonyms` (from CAS) into `resolved_names` — deduped, including the
+   original label.
 5. **Identify the source paper of the annotation.** Usually the annotation is
    the atlas authors' own (`role: atlas`). But when the label was integrated
    from an upstream study (e.g. adult annotations from a subatlas paper mapped

--- a/.claude/agents/synthesize-report.md
+++ b/.claude/agents/synthesize-report.md
@@ -1,3 +1,9 @@
+---
+name: synthesize-report
+description: Synthesize an evidence-grounded markdown cell type report from the traversal evidence, CAS+ annotation, and query_decomposition — with report sections driven by the decomposition's aspects.
+model: sonnet
+---
+
 # Subagent: Synthesize Cell Type Report
 
 You generate a well-written markdown report about a cell type, grounded
@@ -6,10 +12,17 @@ entirely in the evidence collected by previous workflow steps.
 ## Input
 
 You read these files from `{traversal_dir}`:
+- `query_decomposition.json` — subject, scope, and the **aspects** that drive the
+  report's sections (one section per aspect, in order).
 - `name_resolution.json` — resolved names and tissue context
 - `supplementary_findings.json` — markers, annotations, evidence quotes
 - `all_summaries.json` — citation traversal summaries with quotes
 - `paper_catalogue.json` — metadata for all referenced papers
+
+Plus the cell type's **CAS+ annotation** (from `cas.json`): carry any CAS-provided
+`marker_gene_evidence` / `cell_ontology_term_id` as paraphrased, cited facts (not
+blockquotes). Where evidence is off-scope relative to `query_decomposition.scope`
+(e.g. mouse for a human-scoped report), say so in the text.
 
 ## Shared Prompt
 
@@ -33,3 +46,7 @@ them and rewrite the report.
 5. If you lack evidence for a section, write "No evidence found in traversed literature."
 6. Use multiple sources — cite every paper whose snippet you quote.
 7. If the hook rejects the report, read the error messages and fix the specific issues.
+8. The report's sections follow `query_decomposition.aspects` (in order): Summary
+   first, then one section per aspect — `location` → Location, `structure` →
+   Structure / Morphology, `function` → Function, `markers` → Markers,
+   `marker_roles` → Marker roles — then References.

--- a/.claude/hooks/check_query_decomposition.py
+++ b/.claude/hooks/check_query_decomposition.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python
+"""Claude Code hook: validate a query_decomposition against JSON Schema.
+
+Fires as a PostToolUse hook on Write/Edit to ``query_decomposition.json`` (the
+query-decomposer subagent's output), validating against
+``query_decomposition.schema.json``.
+
+Exit codes:
+    0 — valid, or file is not a query_decomposition file, or jsonschema unavailable
+    2 — validation failed (Claude sees stderr and self-corrects)
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+SCHEMA_PATH = Path("src/atlas_chat/atlas_chat/schemas/query_decomposition.schema.json")
+
+
+def _targets(file_path: str) -> bool:
+    return Path(file_path).name == "query_decomposition.json"
+
+
+def _errors(data: object, schema: dict) -> list[str]:
+    import jsonschema
+
+    validator = jsonschema.Draft202012Validator(schema)
+    errors: list[str] = []
+    for err in sorted(validator.iter_errors(data), key=lambda e: list(e.path)):
+        path = ".".join(str(p) for p in err.absolute_path)
+        errors.append(f"{path or '(root)'}: {err.message}")
+    return errors
+
+
+def main() -> int:
+    try:
+        hook_input = json.loads(sys.stdin.read())
+    except (json.JSONDecodeError, OSError):
+        return 0
+
+    tool_input = hook_input.get("tool_input", {})
+    file_path = tool_input.get("file_path", "")
+    if not file_path or not _targets(file_path):
+        return 0
+
+    content = tool_input.get("content", "")
+    if not content:
+        print(f"{Path(file_path).name} is empty", file=sys.stderr)
+        return 2
+
+    try:
+        data = json.loads(content)
+    except json.JSONDecodeError as exc:
+        print(f"{Path(file_path).name} is not valid JSON: {exc}", file=sys.stderr)
+        return 2
+
+    if not SCHEMA_PATH.exists():
+        return 0
+    try:
+        import jsonschema  # noqa: F401
+    except ImportError:
+        print("jsonschema not available — skipping query_decomposition check", file=sys.stderr)
+        return 0
+
+    errors = _errors(data, json.loads(SCHEMA_PATH.read_text()))
+    if not errors:
+        return 0
+
+    print("QUERY_DECOMPOSITION VALIDATION FAILED", file=sys.stderr)
+    print(f"Fix these issues and rewrite {Path(file_path).name}:", file=sys.stderr)
+    for error in errors:
+        print(f"  - {error}", file=sys.stderr)
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -22,6 +22,10 @@
           },
           {
             "type": "command",
+            "command": "uv run python .claude/hooks/check_query_decomposition.py"
+          },
+          {
+            "type": "command",
             "command": "uv run python .claude/hooks/check_cl_mapping.py"
           },
           {

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,10 @@ coverage.xml
 dist/
 build/
 docs/_build/
-.claude/settings.local.json
+.claude/settings.local*.json
 
-#projects/
+# Test projects: commit setup only (cas.json, README); ignore generated outputs
+projects/test_projects/**/traversal_output/
+projects/test_projects/**/reports/
+projects/test_projects/**/selections/
+projects/test_projects/**/runs/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,7 +49,9 @@ workflow and the programmatic Python graph.
 
 ## Workflow Sequence
 
-Given a **project name** and **cell type label**:
+Given a **project name** and a **query** — a free-text specification of which cell
+types to report on, optionally with contextual restrictions (e.g. "all fibroblasts",
+"fibroblasts in adult tissue", or a single cell-type label):
 
 ### 1. Load Project Config (CAS+)
 
@@ -76,6 +78,33 @@ From the loaded CAS+ document:
 > Migration note: downstream steps below still reference the legacy `label` /
 > `scope` fields; their input contracts move to CAS+ `cell_label` / `composition`
 > as part of the query-decomposer work.
+
+### 1b. Select target cell types (from the query)
+
+Interpret the **query** against the CAS+ annotations to choose which cell types to
+report on. Match flexibly — as a knowledgeable curator would — on `cell_label`,
+`lineage` / hierarchy, and `synonyms`; apply any contextual restriction in the query
+(developmental stage, tissue, organism, disease, …) as a filter over each
+annotation's `composition`. Do **not** impose a rigid query grammar: a query like
+"all fibroblasts" or "fibroblasts in adult tissue" is interpreted directly, and a
+bare cell-type label selects just that annotation.
+
+Record the resolved selection to `projects/{project}/selections/{slug}.json` for
+provenance (slug derived from the query text):
+
+```json
+{
+  "query": "fibroblasts in adult tissue",
+  "context": { "developmental_stage": "adult" },
+  "cas_source": "projects/{project}/cas.json",
+  "selected": [
+    { "cell_label": "...", "cell_set_accession": "...", "labelset": "..." }
+  ]
+}
+```
+
+**Steps 2–9 below run once per selected cell type.** The query's contextual
+restriction carries forward as that cell type's scope.
 
 ### 2. Fetch Supplementary Material
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,10 +126,13 @@ the atlas paper. This avoids fragile full text download → grep → parse cycle
 and returns relevance-ranked text.
 
 **Input:**
-- Cell type label, atlas DOI, scope
+- CAS+ annotation for the cell type: `cell_label`, plus any CAS `synonyms`
+  (`provided_synonyms` — resolve-name **unions** these with paper-found names)
+- Atlas DOI; scope/tissue from the annotation's `composition`
 - Supplementary text from step 2
 
 **Output:** `projects/{project}/traversal_output/{cell_type}/name_resolution.json`
+(schema: `src/atlas_chat/atlas_chat/schemas/name_resolution.schema.json`)
 
 **Contract:**
 ```json
@@ -139,9 +142,21 @@ and returns relevance-ranked text.
   "scope": "fetal",
   "tissue_context": "fetal skin",
   "confidence": "high",
-  "evidence": "Found in cluster annotations table"
+  "evidence": "Found in cluster annotations table",
+  "source_paper": { "corpus_id": "CorpusId:2762329", "doi": "10.1038/s41586-024-08002-x", "role": "atlas" }
 }
 ```
+
+### 3b. Decompose query → subagent: `query-decomposer`
+
+For each selected cell type, dispatch `query-decomposer` with its CAS+ annotation,
+`name_resolution.json`, and the query's context. It writes
+`projects/{project}/traversal_output/{cell_type}/query_decomposition.json`
+(schema: `src/atlas_chat/atlas_chat/schemas/query_decomposition.schema.json`):
+grounding (`subject`, `aliases`, `non_subject_terms`, `scope`, `seed`) plus one
+authored query per fixed aspect (`location, structure, function, markers,
+marker_roles`) and a `combined_query`. Validated by the `check_query_decomposition`
+PostToolUse hook.
 
 ### 4. Parallel: Scan Supplements + Citation Traverse
 
@@ -166,10 +181,20 @@ These two steps are independent after name resolution. Run them in parallel.
 
 #### 4b. Citation Traverse → subagent: `citation-traverse`
 
-**Input:**
-- Seed paper ID (CorpusId from snippet metadata, or `DOI:{doi}`)
-- Query: `"{label} / {resolved_name} in {scope} {tissue}: location, structure, function, markers"`
-- Depth: 1 (default), configurable up to 3
+**Input:** the cell type's `query_decomposition.json` (from step 3b).
+
+**Hybrid strategy (orchestrator-driven):**
+1. Run `citation-traverse` with `combined_query`; `seed_paper_id` / `seed_role` from
+   `seed`; depth 1.
+2. Assess **per-aspect in-scope coverage** of the returned `all_summaries`, using
+   `scope` to judge in-scope vs off-scope evidence.
+3. For each aspect that is thin — or covered only by **off-scope** evidence — run
+   `citation-traverse` with that `aspects[].query`. If it is still thin/off-scope,
+   run a **scope-targeted free search**: `cli_annotate fetch` with **no**
+   `--paper-ids`, `--retrieval-method free_search`, query = the aspect query plus the
+   `scope` terms. Stop gracefully once in-scope evidence is found or effort is spent.
+4. **Merge** the per-run `all_summaries` / `paper_catalogue` (dedup by CorpusId and
+   by evidence item); tag each followed paper's organism/stage for scope.
 
 **Local snippet index (fresh preprints):** if
 `projects/{project}/local_index/manifest.json` exists, the graph also calls

--- a/projects/test_projects/README.md
+++ b/projects/test_projects/README.md
@@ -1,0 +1,45 @@
+# Test projects
+
+Sandbox projects for exercising the report-generation workflow end-to-end, kept
+**separate from official reports** (which live on their own per-atlas project
+branches). Nothing here is an authoritative report.
+
+## What is committed vs generated
+
+For each test project `test_projects/<name>/`:
+
+- **Committed setup** (tracked): `cas.json` (the CAS+ config the run reads) and this
+  project's `README.md` / any small source notes.
+- **Generated output** (git-ignored): `traversal_output/`, `reports/`, `selections/`,
+  and `runs/`. See `.gitignore`. Only the setup needed to reproduce a run is tracked.
+
+## Running a test
+
+Launch a session **inside this worktree** (agents load from the launch dir's
+`.claude/`), then drive the workflow with the project addressed under this folder:
+
+```
+project = "test_projects/<name>"     # orchestrator reads projects/test_projects/<name>/cas.json
+query   = "<free-text cell-type selection>"   # e.g. "all macrophages"
+```
+
+## Run tracking
+
+Each test run writes a manifest to `runs/<UTC-timestamp>/run.json` (git-ignored)
+recording the **directory it was run in** and the **nature of the run**:
+
+```jsonc
+{
+  "run_id": "<uuid>", "timestamp": "<ISO-8601 UTC>", "mode": "agentic",
+  "worktree_dir": "<abs path the run was driven from>",
+  "git_branch": "...", "git_version": "<git describe --always --dirty>",
+  "project": "test_projects/<name>", "query": "<the query>",
+  "selected_cell_types": ["..."],
+  "outputs": ["traversal_output/...", "reports/..."],
+  "notes": "<what this run was testing>"
+}
+```
+
+(This is a lightweight, test-scoped record. The heavier infra standard is
+`src/atlas_chat/atlas_chat/schemas/run_provenance.schema.json` — align to it later
+if test runs need to feed the validation-tools run-comparison.)

--- a/projects/test_projects/README.md
+++ b/projects/test_projects/README.md
@@ -10,8 +10,10 @@ For each test project `test_projects/<name>/`:
 
 - **Committed setup** (tracked): `cas.json` (the CAS+ config the run reads) and this
   project's `README.md` / any small source notes.
-- **Generated output** (git-ignored): `traversal_output/`, `reports/`, `selections/`,
-  and `runs/`. See `.gitignore`. Only the setup needed to reproduce a run is tracked.
+- **Generated output** (git-ignored): each run is a **self-contained folder**
+  `runs/<UTC-timestamp>/` holding `run.json`, `selections/`,
+  `traversal_output/<cell_type>/`, and `reports/<cell_type>.md`. All of `runs/` is
+  git-ignored; only the setup is tracked. See `.gitignore`.
 
 ## Running a test
 
@@ -25,8 +27,10 @@ query   = "<free-text cell-type selection>"   # e.g. "all macrophages"
 
 ## Run tracking
 
-Each test run writes a manifest to `runs/<UTC-timestamp>/run.json` (git-ignored)
-recording the **directory it was run in** and the **nature of the run**:
+Each run's reports and evidence live in its own `runs/<UTC-timestamp>/` folder (see
+above). That folder's `run.json` (git-ignored) records the **directory it was run
+in** and the **nature of the run** — and an optional `provenance_warning` when the
+run's provenance is uncertain:
 
 ```jsonc
 {

--- a/projects/test_projects/fetal_skin_atlas/README.md
+++ b/projects/test_projects/fetal_skin_atlas/README.md
@@ -1,0 +1,31 @@
+# test_projects/fetal_skin_atlas
+
+Test project for the prenatal (fetal) human skin atlas — Gopee et al. (2024),
+*Nature*, DOI `10.1038/s41586-024-08002-x`.
+
+## Setup (committed)
+
+`cas.json` — a **hand-built minimal CAS+** for testing (not the full atlas):
+
+- Six annotations: a broad `Macrophage` plus four fine macrophage subsets
+  (`TML macrophage`, `Iron-recycling macrophage`, `LYVE1++ macrophage`,
+  `MHCII+ macrophage`) and `Dermal papilla`.
+- The fine macrophage subsets share `parent_cell_set_accession: FS_macro`, so the
+  decomposer gets **real sibling `non_subject_terms`** from the hierarchy.
+- Deliberately **no `synonyms` / `marker_gene_evidence`** — this exercises the
+  minimal-source path (the grounder derives aliases from the paper).
+- Context lives in `composition` (organism human, developmental_stage fetal,
+  tissue skin).
+
+## Baselines for diffing
+
+Earlier direct-traversal outputs (pre-decomposer) for coverage comparison:
+`/tmp/tml_traversal/` (TML) and `/tmp/dp_test/` (Dermal papilla) — ephemeral, may be
+gone after a reboot; the reports under `reports/` here are the current-flow outputs.
+
+## Running
+
+Fresh session in the `query-decomposer` worktree, then a query such as
+`all macrophages`, `TML macrophage and dermal papilla`, or a single label. Generated
+outputs land under `traversal_output/`, `reports/`, `selections/`, `runs/` (all
+git-ignored).

--- a/projects/test_projects/fetal_skin_atlas/README.md
+++ b/projects/test_projects/fetal_skin_atlas/README.md
@@ -26,6 +26,10 @@ gone after a reboot; the reports under `reports/` here are the current-flow outp
 ## Running
 
 Fresh session in the `query-decomposer` worktree, then a query such as
-`all macrophages`, `TML macrophage and dermal papilla`, or a single label. Generated
-outputs land under `traversal_output/`, `reports/`, `selections/`, `runs/` (all
-git-ignored).
+`all macrophages`, `TML macrophage and dermal papilla`, or a single label. Each run's
+outputs land in a self-contained folder `runs/<UTC-timestamp>/` (git-ignored):
+`run.json` + `selections/` + `traversal_output/` + `reports/`.
+
+The existing `runs/20260818T184313Z/` was the first end-to-end run; its `run.json`
+carries a `provenance_warning` (it may have been driven from the wrong worktree
+folder). A clean re-run from the correct folder is planned.

--- a/projects/test_projects/fetal_skin_atlas/cas.json
+++ b/projects/test_projects/fetal_skin_atlas/cas.json
@@ -1,0 +1,79 @@
+{
+  "title": "A prenatal skin atlas reveals immune regulation of human skin morphogenesis",
+  "cellannotation_schema_version": "0.1.0-local",
+  "source": {
+    "doi": "10.1038/s41586-024-08002-x",
+    "title": "A prenatal skin atlas reveals immune regulation of human skin morphogenesis",
+    "atlas_name": "Prenatal Skin Atlas (Gopee et al. 2024)"
+  },
+  "labelsets": [
+    { "name": "broad", "rank": 1, "annotation_method": "manual" },
+    { "name": "fine", "rank": 0, "annotation_method": "manual" }
+  ],
+  "annotations": [
+    {
+      "labelset": "broad",
+      "cell_label": "Macrophage",
+      "cell_set_accession": "FS_macro",
+      "composition": {
+        "developmental_stage": { "author_field_name": "scope", "values": [ { "author_value": "fetal" } ] },
+        "organism": { "values": [ { "author_value": "human", "ontology_term_id": "NCBITaxon:9606" } ] },
+        "tissue": { "values": [ { "author_value": "skin", "ontology_term_id": "UBERON:0002097" } ] }
+      }
+    },
+    {
+      "labelset": "fine",
+      "cell_label": "TML macrophage",
+      "cell_set_accession": "FS_tml",
+      "parent_cell_set_accession": "FS_macro",
+      "composition": {
+        "developmental_stage": { "author_field_name": "scope", "values": [ { "author_value": "fetal" } ] },
+        "organism": { "values": [ { "author_value": "human", "ontology_term_id": "NCBITaxon:9606" } ] },
+        "tissue": { "values": [ { "author_value": "skin", "ontology_term_id": "UBERON:0002097" } ] }
+      }
+    },
+    {
+      "labelset": "fine",
+      "cell_label": "Iron-recycling macrophage",
+      "cell_set_accession": "FS_iron",
+      "parent_cell_set_accession": "FS_macro",
+      "composition": {
+        "developmental_stage": { "author_field_name": "scope", "values": [ { "author_value": "fetal" } ] },
+        "organism": { "values": [ { "author_value": "human", "ontology_term_id": "NCBITaxon:9606" } ] },
+        "tissue": { "values": [ { "author_value": "skin", "ontology_term_id": "UBERON:0002097" } ] }
+      }
+    },
+    {
+      "labelset": "fine",
+      "cell_label": "LYVE1++ macrophage",
+      "cell_set_accession": "FS_lyve1",
+      "parent_cell_set_accession": "FS_macro",
+      "composition": {
+        "developmental_stage": { "author_field_name": "scope", "values": [ { "author_value": "fetal" } ] },
+        "organism": { "values": [ { "author_value": "human", "ontology_term_id": "NCBITaxon:9606" } ] },
+        "tissue": { "values": [ { "author_value": "skin", "ontology_term_id": "UBERON:0002097" } ] }
+      }
+    },
+    {
+      "labelset": "fine",
+      "cell_label": "MHCII+ macrophage",
+      "cell_set_accession": "FS_mhcii",
+      "parent_cell_set_accession": "FS_macro",
+      "composition": {
+        "developmental_stage": { "author_field_name": "scope", "values": [ { "author_value": "fetal" } ] },
+        "organism": { "values": [ { "author_value": "human", "ontology_term_id": "NCBITaxon:9606" } ] },
+        "tissue": { "values": [ { "author_value": "skin", "ontology_term_id": "UBERON:0002097" } ] }
+      }
+    },
+    {
+      "labelset": "fine",
+      "cell_label": "Dermal papilla",
+      "cell_set_accession": "FS_dp",
+      "composition": {
+        "developmental_stage": { "author_field_name": "scope", "values": [ { "author_value": "fetal" } ] },
+        "organism": { "values": [ { "author_value": "human", "ontology_term_id": "NCBITaxon:9606" } ] },
+        "tissue": { "values": [ { "author_value": "skin", "ontology_term_id": "UBERON:0002097" } ] }
+      }
+    }
+  ]
+}

--- a/src/atlas_chat/atlas_chat/agents/report_synthesizer.prompt.yaml
+++ b/src/atlas_chat/atlas_chat/agents/report_synthesizer.prompt.yaml
@@ -59,6 +59,10 @@ user_prompt: |
   supports them. Provide narrative context around quotes — don't just list
   quotes without explanation.
 
+  The aspect sections below correspond to the query_decomposition aspects
+  (location, structure, function, markers, marker_roles); keep this order, with
+  Summary and References framing them.
+
   # [Cell Type Name]
   Atlas: [atlas title] (DOI: [doi])
   Scope: [scope]
@@ -80,6 +84,10 @@ user_prompt: |
   Biological roles with evidence. Use subsections for distinct functions.
 
   ## Structure / Morphology
+  If evidence exists.
+
+  ## Marker roles
+  What the marker genes do — their roles in the cell type's structure and function.
   If evidence exists.
 
   ## References

--- a/src/atlas_chat/atlas_chat/schemas/name_resolution.schema.json
+++ b/src/atlas_chat/atlas_chat/schemas/name_resolution.schema.json
@@ -1,0 +1,57 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "name_resolution.schema.json",
+  "title": "NameResolution",
+  "description": "Output of the resolve-name (grounder) subagent: how the atlas authors refer to a cell type, plus which corpus paper the annotation comes from. Consumed by scan-supplements (source_paper) and by the query-decomposer (aliases + seed). resolved_names is the union of CAS-provided synonyms and names found in the paper.",
+  "type": "object",
+  "required": ["label", "resolved_names", "source_paper"],
+  "additionalProperties": false,
+  "properties": {
+    "label": {
+      "type": "string",
+      "minLength": 1,
+      "description": "The original annotation label (CAS cell_label)."
+    },
+    "resolved_names": {
+      "type": "array",
+      "description": "Names the authors use for this cell type — CAS synonyms unioned with paper-found names. Includes the original label.",
+      "items": { "type": "string" }
+    },
+    "scope": {
+      "type": "string",
+      "description": "Biological context/origin as author text (e.g. 'fetal', 'adult', 'organoid'). Free text by design."
+    },
+    "tissue_context": {
+      "type": "string",
+      "description": "Tissue/organ context from the paper (e.g. 'fetal skin')."
+    },
+    "confidence": {
+      "type": "string",
+      "enum": ["high", "medium", "low"]
+    },
+    "evidence": {
+      "type": "string",
+      "description": "Brief note on where the name was found."
+    },
+    "source_paper": {
+      "type": "object",
+      "description": "The paper the annotation comes from (atlas or an integrated subatlas). At least one of doi / corpus_id must be present.",
+      "required": ["role"],
+      "anyOf": [{ "required": ["doi"] }, { "required": ["corpus_id"] }],
+      "additionalProperties": false,
+      "properties": {
+        "doi": { "type": "string", "description": "DOI of the source paper." },
+        "corpus_id": {
+          "type": "string",
+          "pattern": "^CorpusId:\\d+$",
+          "description": "Semantic Scholar CorpusId, formatted 'CorpusId:NNNN'."
+        },
+        "role": {
+          "type": "string",
+          "enum": ["atlas", "subatlas"],
+          "description": "'atlas' = the annotation is the atlas authors' own; 'subatlas' = integrated from an upstream corpus paper."
+        }
+      }
+    }
+  }
+}

--- a/src/atlas_chat/atlas_chat/schemas/query_decomposition.schema.json
+++ b/src/atlas_chat/atlas_chat/schemas/query_decomposition.schema.json
@@ -1,0 +1,87 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "query_decomposition.schema.json",
+  "title": "QueryDecomposition",
+  "description": "Per-cell-type decomposition produced by the query-decomposer subagent (Layer B). Grounds one selected cell type and authors the search queries that citation-traversal consumes. The aspect names double as the report's sections (shared contract with synthesis). combined_query is the hybrid first pass; each aspects[].query is a focused follow-up used only where an aspect comes back thin or off-scope. seed maps to citation_traverse_input.seed_paper_id/seed_role; scope is orchestrator-side (evidence tagging + scope-targeted escalation), not part of the traversal input.",
+  "type": "object",
+  "required": ["subject", "aspects", "combined_query", "seed"],
+  "additionalProperties": false,
+  "properties": {
+    "subject": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Canonical name of the cell type being reported on (the CAS cell_label or its resolved full name)."
+    },
+    "aliases": {
+      "type": "array",
+      "description": "Names the subject is known by — the union of CAS synonyms and paper-found names from resolve-name. Used to steer retrieval and gating toward the subject.",
+      "items": { "type": "string" }
+    },
+    "non_subject_terms": {
+      "type": "array",
+      "description": "Confusable neighbours that are NOT the subject (e.g. sibling/precursor cell types from the CAS hierarchy). A sentence whose subject is one of these should not be treated as evidence about the subject.",
+      "items": { "type": "string" }
+    },
+    "scope": {
+      "type": "object",
+      "description": "Biological context the report is restricted to — the query's contextual restriction unioned with the annotation's CAS composition. Drives evidence tagging and scope-targeted escalation. All keys optional.",
+      "properties": {
+        "organism": { "type": "string", "description": "e.g. 'human' or an NCBITaxon CURIE." },
+        "developmental_stage": { "type": "string", "description": "e.g. 'fetal' / 'adult' or an HsapDv CURIE." },
+        "tissue": { "type": "string", "description": "e.g. 'skin' or a UBERON CURIE." }
+      },
+      "additionalProperties": { "type": "string" }
+    },
+    "aspects": {
+      "type": "array",
+      "description": "One entry per report aspect, each with an authored focused query. The five names are fixed and correspond to the report's sections.",
+      "minItems": 5,
+      "maxItems": 5,
+      "items": {
+        "type": "object",
+        "required": ["name", "query"],
+        "additionalProperties": false,
+        "properties": {
+          "name": {
+            "type": "string",
+            "enum": ["location", "structure", "function", "markers", "marker_roles"]
+          },
+          "query": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Focused retrieval query for this aspect (a retrieval seed, not a claim)."
+          }
+        }
+      },
+      "allOf": [
+        { "contains": { "properties": { "name": { "const": "location" } }, "required": ["name"] } },
+        { "contains": { "properties": { "name": { "const": "structure" } }, "required": ["name"] } },
+        { "contains": { "properties": { "name": { "const": "function" } }, "required": ["name"] } },
+        { "contains": { "properties": { "name": { "const": "markers" } }, "required": ["name"] } },
+        { "contains": { "properties": { "name": { "const": "marker_roles" } }, "required": ["name"] } }
+      ]
+    },
+    "combined_query": {
+      "type": "string",
+      "minLength": 1,
+      "description": "All-aspect query for the hybrid first pass over the seed."
+    },
+    "seed": {
+      "type": "object",
+      "description": "The seed paper for citation traversal, from resolve-name's source_paper.",
+      "required": ["paper_id", "role"],
+      "additionalProperties": false,
+      "properties": {
+        "paper_id": {
+          "type": "string",
+          "description": "Seed identifier: 'CorpusId:NNNN' or 'DOI:10.xxxx/...'."
+        },
+        "role": {
+          "type": "string",
+          "enum": ["atlas", "subatlas"],
+          "description": "Provenance role stamped on hop-0 evidence."
+        }
+      }
+    }
+  }
+}

--- a/tests/unit/fixtures/decomposition/query_decomposition.bad.json
+++ b/tests/unit/fixtures/decomposition/query_decomposition.bad.json
@@ -1,0 +1,11 @@
+{
+  "subject": "x",
+  "aspects": [
+    { "name": "location", "query": "q" },
+    { "name": "structure", "query": "q" },
+    { "name": "function", "query": "q" },
+    { "name": "markers", "query": "q" }
+  ],
+  "combined_query": "q",
+  "seed": { "paper_id": "CorpusId:1", "role": "atlas" }
+}

--- a/tests/unit/fixtures/decomposition/query_decomposition.good.json
+++ b/tests/unit/fixtures/decomposition/query_decomposition.good.json
@@ -1,0 +1,15 @@
+{
+  "subject": "Dermal papilla",
+  "aliases": ["Dermal papilla", "DP", "dermal papilla cells"],
+  "non_subject_terms": ["dermal condensate", "placode"],
+  "scope": { "organism": "human", "developmental_stage": "fetal", "tissue": "skin" },
+  "aspects": [
+    { "name": "location", "query": "dermal papilla location within the hair follicle in prenatal human skin" },
+    { "name": "structure", "query": "dermal papilla morphology condensed mesenchymal cluster ECM" },
+    { "name": "function", "query": "dermal papilla instructive signalling to hair matrix follicle induction" },
+    { "name": "markers", "query": "dermal papilla marker genes prenatal human skin" },
+    { "name": "marker_roles", "query": "roles of dermal papilla marker genes in signalling and morphogenesis" }
+  ],
+  "combined_query": "Dermal papilla (DP) in prenatal human skin hair follicle: location, structure, function, markers, marker roles",
+  "seed": { "paper_id": "DOI:10.1038/s41586-024-08002-x", "role": "atlas" }
+}

--- a/tests/unit/fixtures/decomposition/query_decomposition.minimal.good.json
+++ b/tests/unit/fixtures/decomposition/query_decomposition.minimal.good.json
@@ -1,0 +1,12 @@
+{
+  "subject": "Iron-recycling macrophage",
+  "aspects": [
+    { "name": "location", "query": "iron-recycling macrophage location" },
+    { "name": "structure", "query": "iron-recycling macrophage morphology" },
+    { "name": "function", "query": "iron-recycling macrophage function" },
+    { "name": "markers", "query": "iron-recycling macrophage markers" },
+    { "name": "marker_roles", "query": "iron-recycling macrophage marker roles" }
+  ],
+  "combined_query": "iron-recycling macrophage: location structure function markers marker roles",
+  "seed": { "paper_id": "CorpusId:273400864", "role": "atlas" }
+}

--- a/tests/unit/fixtures/name_resolution/name_resolution.bad.json
+++ b/tests/unit/fixtures/name_resolution/name_resolution.bad.json
@@ -1,0 +1,5 @@
+{
+  "label": "x",
+  "resolved_names": ["x"],
+  "source_paper": {}
+}

--- a/tests/unit/fixtures/name_resolution/name_resolution.good.json
+++ b/tests/unit/fixtures/name_resolution/name_resolution.good.json
@@ -1,0 +1,9 @@
+{
+  "label": "Iron-recycling macrophage",
+  "resolved_names": ["Iron-recycling macrophage", "HRG+ macrophage"],
+  "scope": "fetal",
+  "tissue_context": "fetal skin",
+  "confidence": "high",
+  "evidence": "Found in Extended Data Fig. 5 cluster annotations",
+  "source_paper": { "doi": "10.1038/s41586-024-08002-x", "corpus_id": "CorpusId:2762329", "role": "atlas" }
+}

--- a/tests/unit/test_name_resolution_schema.py
+++ b/tests/unit/test_name_resolution_schema.py
@@ -1,0 +1,58 @@
+"""Schema regression for name_resolution.schema.json (the grounder output).
+
+Formalises the resolve-name → query-decomposer contract: required label /
+resolved_names / source_paper, source_paper needing a role + at least one id, and
+additionalProperties teeth.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import jsonschema
+import pytest
+
+from atlas_chat.schemas import load_schema
+
+FIXTURES = Path(__file__).parent / "fixtures" / "name_resolution"
+SCHEMA = "name_resolution.schema.json"
+
+
+def _load(name: str) -> object:
+    return json.loads((FIXTURES / name).read_text())
+
+
+def _errors(data: object) -> list[str]:
+    validator = jsonschema.Draft202012Validator(load_schema(SCHEMA))
+    return [e.message for e in validator.iter_errors(data)]
+
+
+@pytest.mark.unit
+def test_schema_is_well_formed() -> None:
+    jsonschema.Draft202012Validator.check_schema(load_schema(SCHEMA))
+
+
+@pytest.mark.unit
+def test_good_validates() -> None:
+    assert _errors(_load("name_resolution.good.json")) == []
+
+
+@pytest.mark.unit
+def test_requires_source_paper() -> None:
+    data = _load("name_resolution.good.json")
+    del data["source_paper"]
+    assert _errors(data)
+
+
+@pytest.mark.unit
+def test_source_paper_requires_role_and_id() -> None:
+    # The bad fixture's source_paper is empty (no role, no doi/corpus_id).
+    assert _errors(_load("name_resolution.bad.json"))
+
+
+@pytest.mark.unit
+def test_additional_properties_closed() -> None:
+    data = _load("name_resolution.good.json")
+    data["bogus_field"] = 1
+    assert _errors(data)

--- a/tests/unit/test_query_decomposition_schema.py
+++ b/tests/unit/test_query_decomposition_schema.py
@@ -1,0 +1,112 @@
+"""Schema + hook regression for query_decomposition.schema.json (Layer B).
+
+Pins well-formedness, the minimal valid decomposition, the fixed-5-aspects
+constraint, the seed-role enum, additionalProperties teeth, and the
+check_query_decomposition PostToolUse hook (subprocess 0/2/ignore).
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import jsonschema
+import pytest
+
+from atlas_chat.schemas import load_schema
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+FIXTURES = Path(__file__).parent / "fixtures" / "decomposition"
+SCHEMA = "query_decomposition.schema.json"
+HOOK = REPO_ROOT / ".claude" / "hooks" / "check_query_decomposition.py"
+
+
+def _load(name: str) -> object:
+    return json.loads((FIXTURES / name).read_text())
+
+
+def _errors(data: object) -> list[str]:
+    validator = jsonschema.Draft202012Validator(load_schema(SCHEMA))
+    return [e.message for e in validator.iter_errors(data)]
+
+
+def _run_hook(file_path: str, payload: object) -> subprocess.CompletedProcess:
+    hook_input = json.dumps(
+        {"tool_input": {"file_path": file_path, "content": json.dumps(payload)}}
+    )
+    return subprocess.run(
+        [sys.executable, str(HOOK)],
+        input=hook_input,
+        capture_output=True,
+        text=True,
+        cwd=REPO_ROOT,
+    )
+
+
+@pytest.mark.unit
+def test_schema_is_well_formed() -> None:
+    jsonschema.Draft202012Validator.check_schema(load_schema(SCHEMA))
+
+
+@pytest.mark.unit
+def test_minimal_good_validates() -> None:
+    assert _errors(_load("query_decomposition.minimal.good.json")) == []
+
+
+@pytest.mark.unit
+def test_rich_good_validates() -> None:
+    assert _errors(_load("query_decomposition.good.json")) == []
+
+
+@pytest.mark.unit
+def test_requires_all_five_aspects() -> None:
+    # The bad fixture has only four aspects.
+    assert _errors(_load("query_decomposition.bad.json"))
+
+
+@pytest.mark.unit
+def test_rejects_unknown_aspect_name() -> None:
+    data = _load("query_decomposition.minimal.good.json")
+    data["aspects"][0]["name"] = "other"
+    assert _errors(data)
+
+
+@pytest.mark.unit
+def test_seed_role_enum_enforced() -> None:
+    data = _load("query_decomposition.minimal.good.json")
+    data["seed"]["role"] = "external"
+    assert _errors(data)
+
+
+@pytest.mark.unit
+def test_additional_properties_closed() -> None:
+    data = _load("query_decomposition.minimal.good.json")
+    data["bogus_field"] = 1
+    assert _errors(data)
+
+
+@pytest.mark.unit
+def test_hook_accepts_good() -> None:
+    r = _run_hook(
+        "projects/x/traversal_output/ct/query_decomposition.json",
+        _load("query_decomposition.good.json"),
+    )
+    assert r.returncode == 0, r.stderr
+
+
+@pytest.mark.unit
+def test_hook_rejects_bad() -> None:
+    r = _run_hook(
+        "projects/x/traversal_output/ct/query_decomposition.json",
+        _load("query_decomposition.bad.json"),
+    )
+    assert r.returncode == 2
+    assert "VALIDATION FAILED" in r.stderr
+
+
+@pytest.mark.unit
+def test_hook_ignores_other_files() -> None:
+    r = _run_hook("projects/x/notes.txt", {"anything": 1})
+    assert r.returncode == 0


### PR DESCRIPTION
Reframe the workflow entry from a single cell-type label to a free-text query (e.g. "all fibroblasts", "fibroblasts in adult tissue", or a bare label). Add an agentic selection step (1b): interpret the query against the CAS+ annotations, matching flexibly on cell_label / lineage / synonyms and applying any contextual restriction as a filter over composition — deliberately no rigid query grammar. Record the resolved set to projects/{project}/selections/{slug}.json for provenance; steps 2-9 then run per selected cell type with the query's context as scope.

Layer B (per-type aspect decomposition) to be reviewed before implementation.