### PR TITLE
Embed local index chunks in windows the model can actually read (#23)

### DIFF
--- a/.claude/skills/local-paper-index/SKILL.md
+++ b/.claude/skills/local-paper-index/SKILL.md
@@ -52,16 +52,27 @@ uv run python scripts/setup_local_index.py search \
 projects/<name>/local_index/
   corpus.json                # version, atlas_doi, use_in_fanout flag, papers list
   papers/<paper_slug>/
-    manifest.json            # role, source_type, hash, n_chunks, paper metadata
+    manifest.json            # role, source_type, hash, n_chunks, n_windows, paper metadata
     source/{paper.jats.xml | paper.pdf}
-    chunks/{chunks.jsonl, embeddings.npy, chunks.fulltext.txt}
+    chunks/{chunks.jsonl, embeddings.npy, window_index.json, chunks.fulltext.txt}
     citations/{sentences.jsonl, ref_resolution.json}   # JATS papers only
     snippet_index/snippets.json
 ```
 
 `paper_slug` = DOI lowercased with `/` → `_` (e.g. `10.1126_science.adf1226`), sha1 fallback for pathological DOIs.
 
-Builds are idempotent — per-paper hash short-circuits a rebuild unless `--force` or the source changed. Adding or removing one paper never re-embeds the others.
+Builds are idempotent — per-paper hash short-circuits a rebuild unless `--force` or the source changed. Adding or removing one paper never re-embeds the others. The hash covers the source bytes, the embedding model, `MANIFEST_VERSION`, and the chunk/window sizes, so changing any of those invalidates existing indexes instead of leaving stale vectors in place.
+
+**Chunks vs embedding windows.** A chunk (~2800 chars) is the unit stored, returned and quoted. The embedding model only reads its first 256 word pieces, so each chunk is embedded as one or more overlapping windows that fit, and `window_index.json` maps every row of `embeddings.npy` back to its chunk. A chunk scores as the best of its windows and is returned once, with its full text. Papers built before this (no `window_index.json`) are skipped at load with a warning — rebuild them.
+
+**Rebuilding a whole corpus.** `init-corpus --force` only re-does the atlas paper and the JATS subatlas papers named in the project config, so papers added from a PDF are left behind. Use `rebuild` instead — it walks `corpus.json` and force-rebuilds each paper from the source already on disk:
+
+```bash
+python scripts/setup_local_index.py rebuild --project <project>          # whole corpus
+python scripts/setup_local_index.py rebuild --project <project> --paper 10.1234/x
+```
+
+It prints the chunk and window counts before and after per paper, and exits non-zero if any paper failed.
 
 ## Integration with fan-out
 

--- a/.claude/skills/local-paper-index/SKILL.md
+++ b/.claude/skills/local-paper-index/SKILL.md
@@ -74,6 +74,14 @@ python scripts/setup_local_index.py rebuild --project <project> --paper 10.1234/
 
 It prints the chunk and window counts before and after per paper, and exits non-zero if any paper failed.
 
+**Checking before you rely on it.** `check` reports any paper whose vectors cannot be used and why, and exits non-zero if there are any:
+
+```bash
+python scripts/setup_local_index.py check --project <project>
+```
+
+Worth running before a batch of reports. A corpus that can serve no papers returns `[]` from `search`, which looks the same as a corpus with nothing relevant to say — so that case is also logged at ERROR level, not just as a warning.
+
 ## Integration with fan-out
 
 **Default: local index is NOT queried during `FanOut._citation_traverse`.** Subatlas papers are surfaced as a curated corpus; fan-out relies on ASTA for citation traversal.

--- a/docs/codebase_overview.md
+++ b/docs/codebase_overview.md
@@ -93,6 +93,8 @@ cli.py:main()
 
 **Local snippet index** (`local_snippet_index.py`) — self-contained vector search engine: JATS XML or PDF → paragraph segments → chunks → sentence-transformers embeddings (`all-MiniLM-L6-v2`) → ASTA-shape `snippets.json`. The `search()` function returns the same dict shape as ASTA snippets, so downstream code is source-agnostic. Multi-paper corpus model with one `atlas` paper and zero or more `subatlas` papers. `@lru_cache` on `_load_index()` keeps embeddings in memory across calls.
 
+A chunk (~2800 chars) is the unit stored and returned, but the model only reads 256 word pieces, so each chunk is embedded as one or more overlapping windows that fit and `chunks/window_index.json` maps every row of `embeddings.npy` back to its chunk. A chunk scores as the best of its windows and is returned once, with its full text. Indexes built before this carry truncated vectors and no window index; `_load_index()` skips them with a warning, and `setup_local_index.py rebuild` re-embeds a whole corpus from the sources on disk (reusing the cached reference resolution, which is far slower than the embedding).
+
 **`report_checker.py`** — shared between the Python graph (node `ValidateReport`) and the Claude Code hook (`.claude/hooks/check_report_refs.py`). `check_quotes()` does normalised substring matching with ellipsis splitting; `check_references()` validates DOIs and CorpusIds against the catalogue.
 
 **Prompt YAML files** — co-located with agents in `src/atlas_chat/atlas_chat/agents/*.prompt.yaml`. Each has `system_prompt` / `user_prompt` keys with `{variable}` placeholders. `prompt_loader.py:render_prompt()` uses `str.format_map` with a default-passthrough dict so missing variables are left intact rather than raising.

--- a/scripts/setup_local_index.py
+++ b/scripts/setup_local_index.py
@@ -6,6 +6,7 @@ Subcommands::
     init-corpus         Run the asta/jats/pdf waterfall + build atlas index.
     add                 Add a paper from a PDF or JATS file.
     rebuild             Force-rebuild every paper in the corpus from its saved source.
+    check               Report papers whose vectors need a rebuild.
     list                List papers in the corpus.
     remove              Remove a paper from the corpus.
     search              Query the corpus.
@@ -73,6 +74,9 @@ def _build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Re-resolve references instead of reusing the cached resolution (slow)",
     )
+
+    p_check = sub.add_parser("check")
+    p_check.add_argument("--project", required=True)
 
     p_list = sub.add_parser("list")
     p_list.add_argument("--project", required=True)
@@ -148,6 +152,19 @@ def main(argv: list[str] | None = None) -> int:
             if "error" in r:
                 print(f"ERROR {r['slug']}: {r['error']}", file=sys.stderr)
         return 1 if any("error" in r for r in results) else 0
+
+    if args.cmd == "check":
+        from atlas_chat.services.local_snippet_index import stale_papers
+
+        stale = stale_papers(project_dir)
+        print(json.dumps(stale, indent=2))
+        if stale:
+            print(
+                f"{len(stale)} paper(s) need a rebuild: "
+                f"setup_local_index.py rebuild --project {args.project}",
+                file=sys.stderr,
+            )
+        return 1 if stale else 0
 
     if args.cmd == "list":
         from atlas_chat.services.local_snippet_index import list_papers

--- a/scripts/setup_local_index.py
+++ b/scripts/setup_local_index.py
@@ -5,6 +5,7 @@ Subcommands::
     discover-subatlas   Propose subatlas DOIs from label_provenance.json.
     init-corpus         Run the asta/jats/pdf waterfall + build atlas index.
     add                 Add a paper from a PDF or JATS file.
+    rebuild             Force-rebuild every paper in the corpus from its saved source.
     list                List papers in the corpus.
     remove              Remove a paper from the corpus.
     search              Query the corpus.
@@ -63,6 +64,15 @@ def _build_parser() -> argparse.ArgumentParser:
     src.add_argument("--jats", type=Path, default=None)
     p_add.add_argument("--role", default="subatlas", choices=("atlas", "subatlas"))
     p_add.add_argument("--force", action="store_true")
+
+    p_reb = sub.add_parser("rebuild")
+    p_reb.add_argument("--project", required=True)
+    p_reb.add_argument("--paper", action="append", default=None, help="Limit to this DOI")
+    p_reb.add_argument(
+        "--refresh-refs",
+        action="store_true",
+        help="Re-resolve references instead of reusing the cached resolution (slow)",
+    )
 
     p_list = sub.add_parser("list")
     p_list.add_argument("--project", required=True)
@@ -128,6 +138,16 @@ def main(argv: list[str] | None = None) -> int:
         )
         print(json.dumps(manifest, indent=2))
         return 0
+
+    if args.cmd == "rebuild":
+        from atlas_chat.services.local_snippet_index import rebuild_corpus
+
+        results = rebuild_corpus(project_dir, dois=args.paper, refresh_refs=args.refresh_refs)
+        print(json.dumps(results, indent=2))
+        for r in results:
+            if "error" in r:
+                print(f"ERROR {r['slug']}: {r['error']}", file=sys.stderr)
+        return 1 if any("error" in r for r in results) else 0
 
     if args.cmd == "list":
         from atlas_chat.services.local_snippet_index import list_papers

--- a/src/atlas_chat/atlas_chat/services/local_snippet_index.py
+++ b/src/atlas_chat/atlas_chat/services/local_snippet_index.py
@@ -1324,6 +1324,72 @@ def rebuild_corpus(
 # ------------------------------------------------------------------
 
 
+def _stale_reason(
+    manifest: dict[str, Any],
+    windows_path: Path,
+    n_vectors: int,
+    chunks_by_id: dict[int, Any] | None = None,
+) -> str | None:
+    """Why this paper's vectors cannot be used, or ``None`` if they can.
+
+    Kept separate from loading so a caller can ask about a corpus without paying
+    for it — see :func:`stale_papers`.
+    """
+    version = manifest.get("version")
+    if version != MANIFEST_VERSION:
+        return f"manifest version {version}, expected {MANIFEST_VERSION}"
+    if not windows_path.exists():
+        return "no window_index.json (built before #23)"
+    try:
+        rows = json.loads(windows_path.read_text())["rows"]
+    except Exception as exc:
+        return f"unreadable window_index.json ({type(exc).__name__})"
+    if len(rows) != n_vectors:
+        return f"window index has {len(rows)} rows, embeddings have {n_vectors}"
+    if chunks_by_id is not None:
+        # Row counts can agree while the ids are stale. An unknown chunk_id would
+        # otherwise be served as an empty snippet.
+        unknown = sorted({c for c in rows if c not in chunks_by_id})
+        if unknown:
+            return f"window index names chunk_id(s) absent from chunks.jsonl: {unknown[:3]}"
+    return None
+
+
+def stale_papers(project_dir: Path) -> list[dict[str, str]]:
+    """Papers in the corpus whose vectors cannot be used, with the reason.
+
+    Empty list means every paper is usable. Cheap — reads manifests and the
+    window index, never the embeddings. Call this before relying on the local
+    index if you would rather fail loudly than search an empty corpus.
+    """
+    project_dir = Path(project_dir)
+    _migrate_legacy_layout_if_needed(project_dir)
+    out: list[dict[str, str]] = []
+    for entry in _load_corpus_json(project_dir).get("papers", []):
+        slug = entry["slug"]
+        p_dir = _paper_dir(project_dir, slug)
+        manifest_path = p_dir / "manifest.json"
+        emb_path = p_dir / "chunks" / "embeddings.npy"
+        if not (manifest_path.exists() and emb_path.exists()):
+            out.append({"slug": slug, "reason": "incomplete on disk"})
+            continue
+        try:
+            manifest = json.loads(manifest_path.read_text())
+        except Exception:
+            out.append({"slug": slug, "reason": "unreadable manifest.json"})
+            continue
+        # n_windows is the recorded row count; trust it rather than loading numpy.
+        n_vectors = manifest.get("n_windows")
+        reason = _stale_reason(
+            manifest,
+            p_dir / "chunks" / "window_index.json",
+            n_vectors if isinstance(n_vectors, int) else -1,
+        )
+        if reason:
+            out.append({"slug": slug, "reason": reason})
+    return out
+
+
 @lru_cache(maxsize=8)
 def _load_index(project_dir_str: str) -> dict[str, Any]:
     """Load corpus + all per-paper indices into memory.
@@ -1342,6 +1408,7 @@ def _load_index(project_dir_str: str) -> dict[str, Any]:
 
     embeddings_parts: list[Any] = []
     row_index: list[dict[str, Any]] = []
+    skipped: list[tuple[str, str]] = []
 
     for entry in papers:
         slug = entry["slug"]
@@ -1371,39 +1438,19 @@ def _load_index(project_dir_str: str) -> dict[str, Any]:
 
         vecs = np.load(emb_path)
 
-        # window_index.json maps each embedding row to its chunk. Papers built
-        # before #23 have one row per chunk and no window index; they carry
-        # truncated vectors, so skip rather than mis-score them — a bumped
-        # MANIFEST_VERSION means a rebuild will regenerate both files.
-        if not windows_path.exists():
+        # A paper whose vectors predate the current chunking cannot be scored
+        # against papers that postdate it, so it is skipped rather than
+        # mis-ranked. _stale_reason names why; `rebuild` fixes all of them.
+        reason = _stale_reason(manifest, windows_path, len(vecs), chunks_by_id)
+        if reason:
+            skipped.append((slug, reason))
             logger.warning(
-                "Paper %s has no window_index.json (built before #23); "
-                "skipping — rebuild the corpus with `setup_local_index.py rebuild`",
+                "Paper %s skipped: %s — rebuild with `setup_local_index.py rebuild`",
                 slug,
+                reason,
             )
             continue
-        rows = json.loads(windows_path.read_text()).get("rows", [])
-        if len(rows) != len(vecs):
-            logger.warning(
-                "Paper %s window index (%d rows) does not match embeddings (%d rows); "
-                "skipping — rebuild the corpus",
-                slug,
-                len(rows),
-                len(vecs),
-            )
-            continue
-        # A row count can match while the ids are stale. An unknown chunk_id would
-        # otherwise be served as an empty snippet, so skip the paper instead.
-        unknown = {c for c in rows if c not in chunks_by_id}
-        if unknown:
-            logger.warning(
-                "Paper %s window index names %d chunk_id(s) missing from chunks.jsonl "
-                "(e.g. %s); skipping — rebuild the corpus",
-                slug,
-                len(unknown),
-                sorted(unknown)[:3],
-            )
-            continue
+        rows = json.loads(windows_path.read_text())["rows"]
 
         embeddings_parts.append(vecs)
         for chunk_id in rows:
@@ -1419,6 +1466,21 @@ def _load_index(project_dir_str: str) -> dict[str, Any]:
             )
 
     embeddings = np.vstack(embeddings_parts) if embeddings_parts else np.zeros((0, 0))
+
+    # A corpus that lists papers but can serve none of them looks identical, from
+    # the caller's side, to a corpus with nothing relevant to say: search returns
+    # []. Say so at ERROR, so the difference reaches someone who is only watching
+    # for errors.
+    if papers and not row_index:
+        logger.error(
+            "Local index for %s has %d paper(s) but none are usable (%s). "
+            "Searches will return nothing until you run "
+            "`setup_local_index.py rebuild --project %s`.",
+            project_dir,
+            len(papers),
+            "; ".join(f"{slug}: {reason}" for slug, reason in skipped) or "unknown",
+            project_dir,
+        )
 
     return {
         "corpus": corpus,
@@ -1586,6 +1648,9 @@ def main(argv: list[str] | None = None) -> int:
         help="Re-resolve references instead of reusing the cached resolution (slow)",
     )
 
+    p_check = sub.add_parser("check", help="Report papers whose vectors need a rebuild")
+    p_check.add_argument("--project", required=True, type=Path)
+
     p_list = sub.add_parser("list", help="List papers in the corpus")
     p_list.add_argument("--project", required=True, type=Path)
 
@@ -1627,6 +1692,10 @@ def main(argv: list[str] | None = None) -> int:
         results = rebuild_corpus(args.project, dois=args.paper, refresh_refs=args.refresh_refs)
         print(json.dumps(results, indent=2))
         return 1 if any("error" in r for r in results) else 0
+    if args.cmd == "check":
+        stale = stale_papers(args.project)
+        print(json.dumps(stale, indent=2))
+        return 1 if stale else 0
     if args.cmd == "list":
         print(json.dumps(list_papers(args.project), indent=2))
         return 0

--- a/src/atlas_chat/atlas_chat/services/local_snippet_index.py
+++ b/src/atlas_chat/atlas_chat/services/local_snippet_index.py
@@ -20,7 +20,8 @@ On-disk layout::
         <paper_slug>/
           manifest.json
           source/{paper.jats.xml|paper.pdf|paper.md}
-          chunks/{chunks.jsonl, embeddings.npy, chunks.fulltext.txt}
+          chunks/{chunks.jsonl, embeddings.npy, window_index.json,
+                  chunks.fulltext.txt}
           citations/{sentences.jsonl, ref_resolution.json}   # JATS only
           snippet_index/snippets.json
 
@@ -42,6 +43,7 @@ import sys
 import urllib.parse
 import urllib.request
 import xml.etree.ElementTree as ET
+from collections.abc import Callable
 from dataclasses import asdict, dataclass, field
 from functools import lru_cache
 from pathlib import Path
@@ -52,7 +54,16 @@ logger = logging.getLogger(__name__)
 EMBED_MODEL = "sentence-transformers/all-MiniLM-L6-v2"
 CHUNK_TARGET_CHARS = 2800
 CHUNK_OVERLAP_CHARS = 200
-MANIFEST_VERSION = 2  # bumped: per-paper manifest, corpus model
+
+# The embedding model only reads its first ``EMBED_MAX_TOKENS`` word pieces and
+# silently drops the rest, while chunks run to ~2800 chars. So chunks are the
+# unit we store and return, and each is embedded as one or more windows that fit
+# the model; a chunk scores as the best of its windows. See issue #23.
+EMBED_MAX_TOKENS = 256  # all-MiniLM-L6-v2 max_seq_length
+WINDOW_TARGET_TOKENS = 230  # headroom for [CLS]/[SEP] and tokeniser disagreement
+WINDOW_OVERLAP_TOKENS = 40
+
+MANIFEST_VERSION = 3  # bumped: windowed embeddings (#23)
 CORPUS_VERSION = 1
 
 SourceType = Literal["jats", "pdf"]
@@ -301,6 +312,107 @@ def chunk_segments(
 
     fulltext = "".join(fulltext_parts)
     return fulltext, chunks
+
+
+_SENTENCE_END = re.compile(r"(?<=[.!?])\s+|\n\n+")
+
+
+def _sentence_spans(text: str) -> list[tuple[int, int]]:
+    """Char spans of the sentence-ish pieces of ``text``, in order and covering it all."""
+    spans: list[tuple[int, int]] = []
+    pos = 0
+    for m in _SENTENCE_END.finditer(text):
+        if m.end() > pos:
+            spans.append((pos, m.end()))
+            pos = m.end()
+    if pos < len(text):
+        spans.append((pos, len(text)))
+    return spans or [(0, len(text))]
+
+
+def _split_long_span(
+    text: str,
+    start: int,
+    end: int,
+    count_tokens: Callable[[str], int],
+    target_tokens: int,
+) -> list[tuple[int, int]]:
+    """Break one over-long span at whitespace so each piece fits ``target_tokens``.
+
+    Used for the rare sentence (or unsplittable table row) that is on its own
+    longer than a window.
+    """
+    if count_tokens(text[start:end]) <= target_tokens:
+        return [(start, end)]
+
+    # Pack whole words. Summing per-word counts overestimates the count of the
+    # joined text (word pieces never merge across whitespace), so a piece built
+    # this way is guaranteed to fit — a char-proportional split is not, because
+    # tokens per char varies wildly across gene symbols and accession numbers.
+    word_spans = [(m.start(), m.end()) for m in re.finditer(r"\S+", text[start:end])]
+    if not word_spans:
+        return [(start, end)]
+
+    out: list[tuple[int, int]] = []
+    piece_start = 0
+    running = 0
+    for w_start, w_end in word_spans:
+        cost = count_tokens(text[start + w_start : start + w_end])
+        if running and running + cost > target_tokens:
+            out.append((start + piece_start, start + w_start))
+            piece_start = w_start
+            running = 0
+        running += cost
+    out.append((start + piece_start, end))
+    return out
+
+
+def split_chunk_into_windows(
+    text: str,
+    count_tokens: Callable[[str], int],
+    target_tokens: int = WINDOW_TARGET_TOKENS,
+    overlap_tokens: int = WINDOW_OVERLAP_TOKENS,
+) -> list[str]:
+    """Split one chunk into overlapping windows the embedding model can read whole.
+
+    ``count_tokens`` should be the embedding model's own tokeniser, so window
+    sizing and encoding cannot drift apart. Every window is an exact substring of
+    ``text``; a chunk that already fits comes back as a single window equal to its
+    input, so short chunks behave exactly as they did before windowing.
+
+    Windows are the retrieval unit only — the chunk stays the unit that is stored,
+    returned and quoted.
+    """
+    if not text:
+        return []
+    if count_tokens(text) <= target_tokens:
+        return [text]
+
+    # Sentence spans, with any over-long sentence pre-broken so packing always fits.
+    spans: list[tuple[int, int]] = []
+    for start, end in _sentence_spans(text):
+        spans.extend(_split_long_span(text, start, end, count_tokens, target_tokens))
+    costs = [count_tokens(text[a:b]) for a, b in spans]
+
+    windows: list[str] = []
+    i = 0
+    while i < len(spans):
+        total = 0
+        j = i
+        while j < len(spans) and (total + costs[j] <= target_tokens or j == i):
+            total += costs[j]
+            j += 1
+        windows.append(text[spans[i][0] : spans[j - 1][1]])
+        if j >= len(spans):
+            break
+        # Step back over the trailing spans that fit in the overlap budget.
+        back = 0
+        carried = 0
+        while back < (j - i) - 1 and carried + costs[j - 1 - back] <= overlap_tokens:
+            carried += costs[j - 1 - back]
+            back += 1
+        i = j - back
+    return windows
 
 
 # ------------------------------------------------------------------
@@ -591,22 +703,117 @@ def _local_corpus_id(doi: str) -> str:
 
 
 def _manifest_hash(source_bytes: bytes, source_type: SourceType) -> str:
+    """Hash of everything that would change the vectors, so a parameter change
+    invalidates existing indexes instead of leaving stale vectors in place."""
     h = hashlib.sha256()
     h.update(source_bytes)
-    h.update(f"|emb={EMBED_MODEL}|st={source_type}|m={MANIFEST_VERSION}".encode())
+    h.update(
+        (
+            f"|emb={EMBED_MODEL}|st={source_type}|m={MANIFEST_VERSION}"
+            f"|ct={CHUNK_TARGET_CHARS}|co={CHUNK_OVERLAP_CHARS}"
+            f"|wt={WINDOW_TARGET_TOKENS}|wo={WINDOW_OVERLAP_TOKENS}"
+        ).encode()
+    )
     return h.hexdigest()
 
 
-def _embed_and_save(texts: list[str], out_path: Path) -> None:
-    import numpy as np
+@lru_cache(maxsize=2)
+def _get_embedder(model_name: str = EMBED_MODEL) -> Any:
+    """Load the sentence-transformers model once per process.
+
+    ``search`` used to reload it on every call, which dominated the cost of a
+    query on a warm index.
+    """
     from sentence_transformers import SentenceTransformer
 
-    model = SentenceTransformer(EMBED_MODEL)
+    model = SentenceTransformer(model_name)
+    if getattr(model, "max_seq_length", None) != EMBED_MAX_TOKENS:
+        logger.warning(
+            "%s reports max_seq_length=%s but windows are sized for %d — "
+            "check WINDOW_TARGET_TOKENS.",
+            model_name,
+            getattr(model, "max_seq_length", "?"),
+            EMBED_MAX_TOKENS,
+        )
+    return model
+
+
+def _token_counter(tokenizer: Any) -> Callable[[str], int]:
+    """Count word pieces without tripping the model's length warning.
+
+    Counting a whole chunk is how we decide to split it, so the text handed to
+    the tokeniser here is deliberately longer than the model can read. Left to
+    itself transformers logs "Token indices sequence length is longer than the
+    specified maximum" — a warning that means something real during encoding and
+    nothing at all during counting. Silencing it here keeps it trustworthy in the
+    place it matters.
+    """
+
+    def count(text: str) -> int:
+        try:
+            return len(tokenizer(text, add_special_tokens=False, verbose=False)["input_ids"])
+        except TypeError:
+            return len(tokenizer.tokenize(text))
+
+    return count
+
+
+def _cached_ref_resolution(
+    citations_dir: Path,
+    prior: dict[str, Any],
+    source_sha: str,
+) -> dict[str, dict[str, str | None]] | None:
+    """The previous run's ``ref_resolution.json``, if it was built from this exact
+    source. ``None`` when there is nothing safe to reuse.
+
+    Manifests written before ``source_sha`` existed get the benefit of the doubt:
+    the source lives inside the paper directory and only changes when the paper is
+    re-fetched, so the stored resolution came from the stored source. Callers that
+    want to resolve again regardless pass ``refresh_refs`` to
+    :func:`build_paper_index`.
+    """
+    if "source_sha" in prior:
+        if prior["source_sha"] != source_sha:
+            return None
+    elif not prior:
+        return None
+    path = citations_dir / "ref_resolution.json"
+    if not path.exists():
+        return None
+    try:
+        cached = json.loads(path.read_text())
+    except Exception:
+        return None
+    return cached if isinstance(cached, dict) and cached else None
+
+
+def _embed_chunks_and_save(chunks: list[Chunk], chunks_dir: Path) -> int:
+    """Embed each chunk as one or more model-sized windows.
+
+    Writes ``embeddings.npy`` with one row per window and ``window_index.json``
+    mapping row → ``chunk_id``. Returns the number of windows.
+    """
+    import numpy as np
+
+    model = _get_embedder()
+    count_tokens = _token_counter(model.tokenizer)
+
+    texts: list[str] = []
+    rows: list[int] = []
+    for chunk in chunks:
+        windows = split_chunk_into_windows(chunk.text, count_tokens) or [chunk.text]
+        texts.extend(windows)
+        rows.extend([chunk.chunk_id] * len(windows))
+
     vecs = model.encode(texts, convert_to_numpy=True, show_progress_bar=False)
     norms = np.linalg.norm(vecs, axis=1, keepdims=True)
     norms[norms == 0] = 1.0
     vecs = vecs / norms
-    np.save(out_path, vecs)
+    np.save(chunks_dir / "embeddings.npy", vecs)
+    (chunks_dir / "window_index.json").write_text(
+        json.dumps({"n_chunks": len(chunks), "n_windows": len(rows), "rows": rows})
+    )
+    return len(rows)
 
 
 def _resolution_breakdown(ref_resolution: dict[str, dict[str, str | None]]) -> dict[str, int]:
@@ -625,6 +832,7 @@ def build_paper_index(
     pdf_path: Path | None = None,
     role: PaperRole = "atlas",
     force: bool = False,
+    refresh_refs: bool = False,
 ) -> dict[str, Any]:
     """Build (or refresh) the local index entry for one paper.
 
@@ -673,16 +881,16 @@ def build_paper_index(
 
     raw_bytes = source_path.read_bytes()
     expected_hash = _manifest_hash(raw_bytes, source_type)
+    source_sha = hashlib.sha256(raw_bytes).hexdigest()
     manifest_path = p_dir / "manifest.json"
-    if manifest_path.exists() and not force:
-        try:
-            existing = json.loads(manifest_path.read_text())
-            if existing.get("hash") == expected_hash:
-                logger.info("Paper %s already up to date.", slug)
-                _upsert_corpus_entry(project_dir, slug, existing)
-                return existing
-        except Exception:
-            pass
+    prior: dict[str, Any] = {}
+    if manifest_path.exists():
+        with contextlib.suppress(Exception):
+            prior = json.loads(manifest_path.read_text())
+    if prior and not force and prior.get("hash") == expected_hash:
+        logger.info("Paper %s already up to date.", slug)
+        _upsert_corpus_entry(project_dir, slug, prior)
+        return prior
 
     # Extract body segments
     if source_type == "jats":
@@ -702,7 +910,7 @@ def build_paper_index(
         for c in chunks:
             fh.write(json.dumps(asdict(c)) + "\n")
 
-    _embed_and_save([c.text for c in chunks], chunks_dir / "embeddings.npy")
+    n_windows = _embed_chunks_and_save(chunks, chunks_dir)
 
     # Citation graph: JATS only — PDFs have no xref markers.
     sent_rows: list[SentenceRow] = []
@@ -715,8 +923,19 @@ def build_paper_index(
             with (citations_dir / "sentences.jsonl").open("w") as fh:
                 for r in sent_rows:
                     fh.write(json.dumps(asdict(r)) + "\n")
-            ref_resolution = _resolve_refs_to_corpus_ids(refs_full)
-            (citations_dir / "ref_resolution.json").write_text(json.dumps(ref_resolution, indent=2))
+            # Resolving references means one Semantic Scholar title-match per
+            # unresolved ref, serially — tens of minutes for a paper with a long
+            # bibliography. It depends only on the source, so a rebuild forced by
+            # a chunking or embedding change reuses it.
+            cached_refs = _cached_ref_resolution(citations_dir, prior, source_sha)
+            if cached_refs is not None and not refresh_refs:
+                logger.info("Reusing cached reference resolution for %s (source unchanged)", slug)
+                ref_resolution = cached_refs
+            else:
+                ref_resolution = _resolve_refs_to_corpus_ids(refs_full)
+                (citations_dir / "ref_resolution.json").write_text(
+                    json.dumps(ref_resolution, indent=2)
+                )
             ref_id_to_corpus = {
                 rid: entry["corpus_id"]
                 for rid, entry in ref_resolution.items()
@@ -738,8 +957,10 @@ def build_paper_index(
         "source_type": source_type,
         "citation_graph": citation_graph,
         "hash": expected_hash,
+        "source_sha": source_sha,
         "embedding_model": EMBED_MODEL,
         "n_chunks": len(chunks),
+        "n_windows": n_windows,
         "n_sentences": len(sent_rows),
         "n_refs": len(ref_resolution),
         "n_corpus_ids_resolved": len(ref_id_to_corpus),
@@ -748,10 +969,11 @@ def build_paper_index(
     }
     manifest_path.write_text(json.dumps(manifest, indent=2))
     logger.info(
-        "Built paper index [%s/%s]: %d chunks, %d sentences, citation_graph=%s",
+        "Built paper index [%s/%s]: %d chunks (%d embed windows), %d sentences, citation_graph=%s",
         slug,
         source_type,
         len(chunks),
+        n_windows,
         len(sent_rows),
         citation_graph,
     )
@@ -850,6 +1072,7 @@ def _upsert_corpus_entry(project_dir: Path, slug: str, manifest: dict[str, Any])
         "source_type": manifest["source_type"],
         "title": manifest.get("paper", {}).get("title", ""),
         "n_chunks": manifest.get("n_chunks", 0),
+        "n_windows": manifest.get("n_windows"),
     }
     by_slug = {p["slug"]: p for p in corpus.get("papers", [])}
     by_slug[slug] = entry
@@ -900,9 +1123,14 @@ def _migrate_legacy_layout_if_needed(project_dir: Path) -> None:
         if old.exists() and not new.exists():
             old.rename(new)
 
-    # Synthesize a v2 manifest from the v1 fields we can fill.
+    # Synthesize a manifest from the v1 fields we can fill. Keep the legacy
+    # version: migration only moves files, and the vectors it moves were embedded
+    # from truncated chunks with no window index (#23). Claiming the current
+    # version would make a stale index look fresh — `rebuild` re-embeds and
+    # stamps the real version.
     new_manifest = {
-        "version": MANIFEST_VERSION,
+        "version": legacy.get("version", 1),
+        "needs_rebuild": True,
         "slug": slug,
         "doi": doi,
         "role": "atlas",
@@ -970,6 +1198,7 @@ def add_paper(
     jats_path: Path | None = None,
     role: PaperRole = "subatlas",
     force: bool = False,
+    refresh_refs: bool = False,
 ) -> dict[str, Any]:
     """Add a subatlas reference paper to the corpus."""
     return build_paper_index(
@@ -979,6 +1208,7 @@ def add_paper(
         jats_path=jats_path,
         role=role,
         force=force,
+        refresh_refs=refresh_refs,
     )
 
 
@@ -1007,6 +1237,88 @@ def list_papers(project_dir: Path) -> list[dict[str, Any]]:
     return _load_corpus_json(project_dir).get("papers", [])
 
 
+def rebuild_corpus(
+    project_dir: Path,
+    dois: list[str] | None = None,
+    refresh_refs: bool = False,
+) -> list[dict[str, Any]]:
+    """Force-rebuild every paper in the corpus from the source already on disk.
+
+    ``init-corpus --force`` only re-does the atlas paper and the JATS subatlas
+    papers named in the project config, so papers added from a PDF via
+    ``add_paper`` are left behind. This walks ``corpus.json`` instead, so whatever
+    is in the corpus gets rebuilt.
+
+    Reference resolution is reused when the source has not changed, since it is
+    much slower than the rebuild itself; pass ``refresh_refs`` to redo it.
+
+    Pass ``dois`` to restrict it to particular papers. Returns one result dict per
+    paper, with the chunk and window counts before and after, or an ``error``.
+    """
+    _migrate_legacy_layout_if_needed(project_dir)
+    wanted: set[str] | None = {paper_slug(d) for d in dois} if dois else None
+
+    results: list[dict[str, Any]] = []
+    for entry in _load_corpus_json(project_dir).get("papers", []):
+        slug = entry["slug"]
+        if wanted is not None and slug not in wanted:
+            continue
+        p_dir = _paper_dir(project_dir, slug)
+        manifest_path = p_dir / "manifest.json"
+        before: dict[str, Any] = {}
+        if manifest_path.exists():
+            with contextlib.suppress(Exception):
+                before = json.loads(manifest_path.read_text())
+
+        doi = before.get("doi") or entry.get("doi")
+        role: PaperRole = before.get("role") or entry.get("role") or "subatlas"
+        source_type = before.get("source_type") or entry.get("source_type")
+        jats = p_dir / "source" / "paper.jats.xml"
+        pdf = p_dir / "source" / "paper.pdf"
+        if source_type == "pdf" or (source_type is None and pdf.exists()):
+            kwargs: dict[str, Any] = {"pdf_path": pdf}
+            source_path = pdf
+        else:
+            kwargs = {"jats_path": jats}
+            source_path = jats
+
+        result: dict[str, Any] = {
+            "slug": slug,
+            "doi": doi,
+            "source_type": source_type,
+            "n_chunks_before": before.get("n_chunks"),
+            "n_windows_before": before.get("n_windows"),
+        }
+        if not doi:
+            result["error"] = "no DOI in manifest or corpus entry"
+            results.append(result)
+            continue
+        if not source_path.exists():
+            result["error"] = f"source missing: {source_path}"
+            results.append(result)
+            continue
+
+        try:
+            manifest = build_paper_index(
+                project_dir,
+                doi,
+                role=role,
+                force=True,
+                refresh_refs=refresh_refs,
+                **kwargs,
+            )
+        except Exception as exc:
+            result["error"] = f"{type(exc).__name__}: {exc}"
+        else:
+            result["n_chunks"] = manifest.get("n_chunks")
+            result["n_windows"] = manifest.get("n_windows")
+            result["version"] = manifest.get("version")
+        results.append(result)
+
+    _load_index.cache_clear()
+    return results
+
+
 # ------------------------------------------------------------------
 # Retrieval API
 # ------------------------------------------------------------------
@@ -1018,7 +1330,8 @@ def _load_index(project_dir_str: str) -> dict[str, Any]:
 
     Returns a dict with concatenated embeddings keyed to a global row index,
     plus a parallel list mapping each row → (slug, paper_meta, chunk dict,
-    snippet dict). Single ``np.load`` per paper; cheap to rebuild after add/remove.
+    snippet dict). One row per **embed window**, so several rows can point at the
+    same chunk. Single ``np.load`` per paper; cheap to rebuild after add/remove.
     """
     import numpy as np
 
@@ -1036,6 +1349,7 @@ def _load_index(project_dir_str: str) -> dict[str, Any]:
         manifest_path = p_dir / "manifest.json"
         emb_path = p_dir / "chunks" / "embeddings.npy"
         chunks_path = p_dir / "chunks" / "chunks.jsonl"
+        windows_path = p_dir / "chunks" / "window_index.json"
         snippets_path = p_dir / "snippet_index" / "snippets.json"
         if not (manifest_path.exists() and emb_path.exists() and chunks_path.exists()):
             logger.warning("Paper %s incomplete on disk; skipping", slug)
@@ -1048,6 +1362,7 @@ def _load_index(project_dir_str: str) -> dict[str, Any]:
         with chunks_path.open() as fh:
             for line in fh:
                 chunks.append(json.loads(line))
+        chunks_by_id = {ch["chunk_id"]: ch for ch in chunks}
 
         snippets_by_chunk: dict[int, dict[str, Any]] = {}
         if snippets_path.exists():
@@ -1055,15 +1370,51 @@ def _load_index(project_dir_str: str) -> dict[str, Any]:
             snippets_by_chunk = {s["chunk_id"]: s for s in snip_list}
 
         vecs = np.load(emb_path)
+
+        # window_index.json maps each embedding row to its chunk. Papers built
+        # before #23 have one row per chunk and no window index; they carry
+        # truncated vectors, so skip rather than mis-score them — a bumped
+        # MANIFEST_VERSION means a rebuild will regenerate both files.
+        if not windows_path.exists():
+            logger.warning(
+                "Paper %s has no window_index.json (built before #23); "
+                "skipping — rebuild the corpus with `setup_local_index.py rebuild`",
+                slug,
+            )
+            continue
+        rows = json.loads(windows_path.read_text()).get("rows", [])
+        if len(rows) != len(vecs):
+            logger.warning(
+                "Paper %s window index (%d rows) does not match embeddings (%d rows); "
+                "skipping — rebuild the corpus",
+                slug,
+                len(rows),
+                len(vecs),
+            )
+            continue
+        # A row count can match while the ids are stale. An unknown chunk_id would
+        # otherwise be served as an empty snippet, so skip the paper instead.
+        unknown = {c for c in rows if c not in chunks_by_id}
+        if unknown:
+            logger.warning(
+                "Paper %s window index names %d chunk_id(s) missing from chunks.jsonl "
+                "(e.g. %s); skipping — rebuild the corpus",
+                slug,
+                len(unknown),
+                sorted(unknown)[:3],
+            )
+            continue
+
         embeddings_parts.append(vecs)
-        for ch in chunks:
+        for chunk_id in rows:
+            ch = chunks_by_id[chunk_id]
             row_index.append(
                 {
                     "slug": slug,
                     "role": role,
                     "paper_meta": paper_meta,
                     "chunk": ch,
-                    "snippet_entry": snippets_by_chunk.get(ch["chunk_id"], {}),
+                    "snippet_entry": snippets_by_chunk.get(chunk_id, {}),
                 }
             )
 
@@ -1098,34 +1449,35 @@ def search(
     if embeddings.size == 0 or not row_index:
         return []
 
-    from sentence_transformers import SentenceTransformer
-
     paper_slug_filter: set[str] | None = None
     if papers:
         paper_slug_filter = {paper_slug(d) for d in papers}
     role_filter: set[str] | None = set(roles) if roles else None
 
-    model = SentenceTransformer(EMBED_MODEL)
+    model = _get_embedder()
     q_vec = model.encode([query], convert_to_numpy=True)[0]
     q_vec = q_vec / max(np.linalg.norm(q_vec), 1e-9)
     scores = embeddings @ q_vec
 
-    # Eligible rows
-    if paper_slug_filter is not None or role_filter is not None:
-        eligible = [
-            i
-            for i, row in enumerate(row_index)
-            if (paper_slug_filter is None or row["slug"] in paper_slug_filter)
-            and (role_filter is None or row["role"] in role_filter)
-        ]
-        if not eligible:
-            return []
-        eligible_scores = [(i, scores[i]) for i in eligible]
-        eligible_scores.sort(key=lambda x: -x[1])
-        top = eligible_scores[:k]
-    else:
-        top_idx = np.argsort(-scores)[:k].tolist()
-        top = [(i, scores[i]) for i in top_idx]
+    eligible = [
+        i
+        for i, row in enumerate(row_index)
+        if (paper_slug_filter is None or row["slug"] in paper_slug_filter)
+        and (role_filter is None or row["role"] in role_filter)
+    ]
+    if not eligible:
+        return []
+
+    # Rows are embed windows; a chunk scores as the best of its windows, and each
+    # chunk is returned once.
+    best_by_chunk: dict[tuple[str, int], int] = {}
+    for i in eligible:
+        row = row_index[i]
+        key = (row["slug"], row["chunk"]["chunk_id"])
+        current = best_by_chunk.get(key)
+        if current is None or scores[i] > scores[current]:
+            best_by_chunk[key] = i
+    top = sorted(((i, scores[i]) for i in best_by_chunk.values()), key=lambda x: -x[1])[:k]
 
     out: list[dict[str, Any]] = []
     for i, score in top:
@@ -1225,6 +1577,15 @@ def main(argv: list[str] | None = None) -> int:
     p_rm.add_argument("--project", required=True, type=Path)
     p_rm.add_argument("--doi", required=True)
 
+    p_reb = sub.add_parser("rebuild", help="Force-rebuild every paper in the corpus")
+    p_reb.add_argument("--project", required=True, type=Path)
+    p_reb.add_argument("--paper", action="append", default=None, help="Limit to this DOI")
+    p_reb.add_argument(
+        "--refresh-refs",
+        action="store_true",
+        help="Re-resolve references instead of reusing the cached resolution (slow)",
+    )
+
     p_list = sub.add_parser("list", help="List papers in the corpus")
     p_list.add_argument("--project", required=True, type=Path)
 
@@ -1262,6 +1623,10 @@ def main(argv: list[str] | None = None) -> int:
         present = remove_paper(args.project, args.doi)
         print(json.dumps({"removed": present}, indent=2))
         return 0
+    if args.cmd == "rebuild":
+        results = rebuild_corpus(args.project, dois=args.paper, refresh_refs=args.refresh_refs)
+        print(json.dumps(results, indent=2))
+        return 1 if any("error" in r for r in results) else 0
     if args.cmd == "list":
         print(json.dumps(list_papers(args.project), indent=2))
         return 0

--- a/tests/unit/test_local_snippet_index.py
+++ b/tests/unit/test_local_snippet_index.py
@@ -7,17 +7,22 @@ are exercised. The embedding step is bypassed via direct chunk inspection.
 
 from __future__ import annotations
 
+import json
 from textwrap import dedent
 
+import atlas_chat.services.local_snippet_index as lsi
 import pytest
 from atlas_chat.services.local_snippet_index import (
+    _cached_ref_resolution,
     _local_corpus_id,
+    _manifest_hash,
     _merge_snippets,
     _normalize_biorxiv_jats,
     build_sentence_rows,
     chunk_segments,
     extract_body_segments,
     has_local_index,
+    split_chunk_into_windows,
 )
 
 # ---------------------------------------------------------------------------
@@ -109,6 +114,11 @@ def test_chunking_produces_fulltext_with_consistent_offsets() -> None:
         assert c.section
     # Re-assemble cleanly
     assert "ILC3_CCL1+PTGDS+" in fulltext
+    # Every chunk must be embeddable: at least one window, none over budget (#23).
+    for c in chunks:
+        windows = split_chunk_into_windows(c.text, _count_words)
+        assert windows
+        assert all(_count_words(w) <= lsi.WINDOW_TARGET_TOKENS for w in windows)
 
 
 # ---------------------------------------------------------------------------
@@ -182,3 +192,137 @@ def test_local_corpus_id_format() -> None:
 @pytest.mark.unit
 def test_has_local_index_false_for_missing(tmp_path) -> None:
     assert not has_local_index(tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# Windowing for the embedding model (#23)
+# ---------------------------------------------------------------------------
+
+
+def _count_words(text: str) -> int:
+    """Stand-in for the model tokeniser — predictable, so window sizes are exact."""
+    return len(text.split())
+
+
+@pytest.mark.unit
+def test_short_chunk_is_a_single_window() -> None:
+    text = "One short sentence about macrophages."
+    assert split_chunk_into_windows(text, _count_words, target_tokens=50) == [text]
+
+
+@pytest.mark.unit
+def test_empty_chunk_yields_no_windows() -> None:
+    assert split_chunk_into_windows("", _count_words) == []
+
+
+@pytest.mark.unit
+def test_long_chunk_windows_fit_the_budget_and_cover_the_text() -> None:
+    sentences = [f"Sentence number {i} describes marker gene GENE{i} in detail." for i in range(40)]
+    text = " ".join(sentences)
+    windows = split_chunk_into_windows(text, _count_words, target_tokens=30, overlap_tokens=10)
+
+    assert len(windows) > 1
+    for w in windows:
+        assert _count_words(w) <= 30
+        assert w in text, "windows must be exact substrings of the chunk"
+    # Nothing is dropped: every sentence lands in at least one window.
+    joined = " ".join(windows)
+    for sent in sentences:
+        assert sent in joined
+    # Consecutive windows overlap, so a claim spanning a boundary stays intact.
+    assert windows[0].split()[-1] in windows[1]
+
+
+@pytest.mark.unit
+def test_single_over_long_sentence_is_split() -> None:
+    """A table row or reference blob with no sentence break still fits."""
+    text = " ".join(f"token{i}" for i in range(200))
+    windows = split_chunk_into_windows(text, _count_words, target_tokens=25, overlap_tokens=5)
+    assert len(windows) > 1
+    assert all(_count_words(w) <= 25 for w in windows)
+
+
+# ---------------------------------------------------------------------------
+# Index invalidation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "const",
+    [
+        "MANIFEST_VERSION",
+        "EMBED_MODEL",
+        "CHUNK_TARGET_CHARS",
+        "CHUNK_OVERLAP_CHARS",
+        "WINDOW_TARGET_TOKENS",
+        "WINDOW_OVERLAP_TOKENS",
+    ],
+)
+def test_manifest_hash_changes_with_index_parameters(
+    const: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Changing anything that changes the vectors must invalidate existing
+    indexes, or a rebuild silently keeps serving stale ones."""
+    baseline = _manifest_hash(b"source", "jats")
+    original = getattr(lsi, const)
+    changed = original + 1 if isinstance(original, int) else original + "-x"
+    monkeypatch.setattr(lsi, const, changed)
+    assert _manifest_hash(b"source", "jats") != baseline
+
+
+@pytest.mark.unit
+def test_manifest_hash_changes_with_source_bytes() -> None:
+    assert _manifest_hash(b"source", "jats") != _manifest_hash(b"other", "jats")
+    assert _manifest_hash(b"source", "jats") != _manifest_hash(b"source", "pdf")
+
+
+# ---------------------------------------------------------------------------
+# Cached reference resolution across rebuilds
+# ---------------------------------------------------------------------------
+
+RESOLUTION = {"c1": {"corpus_id": "CorpusId:1", "doi": "10.1234/x", "method": "doi"}}
+
+
+def _refs_dir(tmp_path):
+    d = tmp_path / "citations"
+    d.mkdir()
+    (d / "ref_resolution.json").write_text(json.dumps(RESOLUTION))
+    return d
+
+
+@pytest.mark.unit
+def test_cached_refs_reused_when_source_unchanged(tmp_path) -> None:
+    d = _refs_dir(tmp_path)
+    assert _cached_ref_resolution(d, {"source_sha": "abc"}, "abc") == RESOLUTION
+
+
+@pytest.mark.unit
+def test_cached_refs_dropped_when_source_changed(tmp_path) -> None:
+    d = _refs_dir(tmp_path)
+    assert _cached_ref_resolution(d, {"source_sha": "abc"}, "def") is None
+
+
+@pytest.mark.unit
+def test_cached_refs_reused_for_manifests_predating_source_sha(tmp_path) -> None:
+    """The pre-#23 corpora everyone has to rebuild have no source_sha, and
+    re-resolving their references costs tens of minutes per paper."""
+    d = _refs_dir(tmp_path)
+    assert _cached_ref_resolution(d, {"version": 2, "hash": "old"}, "abc") == RESOLUTION
+
+
+@pytest.mark.unit
+def test_no_cached_refs_without_a_prior_manifest(tmp_path) -> None:
+    d = _refs_dir(tmp_path)
+    assert _cached_ref_resolution(d, {}, "abc") is None
+
+
+@pytest.mark.unit
+def test_no_cached_refs_when_file_missing_or_empty(tmp_path) -> None:
+    d = tmp_path / "citations"
+    d.mkdir()
+    assert _cached_ref_resolution(d, {"source_sha": "abc"}, "abc") is None
+    (d / "ref_resolution.json").write_text("{}")
+    assert _cached_ref_resolution(d, {"source_sha": "abc"}, "abc") is None
+    (d / "ref_resolution.json").write_text("not json")
+    assert _cached_ref_resolution(d, {"source_sha": "abc"}, "abc") is None

--- a/tests/unit/test_local_snippet_index_corpus.py
+++ b/tests/unit/test_local_snippet_index_corpus.py
@@ -7,6 +7,7 @@ network-free.
 from __future__ import annotations
 
 import json
+import logging
 from pathlib import Path
 
 import numpy as np
@@ -401,6 +402,59 @@ def test_search_filter_by_doi(multi_paper_project: Path) -> None:
 @pytest.mark.unit
 def test_search_empty_corpus_returns_empty(tmp_path: Path) -> None:
     assert lsi.search(tmp_path, "anything", k=5) == []
+
+
+@pytest.mark.unit
+def test_stale_papers_empty_when_current(windowed_project: Path) -> None:
+    assert lsi.stale_papers(windowed_project) == []
+
+
+@pytest.mark.unit
+def test_stale_papers_reports_old_manifest_version(windowed_project: Path) -> None:
+    """The case every existing corpus is in until it is rebuilt."""
+    mpath = windowed_project / "local_index" / "papers" / "atlas-slug" / "manifest.json"
+    manifest = json.loads(mpath.read_text())
+    manifest["version"] = lsi.MANIFEST_VERSION - 1
+    mpath.write_text(json.dumps(manifest))
+    stale = lsi.stale_papers(windowed_project)
+    assert [p["slug"] for p in stale] == ["atlas-slug"]
+    assert str(lsi.MANIFEST_VERSION) in stale[0]["reason"]
+
+
+@pytest.mark.unit
+def test_stale_papers_reports_missing_window_index(windowed_project: Path) -> None:
+    (
+        windowed_project / "local_index" / "papers" / "atlas-slug" / "chunks" / "window_index.json"
+    ).unlink()
+    stale = lsi.stale_papers(windowed_project)
+    assert [p["slug"] for p in stale] == ["atlas-slug"]
+    assert "window_index" in stale[0]["reason"]
+
+
+@pytest.mark.unit
+def test_old_manifest_version_is_not_searched(windowed_project: Path) -> None:
+    """Vectors from a different chunking cannot be ranked against current ones."""
+    mpath = windowed_project / "local_index" / "papers" / "atlas-slug" / "manifest.json"
+    manifest = json.loads(mpath.read_text())
+    manifest["version"] = lsi.MANIFEST_VERSION - 1
+    mpath.write_text(json.dumps(manifest))
+    lsi._load_index.cache_clear()
+    assert lsi.search(windowed_project, "sub", k=5) == []
+
+
+@pytest.mark.unit
+def test_unusable_corpus_logs_an_error(windowed_project: Path, caplog) -> None:
+    """Returning [] is indistinguishable from "nothing relevant found", so a
+    corpus that can serve nothing has to say so above warning level."""
+    (
+        windowed_project / "local_index" / "papers" / "atlas-slug" / "chunks" / "window_index.json"
+    ).unlink()
+    lsi._load_index.cache_clear()
+    with caplog.at_level(logging.ERROR):
+        assert lsi.search(windowed_project, "sub", k=5) == []
+    errors = [r for r in caplog.records if r.levelno >= logging.ERROR]
+    assert errors, "an unusable corpus must log at ERROR"
+    assert "rebuild" in errors[0].getMessage()
 
 
 @pytest.mark.unit

--- a/tests/unit/test_local_snippet_index_corpus.py
+++ b/tests/unit/test_local_snippet_index_corpus.py
@@ -53,6 +53,7 @@ def _write_paper_files(
     role: str,
     chunks: list[dict],
     embeddings: np.ndarray,
+    window_rows: list[int] | None = None,
 ) -> dict:
     p_dir = project_dir / "local_index" / "papers" / slug
     (p_dir / "chunks").mkdir(parents=True, exist_ok=True)
@@ -61,6 +62,11 @@ def _write_paper_files(
         for c in chunks:
             fh.write(json.dumps(c) + "\n")
     np.save(p_dir / "chunks" / "embeddings.npy", embeddings)
+    # One embedding row per window; by default one window per chunk.
+    rows = window_rows if window_rows is not None else [c["chunk_id"] for c in chunks]
+    (p_dir / "chunks" / "window_index.json").write_text(
+        json.dumps({"n_chunks": len(chunks), "n_windows": len(rows), "rows": rows})
+    )
     paper_meta = {
         "corpus_id": lsi._local_corpus_id(doi),
         "title": f"Paper {slug}",
@@ -92,6 +98,7 @@ def _write_paper_files(
         "hash": "deadbeef",
         "embedding_model": lsi.EMBED_MODEL,
         "n_chunks": len(chunks),
+        "n_windows": len(rows),
         "n_sentences": 0,
         "n_refs": 0,
         "n_corpus_ids_resolved": 0,
@@ -188,7 +195,12 @@ def test_migration_moves_legacy_files(tmp_path: Path) -> None:
     assert corpus["atlas_doi"] == "10.1234/legacy"
     new_manifest = json.loads((p_dir / "manifest.json").read_text())
     assert new_manifest["role"] == "atlas"
-    assert new_manifest["version"] == lsi.MANIFEST_VERSION
+    # Migration only moves files. The vectors it moves were embedded from
+    # truncated chunks and have no window index (#23), so the manifest must keep
+    # the legacy version and say it needs rebuilding — stamping the current
+    # version would make a stale index look fresh.
+    assert new_manifest["version"] != lsi.MANIFEST_VERSION
+    assert new_manifest["needs_rebuild"] is True
 
 
 @pytest.mark.unit
@@ -273,10 +285,20 @@ def test_remove_paper_drops_dir_and_corpus_entry(tmp_path: Path) -> None:
 # ---------------------------------------------------------------------------
 
 
+class _FakeTokenizer:
+    """Whitespace tokeniser, so window sizing is predictable in tests."""
+
+    def tokenize(self, text):
+        return text.split()
+
+
 class _FakeEmbedder:
     """Encodes a 'query' to a 2-d vector via simple keyword counting against
     a known token vocabulary. Used to make the search test deterministic
     without loading sentence-transformers."""
+
+    max_seq_length = lsi.EMBED_MAX_TOKENS
+    tokenizer = _FakeTokenizer()
 
     def encode(self, texts, convert_to_numpy=True, show_progress_bar=False):  # noqa: D401
         out = []
@@ -352,6 +374,7 @@ def multi_paper_project(tmp_path, monkeypatch):
     fake_st.SentenceTransformer = lambda *args, **kwargs: _FakeEmbedder()  # type: ignore[attr-defined]
     monkeypatch.setitem(sys.modules, "sentence_transformers", fake_st)
     lsi._load_index.cache_clear()
+    lsi._get_embedder.cache_clear()
     return tmp_path
 
 
@@ -378,3 +401,109 @@ def test_search_filter_by_doi(multi_paper_project: Path) -> None:
 @pytest.mark.unit
 def test_search_empty_corpus_returns_empty(tmp_path: Path) -> None:
     assert lsi.search(tmp_path, "anything", k=5) == []
+
+
+@pytest.mark.unit
+def test_stale_window_ids_are_skipped(windowed_project: Path) -> None:
+    """Matching row counts but stale chunk ids would otherwise be served as
+    empty snippets."""
+    path = (
+        windowed_project / "local_index" / "papers" / "atlas-slug" / "chunks" / "window_index.json"
+    )
+    path.write_text(json.dumps({"n_chunks": 1, "n_windows": 2, "rows": [0, 7]}))
+    lsi._load_index.cache_clear()
+    assert lsi.search(windowed_project, "sub", k=5) == []
+
+
+# ---------------------------------------------------------------------------
+# Windowed embeddings (#23)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def windowed_project(tmp_path, monkeypatch):
+    """One paper, one chunk, two embedding rows — the match is in window 2.
+
+    Before #23 the chunk had a single vector taken from its truncated prefix, so
+    a query matching only the tail of the chunk could not retrieve it.
+    """
+    _write_paper_files(
+        tmp_path,
+        "atlas-slug",
+        "10.1234/atlas",
+        "atlas",
+        [
+            {
+                "chunk_id": 0,
+                "section": "Results",
+                "char_start": 0,
+                "char_end": 60,
+                "text": "Prefix about atlas things. Tail about sub things.",
+            },
+        ],
+        # Row 0 = prefix window ('atlas' axis), row 1 = tail window ('sub' axis).
+        np.array([[1.0, 0.0], [0.0, 1.0]]),
+        window_rows=[0, 0],
+    )
+    corpus = lsi._empty_corpus("10.1234/atlas")
+    corpus["papers"] = [
+        {
+            "slug": "atlas-slug",
+            "doi": "10.1234/atlas",
+            "role": "atlas",
+            "source_type": "jats",
+            "title": "Atlas",
+            "n_chunks": 1,
+        },
+    ]
+    (tmp_path / "local_index" / "corpus.json").write_text(json.dumps(corpus))
+
+    import sys
+    import types
+
+    fake_st = types.ModuleType("sentence_transformers")
+    fake_st.SentenceTransformer = lambda *args, **kwargs: _FakeEmbedder()  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "sentence_transformers", fake_st)
+    lsi._load_index.cache_clear()
+    lsi._get_embedder.cache_clear()
+    return tmp_path
+
+
+@pytest.mark.unit
+def test_search_matches_on_non_first_window(windowed_project: Path) -> None:
+    """A query that only matches the tail of a chunk still retrieves it."""
+    hits = lsi.search(windowed_project, "sub", k=5)
+    assert len(hits) == 1
+    assert hits[0]["chunk_id"] == 0
+    assert hits[0]["score"] == pytest.approx(1.0)
+    # The full chunk text comes back, not the window that matched.
+    assert hits[0]["snippet"] == "Prefix about atlas things. Tail about sub things."
+
+
+@pytest.mark.unit
+def test_search_returns_each_chunk_once(windowed_project: Path) -> None:
+    """Both windows of the chunk score, but the chunk is not duplicated."""
+    hits = lsi.search(windowed_project, "atlas sub", k=5)
+    assert len(hits) == 1
+    assert [(h["paper_slug"], h["chunk_id"]) for h in hits] == [("atlas-slug", 0)]
+
+
+@pytest.mark.unit
+def test_pre_window_paper_is_skipped(windowed_project: Path) -> None:
+    """A paper built before #23 has no window index and carries truncated
+    vectors, so it is skipped rather than mis-scored."""
+    (
+        windowed_project / "local_index" / "papers" / "atlas-slug" / "chunks" / "window_index.json"
+    ).unlink()
+    lsi._load_index.cache_clear()
+    assert lsi.search(windowed_project, "sub", k=5) == []
+
+
+@pytest.mark.unit
+def test_window_index_length_mismatch_is_skipped(windowed_project: Path) -> None:
+    path = (
+        windowed_project / "local_index" / "papers" / "atlas-slug" / "chunks" / "window_index.json"
+    )
+    path.write_text(json.dumps({"n_chunks": 1, "n_windows": 1, "rows": [0]}))
+    lsi._load_index.cache_clear()
+    assert lsi.search(windowed_project, "sub", k=5) == []


### PR DESCRIPTION
Closes #23.

`all-MiniLM-L6-v2` reads 256 word pieces, but `CHUNK_TARGET_CHARS = 2800` produces chunks well past that, so sentence-transformers silently dropped the tail of most of them before computing a vector. Measured on the HDCA_neurons corpus: **248 of 366 chunks (68%)** were over the limit.

Chunk text was always stored in full, so quotes in reports were never affected. The damage was confined to ranking — a passage whose relevant sentence sat in the back half of its chunk could not be retrieved for the query it answered.

## Approach

Option 3 from the issue: embed sub-chunks, keep the chunk as the returned unit. The issue leaned toward option 1 (cut chunks to ~1000 chars); option 3 was chosen so snippet length and the ASTA-shape contract stay put — shrinking chunks would have cut what `snippets.json` hands the traverser by ~2.5x, weakening the context around every quote.

```
chunks.jsonl        unchanged — 2800-char chunks, sections, char offsets
embeddings.npy      (n_windows, 384) instead of (n_chunks, 384)
window_index.json   NEW — row -> chunk_id

search(): scores = E @ q  ->  group rows by (slug, chunk_id), take max  ->  top-k chunks
          returned snippet = full chunk text, same output keys as before
```

Windows are sized by the model's own tokeniser, so window sizing and encoding cannot drift apart. A chunk that already fits comes back as a single window equal to its input, so short chunks behave exactly as before.

## Does it change what ranks?

Yes — on all four queries tried against the same chunks, and the newly surfaced chunks matched on windows 2 through 6, text the old vector could not see. One matched on window 6 of 6.

```
markers of excitatory neuron progenitors
  old top5 (truncated): [9, 14, 22, 1, 33]
  new top5 (windowed):  [0, 14, 2, 9, 18]
    chunk 0 newly surfaced, matched on window 2 of 3 (invisible before)
    chunk 2 newly surfaced, matched on window 3 of 5 (invisible before)
    chunk 18 newly surfaced, matched on window 2 of 6 (invisible before)
```

## Invalidation and rebuild

`MANIFEST_VERSION` 2 -> 3, and the chunk/window sizes now go into `_manifest_hash()`, so existing corpora rebuild and future tuning invalidates itself (the issue's second problem). Indexes without a window index are skipped at load with a warning naming the fix, rather than mis-scored.

New `rebuild` subcommand walks `corpus.json` and rebuilds every paper from the source on disk — including the PDF-sourced ones `init-corpus --force` skips.

```bash
python scripts/setup_local_index.py rebuild --project <project>
python scripts/setup_local_index.py rebuild --project <project> --paper 10.1234/x
```

**Reference resolution is now cached across rebuilds.** It costs one serial Semantic Scholar title-match per unresolved ref, which had a forced rebuild running over 25 minutes without finishing a single paper — unusable given the fix requires everyone to rebuild. It depends only on the source, so a rebuild forced by a chunking or embedding change reuses it. The full 6-paper rebuild now takes **50 seconds**. `--refresh-refs` overrides.

## Also fixed

- **Legacy migration no longer lies about version.** It stamped `version: 3` onto the truncated vectors it moves; it now keeps the legacy version and sets `needs_rebuild: true`. A unit test had been asserting the old behaviour, so it was certifying the lie.
- **The truncation warning is trustworthy again.** `Token indices sequence length is longer than the specified maximum` still fired after the initial fix — not truncation, but the token-counting call that decides whether to split. That is why it went ignored. Counting now passes `verbose=False`, and a full rebuild logs **zero** such warnings.
- **Stale window ids no longer yield empty snippets.** `_load_index` skips a paper whose window index names a `chunk_id` missing from `chunks.jsonl` — row counts can match while ids are stale, and such a row could win its group and reach the summarizer as `"snippet": ""`.
- `search()` loads the model once per process instead of once per call.

## Verification

- 134 unit tests pass; ruff clean; mypy unchanged at the same 15 pre-existing missing-stub errors; coverage 32% -> 34%.
- Real-model rebuild of HDCA_neurons: 358 chunks -> 946 windows, no window over budget, all 6 papers at version 3, `embeddings.npy` rows == `window_index.json` `n_windows`, every chunk mapped to >=1 window.
- Legacy corpus (`spatial_skin_atlas`, the one pre-migration index on disk) end to end: migrates to version 1 + `needs_rebuild`, search skips it with the warning, `rebuild` takes it to v3 (29 chunks -> 79 windows), search then returns full-text hits.
- Downstream checked: `citation_traverser.traverse_local` and the fan-out merge in `report_graph.py` read only `search()`'s output keys, which are unchanged. `subatlas_resolver.ingest()` discards the manifest. Nothing anywhere rejects version 3.

## Notes for review

- **Staleness is now loud (second commit).** Skipping a paper meant `search()` returned `[]`, which from the caller's side is indistinguishable from a corpus with nothing relevant to say — the only signal was one warning per paper. Added in `services/`, so it helps the agentic path too: `stale_papers()` reports which papers are unusable and why (cheap — manifests only, never the embeddings); a corpus that lists papers but can serve none logs at **ERROR** with the rebuild command; skipping now also triggers on a manifest version mismatch, not just a missing window index, so any future bump announces itself; and a `check` subcommand exits non-zero when a rebuild is needed, so it can gate a batch run.

- **`use_in_fanout()` is still version-blind, deliberately.** Worth being precise about the blast radius: `use_in_fanout()` and `traverse_local` are called from exactly one place, `report_graph.py:298` — the deprecated programmatic graph. The agentic path reaches the index through `setup_local_index.py search` → `search()` and never consults that flag. So a project that opted into local fan-out and has not rebuilt gets ASTA-only evidence from the graph runtime, reported as `Merged N ASTA + 0 local snippets`. Left untouched because fixing it means extending the deprecated path; if that path survives, its fan-out should call `stale_papers()` and fail loudly. Tracked in #25 (review and safe deprecation of the programmatic workflow in `src/`), which this work motivated.
- PDF chunk counts shifted slightly on rebuild (86->82, 65->59) from a `pymupdf4llm` version difference in my environment, not the chunker. JATS papers came back identical.
- `experiments/asta_probe.py`, where the issue says this was found, **does not exist in this repo** — `experiments/` holds only a README. The `--backend local` probe and the Gopee numbers (66 local chunks vs 72 ASTA snippets) still need re-running wherever that script lives. Also `Atlas-reporter-wt/query-decomposer/experiments/.local_probe_cache/local_index` holds two pre-#23 indexes that will be skipped until rebuilt.
- `ROADMAP.md:235` and `CLAUDE.md:146` are stale on this but left alone as editorial. `docs/codebase_overview.md` was updated, being a factual description of the changed code.

This unblocks the retrieval-strategy evaluation in ROADMAP section 5 B0 — the local dense arm now measures the encoding rather than the truncation. The remaining B1 prerequisites are #22 (ASTA depth probe) and #21 (supplement store).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
