### PR TITLE
Feature/supplement store

### DIFF
--- a/.claude/hooks/check_supplement_manifest.py
+++ b/.claude/hooks/check_supplement_manifest.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python
+"""Claude Code hook: validate a supplement store manifest.json.
+
+Runs as a PostToolUse hook on Write/Edit. Fires only for a ``manifest.json``
+under a ``supplements/`` path, so it does not collide with the local-index
+manifests (which live under ``local_index/``).
+
+Both checks come from the service rather than being restated here — the schema
+is the source of truth and the cross-field rules live next to the code that
+writes manifests:
+
+* :func:`atlas_chat.services.supplement_store.validate_manifest` — shape.
+* :func:`atlas_chat.services.supplement_store.cross_check_manifest` — the rules
+  a schema cannot express, e.g. a table pointing at a file that isn't present.
+
+Exit codes:
+    0 — valid, or not a supplement manifest
+    2 — validation failed (Claude sees stderr and self-corrects)
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+
+def _is_supplement_manifest(file_path: str) -> bool:
+    path = Path(file_path)
+    if path.name != "manifest.json":
+        return False
+    return "supplements" in path.parts
+
+
+def main() -> int:
+    try:
+        hook_input = json.loads(sys.stdin.read())
+    except (json.JSONDecodeError, OSError):
+        return 0
+
+    tool_input = hook_input.get("tool_input", {})
+    file_path = tool_input.get("file_path", "")
+    if not file_path or not _is_supplement_manifest(file_path):
+        return 0
+
+    # Prefer what is on disk: PostToolUse runs after the write, and an Edit
+    # carries no full content in tool_input.
+    raw = tool_input.get("content", "")
+    path = Path(file_path)
+    if path.exists():
+        raw = path.read_text(encoding="utf-8")
+    if not raw.strip():
+        print("supplement manifest is empty", file=sys.stderr)
+        return 2
+
+    try:
+        manifest = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        print(f"supplement manifest is not valid JSON: {exc}", file=sys.stderr)
+        return 2
+
+    try:
+        from atlas_chat.services.supplement_store import (
+            SupplementStoreError,
+            cross_check_manifest,
+            validate_manifest,
+        )
+    except ImportError as exc:  # pragma: no cover - environment guard
+        print(f"cannot import supplement_store to validate: {exc}", file=sys.stderr)
+        return 0
+
+    errors: list[str] = []
+    try:
+        validate_manifest(manifest)
+    except SupplementStoreError as exc:
+        errors.append(str(exc))
+    else:
+        errors.extend(cross_check_manifest(manifest))
+
+    if not errors:
+        return 0
+
+    print("SUPPLEMENT MANIFEST VALIDATION FAILED", file=sys.stderr)
+    print(f"Fix these issues in {file_path}:", file=sys.stderr)
+    for error in errors:
+        print(f"  - {error}", file=sys.stderr)
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -30,6 +30,10 @@
           },
           {
             "type": "command",
+            "command": "uv run python .claude/hooks/check_supplement_manifest.py"
+          },
+          {
+            "type": "command",
             "command": "uv run python .claude/hooks/check_report_refs.py"
           }
         ]

--- a/.claude/skills/index-supplements/SKILL.md
+++ b/.claude/skills/index-supplements/SKILL.md
@@ -42,8 +42,7 @@ uv run python -m atlas_chat.cli_supplements inventory --jats <paper.jats.xml>
 
 # Take files a user dropped into incoming/ into the store.
 uv run python -m atlas_chat.cli_supplements adopt \
-  --store <store> --doi <doi> --incoming <dir> [--jats <xml>] \
-  [--role atlas|subatlas|external] [--access open|closed|unknown]
+  --store <store> --doi <doi> --incoming <dir> [--jats <xml>] [--pmcid <PMCID>]
 
 # Expand archives, record the member tree. Videos are skipped, big tables are not.
 uv run python -m atlas_chat.cli_supplements unpack --store <store> --doi <doi>
@@ -64,6 +63,32 @@ uv run python -m atlas_chat.cli_supplements check --store <store> --doi <doi>
 # Which papers does a project need supplements for?
 uv run python -m atlas_chat.cli_supplements papers --cas <cas.json>
 ```
+
+## Size limits, and why none of them are silent
+
+Supplementary tables are big — the prenatal skin bundle contains a 95 MB
+spreadsheet of 396,880 rows — so every read here is bounded. That is only safe
+if a bound never looks like an absence, so each one leaves a trace:
+
+| Limit | What it does | The trace it leaves |
+|---|---|---|
+| unpack size caps | leaves an oversized member unextracted | a `gaps` entry naming the file, its size and the flag to raise |
+| `outline --rows` / `--cols` | shows the top-left of a table | `truncated_rows` / `truncated_cols` next to the true `n_rows` / `n_cols` |
+| cell width | clips a long cell | a trailing `…` |
+| `text --max-chars` | clips a document | `truncated: true` plus the true `chars` |
+| `slice --limit` | returns one window | `start`, `returned` and the true `n_rows` |
+| `columns` in a manifest | may list a prefix for a very wide table | compare its length against `n_columns` |
+
+Two consequences for you:
+
+- **Never conclude anything from a bounded read.** If `truncated_rows` is true,
+  you have seen the top of the table, not the table. Say what the table *is*,
+  from its columns and its legend; do not say what is or isn't in it.
+- **Assume the reader after you must explore programmatically.** Nothing
+  downstream can open one of these files whole either, so a pointer earns its
+  keep by carrying `locator`, `header_row`, `n_rows` and `n_columns` — enough to
+  slice straight to the right region. That, not a summary of the contents, is
+  the deliverable.
 
 ## Getting files in
 
@@ -118,6 +143,10 @@ schema and rejects a table that points at a file which isn't there, so run
 
 Keep these in mind:
 
+- **Leave the `paper` block alone.** It carries the DOI and, if known, the
+  PMCID — nothing else. Role, title and organism belong to the corpus's CAS+
+  document; copying them into a fetch cache just creates a second copy that goes
+  stale.
 - **One pointer per table**, not per file. A workbook with twelve sheets that
   each hold different DEG comparisons is twelve pointers.
 - **`description` is what the pointer is for.** Say what the table contains and

--- a/.claude/skills/index-supplements/SKILL.md
+++ b/.claude/skills/index-supplements/SKILL.md
@@ -1,0 +1,147 @@
+---
+name: index-supplements
+description: Index a paper's supplementary material into a store manifest that says precisely which file, sheet or page holds what — DEG results, cluster-to-name mappings, marker lists, cell metadata — and what the columns are. Reads captions first, opens files only when the captions don't answer it. Needs the [supplements] extra (openpyxl).
+output:
+  schema: src/atlas_chat/atlas_chat/schemas/supplement_manifest.schema.json
+---
+
+# index-supplements
+
+Supplementary material carries content a report often cannot be written without:
+DEG tables, cluster-to-name mappings, the marker lists name resolution depends on.
+Your job is to produce a manifest that lets a later reader go straight to the right
+sheet instead of re-scanning a bundle of forty workbooks.
+
+You write the `tables` and `gaps` sections of a paper's `manifest.json`. The
+schema is the contract and is self-documenting — read its field descriptions
+rather than looking for them here.
+
+## What this is not
+
+You are not extracting biology. Do not read a DEG table and write down the genes.
+The manifest describes *where evidence lives and what shape it is in*; the
+querying happens later, against a specific cell type.
+
+## Requirements
+
+- The `[supplements]` extra: `uv sync --extra supplements` (openpyxl).
+- Files already in the store. Retrieval is a separate concern — see
+  "Getting files in" below.
+
+## The mechanical half
+
+Everything that touches bytes is in `atlas_chat.services.supplement_store`,
+behind a CLI. Use it rather than reading supplement files directly: a
+supplementary table can be 400,000 rows wide, and `Read` on one of those wrecks
+your context for no gain.
+
+```bash
+# What supplements does this paper have? Labels and captions come from the
+# article XML and exist nowhere else — this is the cheapest thing you will read.
+uv run python -m atlas_chat.cli_supplements inventory --jats <paper.jats.xml>
+
+# Take files a user dropped into incoming/ into the store.
+uv run python -m atlas_chat.cli_supplements adopt \
+  --store <store> --doi <doi> --incoming <dir> [--jats <xml>] \
+  [--role atlas|subatlas|external] [--access open|closed|unknown]
+
+# Expand archives, record the member tree. Videos are skipped, big tables are not.
+uv run python -m atlas_chat.cli_supplements unpack --store <store> --doi <doi>
+
+# Bounded description of one file's shape: sheet names, dimensions, the guessed
+# header row, a few sample rows. Cost is flat in the size of the file.
+uv run python -m atlas_chat.cli_supplements outline --file <path> [--rows N] [--cols N]
+
+# Targeted read of one region, once you know which sheet you want.
+uv run python -m atlas_chat.cli_supplements slice \
+  --file <path> [--locator <sheet>] [--start N] [--limit N] \
+  [--columns A B] [--header-row N]
+
+# Read, and check, the manifest.
+uv run python -m atlas_chat.cli_supplements show  --store <store> --doi <doi>
+uv run python -m atlas_chat.cli_supplements check --store <store> --doi <doi>
+
+# Which papers does a project need supplements for?
+uv run python -m atlas_chat.cli_supplements papers --cas <cas.json>
+```
+
+## Getting files in
+
+Three routes, cheapest first:
+
+1. **Already in the store.** `show` tells you; a file with `status: "present"`
+   has bytes on disk. Re-indexing an unchanged paper is wasted work — if
+   `indexed_at` is set and the files' `sha256` values haven't changed, stop.
+2. **Manually dropped.** Files under the project's `supplements/incoming/<doi-slug>/`
+   get taken into the store by `adopt`. This is the only route for closed-access
+   papers, and it is a first-class route, not a failure.
+3. **Fetched.** For open-access papers, the article XML lists the filenames and
+   the publisher's static host usually serves them individually. Automated
+   retrieval is deliberately out of scope for this skill — if files are missing,
+   record a gap saying which ones and let the operator drop them in.
+
+## How to index — cheapest evidence first
+
+Work down this ladder and stop as soon as you can characterise a table. Record
+which rung you stopped on in the pointer's `evidence` field, so a reader can
+tell a table described from its caption from one you actually opened.
+
+1. **Captions** (`evidence: "caption"`). Run `inventory` and read the labels and
+   captions. Publishers often describe the contents precisely — "Supplementary
+   Tables 1–40", "Source Data Figs. 2 and 4". If a caption fully accounts for a
+   file, you are done with it.
+2. **A legend sheet** (`evidence: "legend_sheet"`). Multi-sheet workbooks and
+   table bundles frequently carry a contents or legend sheet describing all the
+   others. `outline` the file; if a sheet name or its first rows look like a
+   legend, `slice` that one sheet and use it to characterise its siblings. One
+   read then covers the whole bundle — this is the highest-leverage step, so try
+   it before opening anything else.
+3. **Headers** (`evidence: "headers"`). Otherwise `outline` each file. Sheet
+   names plus the header row usually settle what a table is: `avg_log2FC` and
+   `p_val_adj` mean DEG results; a cluster column beside a name column means a
+   cluster-to-name mapping; one row per barcode means cell metadata.
+4. **Rows** (`evidence: "rows_read"`). Only when the headers are genuinely
+   ambiguous, `slice` a few data rows.
+
+Mind the `header_row_guess` that `outline` reports. Publisher tables routinely
+carry a title row above the real header ("Prenatal skin metadata"), and
+sometimes two. The guess is usually right, but check it against the sample rows
+before recording `header_row` — a reader that slices from the wrong row gets
+nonsense.
+
+## Writing the manifest
+
+Read the current manifest with `show`, add your `tables` and `gaps`, and write
+the whole file back with `Write`. A PostToolUse hook validates it against the
+schema and rejects a table that points at a file which isn't there, so run
+`check` if you want the same verdict before writing.
+
+Keep these in mind:
+
+- **One pointer per table**, not per file. A workbook with twelve sheets that
+  each hold different DEG comparisons is twelve pointers.
+- **`description` is what the pointer is for.** Say what the table contains and
+  what someone would use it for, in a sentence or two, grounded in what you
+  actually read. "DEG results per cluster" is thin; "differential expression of
+  each fine-grained cluster against all other cells in the same broad lineage,
+  with log fold change and adjusted p-values" tells a reader whether it answers
+  their question.
+- **Columns matter as much as the table.** A reader picks a table by its columns
+  without opening it. Give every column, in order, and describe the ones whose
+  headers are not self-explanatory.
+- **Do not enumerate which cell types appear.** That is a query-time question
+  and the lists are long, stale-prone, and rarely complete.
+- **Record what you couldn't do.** An empty `tables` list with no `gaps` reads
+  as "this paper has no useful supplements", which is a claim. If a table was
+  over the size cap, a PDF had no extractable text, or a file was never
+  retrieved, say so in `gaps` with what a human could do about it. This is the
+  difference between "there is nothing there" and "we didn't look".
+- Stamp `indexed_at` when you finish
+  (`touch_indexed_at` in the service, or write it yourself).
+
+## Where the store lives
+
+The store root is an argument, never derived. For a project the convention is
+`projects/{project}/supplements/`, giving
+`supplements/papers/<doi-slug>/{manifest.json, files/}`. Nothing in the service
+knows that convention, so the same store works outside this repo.

--- a/.gitignore
+++ b/.gitignore
@@ -14,4 +14,14 @@ build/
 docs/_build/
 .claude/settings.local.json
 
-#projects/
+# Test projects: commit setup only (cas.json, README); ignore generated outputs
+projects/test_projects/**/traversal_output/
+projects/test_projects/**/reports/
+projects/test_projects/**/selections/
+projects/test_projects/**/runs/
+
+# Supplement store: retrieved/manually-dropped files and unpacked archives are
+# never committed; the manifests describing them are.
+projects/**/supplements/**/files/
+projects/**/supplements/incoming/*
+!projects/**/supplements/incoming/README.md

--- a/projects/test_projects/README.md
+++ b/projects/test_projects/README.md
@@ -1,0 +1,49 @@
+# Test projects
+
+Sandbox projects for exercising the report-generation workflow end-to-end, kept
+**separate from official reports** (which live on their own per-atlas project
+branches). Nothing here is an authoritative report.
+
+## What is committed vs generated
+
+For each test project `test_projects/<name>/`:
+
+- **Committed setup** (tracked): `cas.json` (the CAS+ config the run reads) and this
+  project's `README.md` / any small source notes.
+- **Generated output** (git-ignored): each run is a **self-contained folder**
+  `runs/<UTC-timestamp>/` holding `run.json`, `selections/`,
+  `traversal_output/<cell_type>/`, and `reports/<cell_type>.md`. All of `runs/` is
+  git-ignored; only the setup is tracked. See `.gitignore`.
+
+## Running a test
+
+Launch a session **inside this worktree** (agents load from the launch dir's
+`.claude/`), then drive the workflow with the project addressed under this folder:
+
+```
+project = "test_projects/<name>"     # orchestrator reads projects/test_projects/<name>/cas.json
+query   = "<free-text cell-type selection>"   # e.g. "all macrophages"
+```
+
+## Run tracking
+
+Each run's reports and evidence live in its own `runs/<UTC-timestamp>/` folder (see
+above). That folder's `run.json` (git-ignored) records the **directory it was run
+in** and the **nature of the run** — and an optional `provenance_warning` when the
+run's provenance is uncertain:
+
+```jsonc
+{
+  "run_id": "<uuid>", "timestamp": "<ISO-8601 UTC>", "mode": "agentic",
+  "worktree_dir": "<abs path the run was driven from>",
+  "git_branch": "...", "git_version": "<git describe --always --dirty>",
+  "project": "test_projects/<name>", "query": "<the query>",
+  "selected_cell_types": ["..."],
+  "outputs": ["traversal_output/...", "reports/..."],
+  "notes": "<what this run was testing>"
+}
+```
+
+(This is a lightweight, test-scoped record. The heavier infra standard is
+`src/atlas_chat/atlas_chat/schemas/run_provenance.schema.json` — align to it later
+if test runs need to feed the validation-tools run-comparison.)

--- a/projects/test_projects/fetal_skin_atlas/README.md
+++ b/projects/test_projects/fetal_skin_atlas/README.md
@@ -1,0 +1,35 @@
+# test_projects/fetal_skin_atlas
+
+Test project for the prenatal (fetal) human skin atlas — Gopee et al. (2024),
+*Nature*, DOI `10.1038/s41586-024-08002-x`.
+
+## Setup (committed)
+
+`cas.json` — a **hand-built minimal CAS+** for testing (not the full atlas):
+
+- Six annotations: a broad `Macrophage` plus four fine macrophage subsets
+  (`TML macrophage`, `Iron-recycling macrophage`, `LYVE1++ macrophage`,
+  `MHCII+ macrophage`) and `Dermal papilla`.
+- The fine macrophage subsets share `parent_cell_set_accession: FS_macro`, so the
+  decomposer gets **real sibling `non_subject_terms`** from the hierarchy.
+- Deliberately **no `synonyms` / `marker_gene_evidence`** — this exercises the
+  minimal-source path (the grounder derives aliases from the paper).
+- Context lives in `composition` (organism human, developmental_stage fetal,
+  tissue skin).
+
+## Baselines for diffing
+
+Earlier direct-traversal outputs (pre-decomposer) for coverage comparison:
+`/tmp/tml_traversal/` (TML) and `/tmp/dp_test/` (Dermal papilla) — ephemeral, may be
+gone after a reboot; the reports under `reports/` here are the current-flow outputs.
+
+## Running
+
+Fresh session in the `query-decomposer` worktree, then a query such as
+`all macrophages`, `TML macrophage and dermal papilla`, or a single label. Each run's
+outputs land in a self-contained folder `runs/<UTC-timestamp>/` (git-ignored):
+`run.json` + `selections/` + `traversal_output/` + `reports/`.
+
+The existing `runs/20260818T184313Z/` was the first end-to-end run; its `run.json`
+carries a `provenance_warning` (it may have been driven from the wrong worktree
+folder). A clean re-run from the correct folder is planned.

--- a/projects/test_projects/fetal_skin_atlas/cas.json
+++ b/projects/test_projects/fetal_skin_atlas/cas.json
@@ -1,0 +1,79 @@
+{
+  "title": "A prenatal skin atlas reveals immune regulation of human skin morphogenesis",
+  "cellannotation_schema_version": "0.1.0-local",
+  "source": {
+    "doi": "10.1038/s41586-024-08002-x",
+    "title": "A prenatal skin atlas reveals immune regulation of human skin morphogenesis",
+    "atlas_name": "Prenatal Skin Atlas (Gopee et al. 2024)"
+  },
+  "labelsets": [
+    { "name": "broad", "rank": 1, "annotation_method": "manual" },
+    { "name": "fine", "rank": 0, "annotation_method": "manual" }
+  ],
+  "annotations": [
+    {
+      "labelset": "broad",
+      "cell_label": "Macrophage",
+      "cell_set_accession": "FS_macro",
+      "composition": {
+        "developmental_stage": { "author_field_name": "scope", "values": [ { "author_value": "fetal" } ] },
+        "organism": { "values": [ { "author_value": "human", "ontology_term_id": "NCBITaxon:9606" } ] },
+        "tissue": { "values": [ { "author_value": "skin", "ontology_term_id": "UBERON:0002097" } ] }
+      }
+    },
+    {
+      "labelset": "fine",
+      "cell_label": "TML macrophage",
+      "cell_set_accession": "FS_tml",
+      "parent_cell_set_accession": "FS_macro",
+      "composition": {
+        "developmental_stage": { "author_field_name": "scope", "values": [ { "author_value": "fetal" } ] },
+        "organism": { "values": [ { "author_value": "human", "ontology_term_id": "NCBITaxon:9606" } ] },
+        "tissue": { "values": [ { "author_value": "skin", "ontology_term_id": "UBERON:0002097" } ] }
+      }
+    },
+    {
+      "labelset": "fine",
+      "cell_label": "Iron-recycling macrophage",
+      "cell_set_accession": "FS_iron",
+      "parent_cell_set_accession": "FS_macro",
+      "composition": {
+        "developmental_stage": { "author_field_name": "scope", "values": [ { "author_value": "fetal" } ] },
+        "organism": { "values": [ { "author_value": "human", "ontology_term_id": "NCBITaxon:9606" } ] },
+        "tissue": { "values": [ { "author_value": "skin", "ontology_term_id": "UBERON:0002097" } ] }
+      }
+    },
+    {
+      "labelset": "fine",
+      "cell_label": "LYVE1++ macrophage",
+      "cell_set_accession": "FS_lyve1",
+      "parent_cell_set_accession": "FS_macro",
+      "composition": {
+        "developmental_stage": { "author_field_name": "scope", "values": [ { "author_value": "fetal" } ] },
+        "organism": { "values": [ { "author_value": "human", "ontology_term_id": "NCBITaxon:9606" } ] },
+        "tissue": { "values": [ { "author_value": "skin", "ontology_term_id": "UBERON:0002097" } ] }
+      }
+    },
+    {
+      "labelset": "fine",
+      "cell_label": "MHCII+ macrophage",
+      "cell_set_accession": "FS_mhcii",
+      "parent_cell_set_accession": "FS_macro",
+      "composition": {
+        "developmental_stage": { "author_field_name": "scope", "values": [ { "author_value": "fetal" } ] },
+        "organism": { "values": [ { "author_value": "human", "ontology_term_id": "NCBITaxon:9606" } ] },
+        "tissue": { "values": [ { "author_value": "skin", "ontology_term_id": "UBERON:0002097" } ] }
+      }
+    },
+    {
+      "labelset": "fine",
+      "cell_label": "Dermal papilla",
+      "cell_set_accession": "FS_dp",
+      "composition": {
+        "developmental_stage": { "author_field_name": "scope", "values": [ { "author_value": "fetal" } ] },
+        "organism": { "values": [ { "author_value": "human", "ontology_term_id": "NCBITaxon:9606" } ] },
+        "tissue": { "values": [ { "author_value": "skin", "ontology_term_id": "UBERON:0002097" } ] }
+      }
+    }
+  ]
+}

--- a/projects/test_projects/fetal_skin_atlas/supplements/incoming/README.md
+++ b/projects/test_projects/fetal_skin_atlas/supplements/incoming/README.md
@@ -1,0 +1,14 @@
+# incoming/
+
+Drop supplementary files here by hand (any format). Everything in this folder is
+git-ignored except this README.
+
+The indexer treats a file dropped here exactly like one it fetched itself — the
+manifest records `retrieval.route: "manual"` instead of a URL. This is the only
+route available for closed-access papers, which are out of scope for automated
+retrieval.
+
+Layout: one subdirectory per paper, named with the paper's DOI slug
+(DOI lowercased, `/` → `_`), e.g.
+
+    incoming/10.1038_s41586-024-08002-x/41586_2024_8002_MOESM4_ESM.zip

--- a/projects/test_projects/fetal_skin_atlas/supplements/papers/10.1038_s41586-024-08002-x/manifest.json
+++ b/projects/test_projects/fetal_skin_atlas/supplements/papers/10.1038_s41586-024-08002-x/manifest.json
@@ -1,0 +1,2297 @@
+{
+  "manifest_version": 1,
+  "paper": {
+    "doi": "10.1038/s41586-024-08002-x",
+    "role": "atlas",
+    "access": "open"
+  },
+  "files": [
+    {
+      "file_id": "41586_2024_8002_MOESM1_ESM.docx",
+      "media_type": "docx",
+      "status": "present",
+      "retrieval": {
+        "route": "manual",
+        "retrieved_at": "2026-08-25T13:53:26+00:00",
+        "sha256": "7dcea6f46bc3ed1122f7f190e85c8ae9430fb29e47431c1a5b7360569d03bb93",
+        "note": "copied from projects/test_projects/fetal_skin_atlas/supplements/incoming/10.1038_s41586-024-08002-x"
+      },
+      "label": "Supplementary Information",
+      "caption": "This file contains Supplementary Discussion and Supplementary References",
+      "size_bytes": 10219,
+      "path": "papers/10.1038_s41586-024-08002-x/files/41586_2024_8002_MOESM1_ESM.docx"
+    },
+    {
+      "file_id": "41586_2024_8002_MOESM2_ESM.pdf",
+      "media_type": "pdf",
+      "status": "listed",
+      "retrieval": {
+        "route": "jats_listing"
+      },
+      "caption": "Reporting Summary"
+    },
+    {
+      "file_id": "41586_2024_8002_MOESM3_ESM.pdf",
+      "media_type": "pdf",
+      "status": "listed",
+      "retrieval": {
+        "route": "jats_listing"
+      },
+      "caption": "Peer Review file"
+    },
+    {
+      "file_id": "41586_2024_8002_MOESM4_ESM.zip",
+      "media_type": "zip",
+      "status": "present",
+      "retrieval": {
+        "route": "manual",
+        "retrieved_at": "2026-08-25T13:53:26+00:00",
+        "sha256": "65f5b8fa87a4a626f9a6e1bf169d0b23e92e307cb21cea3bc52362ca3c3d8b09",
+        "note": "copied from projects/test_projects/fetal_skin_atlas/supplements/incoming/10.1038_s41586-024-08002-x"
+      },
+      "label": "Supplementary Tables",
+      "caption": "Supplementary Tables 1\u201340.",
+      "size_bytes": 194851851,
+      "path": "papers/10.1038_s41586-024-08002-x/files/41586_2024_8002_MOESM4_ESM.zip",
+      "members": [
+        {
+          "member_path": "2023-08-13667B-s4/2023-08-13667B-s4/Supplementary Table 1.xlsx",
+          "media_type": "xlsx",
+          "size_bytes": 14062,
+          "extracted": true,
+          "path": "papers/10.1038_s41586-024-08002-x/files/41586_2024_8002_MOESM4_ESM__unpacked/2023-08-13667B-s4/2023-08-13667B-s4/Supplementary Table 1.xlsx"
+        },
+        {
+          "member_path": "2023-08-13667B-s4/2023-08-13667B-s4/Supplementary Table 10.xlsx",
+          "media_type": "xlsx",
+          "size_bytes": 8981255,
+          "extracted": true,
+          "path": "papers/10.1038_s41586-024-08002-x/files/41586_2024_8002_MOESM4_ESM__unpacked/2023-08-13667B-s4/2023-08-13667B-s4/Supplementary Table 10.xlsx"
+        },
+        {
+          "member_path": "2023-08-13667B-s4/2023-08-13667B-s4/Supplementary Table 11.xlsx",
+          "media_type": "xlsx",
+          "size_bytes": 34219438,
+          "extracted": true,
+          "path": "papers/10.1038_s41586-024-08002-x/files/41586_2024_8002_MOESM4_ESM__unpacked/2023-08-13667B-s4/2023-08-13667B-s4/Supplementary Table 11.xlsx"
+        },
+        {
+          "member_path": "2023-08-13667B-s4/2023-08-13667B-s4/Supplementary Table 12.xlsx",
+          "media_type": "xlsx",
+          "size_bytes": 11434,
+          "extracted": true,
+          "path": "papers/10.1038_s41586-024-08002-x/files/41586_2024_8002_MOESM4_ESM__unpacked/2023-08-13667B-s4/2023-08-13667B-s4/Supplementary Table 12.xlsx"
+        },
+        {
+          "member_path": "2023-08-13667B-s4/2023-08-13667B-s4/Supplementary Table 13.xlsx",
+          "media_type": "xlsx",
+          "size_bytes": 91270,
+          "extracted": true,
+          "path": "papers/10.1038_s41586-024-08002-x/files/41586_2024_8002_MOESM4_ESM__unpacked/2023-08-13667B-s4/2023-08-13667B-s4/Supplementary Table 13.xlsx"
+        },
+        {
+          "member_path": "2023-08-13667B-s4/2023-08-13667B-s4/Supplementary Table 14.xlsx",
+          "media_type": "xlsx",
+          "size_bytes": 345669,
+          "extracted": true,
+          "path": "papers/10.1038_s41586-024-08002-x/files/41586_2024_8002_MOESM4_ESM__unpacked/2023-08-13667B-s4/2023-08-13667B-s4/Supplementary Table 14.xlsx"
+        },
+        {
+          "member_path": "2023-08-13667B-s4/2023-08-13667B-s4/Supplementary Table 15.xlsx",
+          "media_type": "xlsx",
+          "size_bytes": 391371,
+          "extracted": true,
+          "path": "papers/10.1038_s41586-024-08002-x/files/41586_2024_8002_MOESM4_ESM__unpacked/2023-08-13667B-s4/2023-08-13667B-s4/Supplementary Table 15.xlsx"
+        },
+        {
+          "member_path": "2023-08-13667B-s4/2023-08-13667B-s4/Supplementary Table 16.xlsx",
+          "media_type": "xlsx",
+          "size_bytes": 60129,
+          "extracted": true,
+          "path": "papers/10.1038_s41586-024-08002-x/files/41586_2024_8002_MOESM4_ESM__unpacked/2023-08-13667B-s4/2023-08-13667B-s4/Supplementary Table 16.xlsx"
+        },
+        {
+          "member_path": "2023-08-13667B-s4/2023-08-13667B-s4/Supplementary Table 17.xlsx",
+          "media_type": "xlsx",
+          "size_bytes": 269720,
+          "extracted": true,
+          "path": "papers/10.1038_s41586-024-08002-x/files/41586_2024_8002_MOESM4_ESM__unpacked/2023-08-13667B-s4/2023-08-13667B-s4/Supplementary Table 17.xlsx"
+        },
+        {
+          "member_path": "2023-08-13667B-s4/2023-08-13667B-s4/Supplementary Table 18.xlsx",
+          "media_type": "xlsx",
+          "size_bytes": 182057,
+          "extracted": true,
+          "path": "papers/10.1038_s41586-024-08002-x/files/41586_2024_8002_MOESM4_ESM__unpacked/2023-08-13667B-s4/2023-08-13667B-s4/Supplementary Table 18.xlsx"
+        },
+        {
+          "member_path": "2023-08-13667B-s4/2023-08-13667B-s4/Supplementary Table 19.xlsx",
+          "media_type": "xlsx",
+          "size_bytes": 260196,
+          "extracted": true,
+          "path": "papers/10.1038_s41586-024-08002-x/files/41586_2024_8002_MOESM4_ESM__unpacked/2023-08-13667B-s4/2023-08-13667B-s4/Supplementary Table 19.xlsx"
+        },
+        {
+          "member_path": "2023-08-13667B-s4/2023-08-13667B-s4/Supplementary Table 2.xlsx",
+          "media_type": "xlsx",
+          "size_bytes": 12924,
+          "extracted": true,
+          "path": "papers/10.1038_s41586-024-08002-x/files/41586_2024_8002_MOESM4_ESM__unpacked/2023-08-13667B-s4/2023-08-13667B-s4/Supplementary Table 2.xlsx"
+        },
+        {
+          "member_path": "2023-08-13667B-s4/2023-08-13667B-s4/Supplementary Table 20.xlsx",
+          "media_type": "xlsx",
+          "size_bytes": 10305,
+          "extracted": true,
+          "path": "papers/10.1038_s41586-024-08002-x/files/41586_2024_8002_MOESM4_ESM__unpacked/2023-08-13667B-s4/2023-08-13667B-s4/Supplementary Table 20.xlsx"
+        },
+        {
+          "member_path": "2023-08-13667B-s4/2023-08-13667B-s4/Supplementary Table 21.xlsx",
+          "media_type": "xlsx",
+          "size_bytes": 3045928,
+          "extracted": true,
+          "path": "papers/10.1038_s41586-024-08002-x/files/41586_2024_8002_MOESM4_ESM__unpacked/2023-08-13667B-s4/2023-08-13667B-s4/Supplementary Table 21.xlsx"
+        },
+        {
+          "member_path": "2023-08-13667B-s4/2023-08-13667B-s4/Supplementary Table 22.xlsx",
+          "media_type": "xlsx",
+          "size_bytes": 71158,
+          "extracted": true,
+          "path": "papers/10.1038_s41586-024-08002-x/files/41586_2024_8002_MOESM4_ESM__unpacked/2023-08-13667B-s4/2023-08-13667B-s4/Supplementary Table 22.xlsx"
+        },
+        {
+          "member_path": "2023-08-13667B-s4/2023-08-13667B-s4/Supplementary Table 23.xlsx",
+          "media_type": "xlsx",
+          "size_bytes": 190717,
+          "extracted": true,
+          "path": "papers/10.1038_s41586-024-08002-x/files/41586_2024_8002_MOESM4_ESM__unpacked/2023-08-13667B-s4/2023-08-13667B-s4/Supplementary Table 23.xlsx"
+        },
+        {
+          "member_path": "2023-08-13667B-s4/2023-08-13667B-s4/Supplementary Table 24.xlsx",
+          "media_type": "xlsx",
+          "size_bytes": 104382,
+          "extracted": true,
+          "path": "papers/10.1038_s41586-024-08002-x/files/41586_2024_8002_MOESM4_ESM__unpacked/2023-08-13667B-s4/2023-08-13667B-s4/Supplementary Table 24.xlsx"
+        },
+        {
+          "member_path": "2023-08-13667B-s4/2023-08-13667B-s4/Supplementary Table 25.xlsx",
+          "media_type": "xlsx",
+          "size_bytes": 252991,
+          "extracted": true,
+          "path": "papers/10.1038_s41586-024-08002-x/files/41586_2024_8002_MOESM4_ESM__unpacked/2023-08-13667B-s4/2023-08-13667B-s4/Supplementary Table 25.xlsx"
+        },
+        {
+          "member_path": "2023-08-13667B-s4/2023-08-13667B-s4/Supplementary Table 26.xlsx",
+          "media_type": "xlsx",
+          "size_bytes": 42878,
+          "extracted": true,
+          "path": "papers/10.1038_s41586-024-08002-x/files/41586_2024_8002_MOESM4_ESM__unpacked/2023-08-13667B-s4/2023-08-13667B-s4/Supplementary Table 26.xlsx"
+        },
+        {
+          "member_path": "2023-08-13667B-s4/2023-08-13667B-s4/Supplementary Table 27.xlsx",
+          "media_type": "xlsx",
+          "size_bytes": 12024,
+          "extracted": true,
+          "path": "papers/10.1038_s41586-024-08002-x/files/41586_2024_8002_MOESM4_ESM__unpacked/2023-08-13667B-s4/2023-08-13667B-s4/Supplementary Table 27.xlsx"
+        },
+        {
+          "member_path": "2023-08-13667B-s4/2023-08-13667B-s4/Supplementary Table 28.xlsx",
+          "media_type": "xlsx",
+          "size_bytes": 11586830,
+          "extracted": true,
+          "path": "papers/10.1038_s41586-024-08002-x/files/41586_2024_8002_MOESM4_ESM__unpacked/2023-08-13667B-s4/2023-08-13667B-s4/Supplementary Table 28.xlsx"
+        },
+        {
+          "member_path": "2023-08-13667B-s4/2023-08-13667B-s4/Supplementary Table 29.xlsx",
+          "media_type": "xlsx",
+          "size_bytes": 15701,
+          "extracted": true,
+          "path": "papers/10.1038_s41586-024-08002-x/files/41586_2024_8002_MOESM4_ESM__unpacked/2023-08-13667B-s4/2023-08-13667B-s4/Supplementary Table 29.xlsx"
+        },
+        {
+          "member_path": "2023-08-13667B-s4/2023-08-13667B-s4/Supplementary Table 3.xlsx",
+          "media_type": "xlsx",
+          "size_bytes": 3092685,
+          "extracted": true,
+          "path": "papers/10.1038_s41586-024-08002-x/files/41586_2024_8002_MOESM4_ESM__unpacked/2023-08-13667B-s4/2023-08-13667B-s4/Supplementary Table 3.xlsx"
+        },
+        {
+          "member_path": "2023-08-13667B-s4/2023-08-13667B-s4/Supplementary Table 30.xlsx",
+          "media_type": "xlsx",
+          "size_bytes": 4012565,
+          "extracted": true,
+          "path": "papers/10.1038_s41586-024-08002-x/files/41586_2024_8002_MOESM4_ESM__unpacked/2023-08-13667B-s4/2023-08-13667B-s4/Supplementary Table 30.xlsx"
+        },
+        {
+          "member_path": "2023-08-13667B-s4/2023-08-13667B-s4/Supplementary Table 31.xlsx",
+          "media_type": "xlsx",
+          "size_bytes": 42797,
+          "extracted": true,
+          "path": "papers/10.1038_s41586-024-08002-x/files/41586_2024_8002_MOESM4_ESM__unpacked/2023-08-13667B-s4/2023-08-13667B-s4/Supplementary Table 31.xlsx"
+        },
+        {
+          "member_path": "2023-08-13667B-s4/2023-08-13667B-s4/Supplementary Table 32.xlsx",
+          "media_type": "xlsx",
+          "size_bytes": 53110,
+          "extracted": true,
+          "path": "papers/10.1038_s41586-024-08002-x/files/41586_2024_8002_MOESM4_ESM__unpacked/2023-08-13667B-s4/2023-08-13667B-s4/Supplementary Table 32.xlsx"
+        },
+        {
+          "member_path": "2023-08-13667B-s4/2023-08-13667B-s4/Supplementary Table 33.xlsx",
+          "media_type": "xlsx",
+          "size_bytes": 223167,
+          "extracted": true,
+          "path": "papers/10.1038_s41586-024-08002-x/files/41586_2024_8002_MOESM4_ESM__unpacked/2023-08-13667B-s4/2023-08-13667B-s4/Supplementary Table 33.xlsx"
+        },
+        {
+          "member_path": "2023-08-13667B-s4/2023-08-13667B-s4/Supplementary Table 34.xlsx",
+          "media_type": "xlsx",
+          "size_bytes": 272645,
+          "extracted": true,
+          "path": "papers/10.1038_s41586-024-08002-x/files/41586_2024_8002_MOESM4_ESM__unpacked/2023-08-13667B-s4/2023-08-13667B-s4/Supplementary Table 34.xlsx"
+        },
+        {
+          "member_path": "2023-08-13667B-s4/2023-08-13667B-s4/Supplementary Table 35.xlsx",
+          "media_type": "xlsx",
+          "size_bytes": 17101,
+          "extracted": true,
+          "path": "papers/10.1038_s41586-024-08002-x/files/41586_2024_8002_MOESM4_ESM__unpacked/2023-08-13667B-s4/2023-08-13667B-s4/Supplementary Table 35.xlsx"
+        },
+        {
+          "member_path": "2023-08-13667B-s4/2023-08-13667B-s4/Supplementary Table 36.xlsx",
+          "media_type": "xlsx",
+          "size_bytes": 41224,
+          "extracted": true,
+          "path": "papers/10.1038_s41586-024-08002-x/files/41586_2024_8002_MOESM4_ESM__unpacked/2023-08-13667B-s4/2023-08-13667B-s4/Supplementary Table 36.xlsx"
+        },
+        {
+          "member_path": "2023-08-13667B-s4/2023-08-13667B-s4/Supplementary Table 37.xlsx",
+          "media_type": "xlsx",
+          "size_bytes": 10856,
+          "extracted": true,
+          "path": "papers/10.1038_s41586-024-08002-x/files/41586_2024_8002_MOESM4_ESM__unpacked/2023-08-13667B-s4/2023-08-13667B-s4/Supplementary Table 37.xlsx"
+        },
+        {
+          "member_path": "2023-08-13667B-s4/2023-08-13667B-s4/Supplementary Table 38.xlsx",
+          "media_type": "xlsx",
+          "size_bytes": 13918,
+          "extracted": true,
+          "path": "papers/10.1038_s41586-024-08002-x/files/41586_2024_8002_MOESM4_ESM__unpacked/2023-08-13667B-s4/2023-08-13667B-s4/Supplementary Table 38.xlsx"
+        },
+        {
+          "member_path": "2023-08-13667B-s4/2023-08-13667B-s4/Supplementary Table 39.xlsx",
+          "media_type": "xlsx",
+          "size_bytes": 3295329,
+          "extracted": true,
+          "path": "papers/10.1038_s41586-024-08002-x/files/41586_2024_8002_MOESM4_ESM__unpacked/2023-08-13667B-s4/2023-08-13667B-s4/Supplementary Table 39.xlsx"
+        },
+        {
+          "member_path": "2023-08-13667B-s4/2023-08-13667B-s4/Supplementary Table 4.xlsx",
+          "media_type": "xlsx",
+          "size_bytes": 5772551,
+          "extracted": true,
+          "path": "papers/10.1038_s41586-024-08002-x/files/41586_2024_8002_MOESM4_ESM__unpacked/2023-08-13667B-s4/2023-08-13667B-s4/Supplementary Table 4.xlsx"
+        },
+        {
+          "member_path": "2023-08-13667B-s4/2023-08-13667B-s4/Supplementary Table 40.xlsx",
+          "media_type": "xlsx",
+          "size_bytes": 9529,
+          "extracted": true,
+          "path": "papers/10.1038_s41586-024-08002-x/files/41586_2024_8002_MOESM4_ESM__unpacked/2023-08-13667B-s4/2023-08-13667B-s4/Supplementary Table 40.xlsx"
+        },
+        {
+          "member_path": "2023-08-13667B-s4/2023-08-13667B-s4/Supplementary Table 5.xlsx",
+          "media_type": "xlsx",
+          "size_bytes": 95089172,
+          "extracted": true,
+          "path": "papers/10.1038_s41586-024-08002-x/files/41586_2024_8002_MOESM4_ESM__unpacked/2023-08-13667B-s4/2023-08-13667B-s4/Supplementary Table 5.xlsx"
+        },
+        {
+          "member_path": "2023-08-13667B-s4/2023-08-13667B-s4/Supplementary Table 6.xlsx",
+          "media_type": "xlsx",
+          "size_bytes": 364729,
+          "extracted": true,
+          "path": "papers/10.1038_s41586-024-08002-x/files/41586_2024_8002_MOESM4_ESM__unpacked/2023-08-13667B-s4/2023-08-13667B-s4/Supplementary Table 6.xlsx"
+        },
+        {
+          "member_path": "2023-08-13667B-s4/2023-08-13667B-s4/Supplementary Table 7.xlsx",
+          "media_type": "xlsx",
+          "size_bytes": 2664048,
+          "extracted": true,
+          "path": "papers/10.1038_s41586-024-08002-x/files/41586_2024_8002_MOESM4_ESM__unpacked/2023-08-13667B-s4/2023-08-13667B-s4/Supplementary Table 7.xlsx"
+        },
+        {
+          "member_path": "2023-08-13667B-s4/2023-08-13667B-s4/Supplementary Table 8.xlsx",
+          "media_type": "xlsx",
+          "size_bytes": 20337277,
+          "extracted": true,
+          "path": "papers/10.1038_s41586-024-08002-x/files/41586_2024_8002_MOESM4_ESM__unpacked/2023-08-13667B-s4/2023-08-13667B-s4/Supplementary Table 8.xlsx"
+        },
+        {
+          "member_path": "2023-08-13667B-s4/2023-08-13667B-s4/Supplementary Table 9.xlsx",
+          "media_type": "xlsx",
+          "size_bytes": 109257,
+          "extracted": true,
+          "path": "papers/10.1038_s41586-024-08002-x/files/41586_2024_8002_MOESM4_ESM__unpacked/2023-08-13667B-s4/2023-08-13667B-s4/Supplementary Table 9.xlsx"
+        },
+        {
+          "member_path": "2023-08-13667B-s4/Supplementary Table legends.docx",
+          "media_type": "docx",
+          "size_bytes": 19098,
+          "extracted": true,
+          "path": "papers/10.1038_s41586-024-08002-x/files/41586_2024_8002_MOESM4_ESM__unpacked/2023-08-13667B-s4/Supplementary Table legends.docx"
+        }
+      ]
+    },
+    {
+      "file_id": "41586_2024_8002_MOESM5_ESM.mp4",
+      "media_type": "video",
+      "status": "listed",
+      "retrieval": {
+        "route": "jats_listing"
+      },
+      "label": "Supplementary Video 1",
+      "caption": "3D view of co-localization of endothelial cells and macrophages with putative contact points. 3D rendering of co-localized areas (magenta) of endothelial cells (CD31+, green) and LYVE1+ macrophages (LYVE1+, yellow) from whole-mount immunostaining of a 15 PCW prenatal skin sample. DAPI nuclear stain is in blue. Scale bar, 100 \u00b5m."
+    },
+    {
+      "file_id": "41586_2024_8002_MOESM6_ESM.xlsx",
+      "media_type": "xlsx",
+      "status": "present",
+      "retrieval": {
+        "route": "manual",
+        "retrieved_at": "2026-08-25T13:53:26+00:00",
+        "sha256": "69b9da3b31f3fd6e82e49df82f0a1a1026f1c5104b7806057ece2c286f0f19b4",
+        "note": "copied from projects/test_projects/fetal_skin_atlas/supplements/incoming/10.1038_s41586-024-08002-x"
+      },
+      "caption": "Source Data Figs. 2 and 4 and Source Data Extended Data Figs. 3, 7, 8, 10 and 11.",
+      "size_bytes": 121826,
+      "path": "papers/10.1038_s41586-024-08002-x/files/41586_2024_8002_MOESM6_ESM.xlsx"
+    }
+  ],
+  "gaps": [
+    {
+      "file_id": "41586_2024_8002_MOESM1_ESM.docx",
+      "reason": "holds Supplementary Discussion and References as prose, not tables, so it yields no table pointers; its text is readable with the store's `text` command"
+    },
+    {
+      "file_id": "41586_2024_8002_MOESM2_ESM.pdf",
+      "reason": "never retrieved (Reporting Summary; no table content expected)",
+      "action": "drop it into incoming/ if the reporting checklist is needed"
+    },
+    {
+      "file_id": "41586_2024_8002_MOESM3_ESM.pdf",
+      "reason": "never retrieved (Peer Review file; no table content expected)",
+      "action": "drop it into incoming/ if the review history is needed"
+    },
+    {
+      "file_id": "41586_2024_8002_MOESM5_ESM.mp4",
+      "reason": "supplementary video, deliberately not retrieved; carries no table content and the Europe PMC bundle for this paper exceeds 445 MB because of it"
+    }
+  ],
+  "tables": [
+    {
+      "file_id": "41586_2024_8002_MOESM4_ESM.zip",
+      "member_path": "2023-08-13667B-s4/2023-08-13667B-s4/Supplementary Table 1.xlsx",
+      "locator": "Sheet1",
+      "table_label": "Supplementary Table 1",
+      "content_type": "sample_metadata",
+      "description": "Prenatal skin scRNA-seq sample metadata: one row per sample, giving sample ID, donor, gestational age in post-conception weeks and FACS enrichment status. Use it to establish which donors and ages any cell state was observed in.",
+      "columns": [
+        {
+          "name": "Sanger_id"
+        },
+        {
+          "name": "Donor"
+        },
+        {
+          "name": "PCW"
+        },
+        {
+          "name": "Sorting"
+        }
+      ],
+      "n_columns": 13,
+      "header_row": 1,
+      "n_rows": 136,
+      "evidence": "legend_sheet"
+    },
+    {
+      "file_id": "41586_2024_8002_MOESM4_ESM.zip",
+      "member_path": "2023-08-13667B-s4/2023-08-13667B-s4/Supplementary Table 2.xlsx",
+      "locator": "Sheet1",
+      "table_label": "Supplementary Table 2",
+      "content_type": "sample_metadata",
+      "description": "Overview of every dataset analysed in the study \u2014 newly generated and published single-cell and spatial prenatal skin data plus the external datasets used for comparison \u2014 with publication, accession codes, technology and per-sample metadata. The place to look up which upstream study a cell state came from.",
+      "columns": [
+        {
+          "name": "dataset"
+        },
+        {
+          "name": "source"
+        },
+        {
+          "name": "public accession code"
+        },
+        {
+          "name": "technology"
+        },
+        {
+          "name": "sample_id"
+        },
+        {
+          "name": "age"
+        },
+        {
+          "name": "sex"
+        },
+        {
+          "name": "sort strategy"
+        },
+        {
+          "name": "chemistry"
+        }
+      ],
+      "n_columns": 9,
+      "header_row": 0,
+      "n_rows": 65,
+      "evidence": "legend_sheet"
+    },
+    {
+      "file_id": "41586_2024_8002_MOESM4_ESM.zip",
+      "member_path": "2023-08-13667B-s4/2023-08-13667B-s4/Supplementary Table 3.xlsx",
+      "locator": "Sheet1",
+      "table_label": "Supplementary Table 3",
+      "content_type": "deg_results",
+      "description": "Differential expression between refined (fine-grained) cell states across the whole prenatal skin scRNA-seq dataset: two-sided Wilcoxon rank-sum, Benjamini-Hochberg adjusted. One row per gene per cluster, so this is the primary marker table for any prenatal skin cell state. 139 columns because results are laid out as repeated column blocks.",
+      "columns": [
+        {
+          "name": "genes"
+        },
+        {
+          "name": "cluster"
+        },
+        {
+          "name": "top_frac"
+        },
+        {
+          "name": "frac_diff"
+        },
+        {
+          "name": "max_frac_diff"
+        },
+        {
+          "name": "top_mean_group"
+        },
+        {
+          "name": "top_mean"
+        },
+        {
+          "name": "mean_diff"
+        },
+        {
+          "name": "max_mean_diff"
+        },
+        {
+          "name": "logfoldchanges"
+        },
+        {
+          "name": "pvals"
+        },
+        {
+          "name": "pvals_adj"
+        }
+      ],
+      "n_columns": 139,
+      "header_row": 2,
+      "n_rows": 5114,
+      "evidence": "legend_sheet"
+    },
+    {
+      "file_id": "41586_2024_8002_MOESM4_ESM.zip",
+      "member_path": "2023-08-13667B-s4/2023-08-13667B-s4/Supplementary Table 4.xlsx",
+      "locator": "Sheet1",
+      "table_label": "Supplementary Table 4",
+      "content_type": "other",
+      "description": "Milo differential abundance testing: FACS-isolated cell proportions used to correct for sort strategy, then per-neighbourhood differential abundance across gestation for broad and refined cell states. Early-enriched neighbourhoods are SpatialFDR < 0.1 with logFC < 0, late-enriched are SpatialFDR < 0.1 with logFC > 0.",
+      "columns": [
+        {
+          "name": "orig.ident"
+        },
+        {
+          "name": "Sample.lanes"
+        },
+        {
+          "name": "age"
+        },
+        {
+          "name": "sort.ids"
+        },
+        {
+          "name": "origin"
+        },
+        {
+          "name": "count"
+        },
+        {
+          "name": "total_live_events"
+        },
+        {
+          "name": "parent_Multiplier"
+        },
+        {
+          "name": "remarks"
+        }
+      ],
+      "n_columns": 14,
+      "header_row": 1,
+      "n_rows": 35753,
+      "evidence": "legend_sheet"
+    },
+    {
+      "file_id": "41586_2024_8002_MOESM4_ESM.zip",
+      "member_path": "2023-08-13667B-s4/2023-08-13667B-s4/Supplementary Table 5.xlsx",
+      "locator": "Sheet1",
+      "table_label": "Supplementary Table 5",
+      "content_type": "cell_metadata",
+      "description": "Logistic regression prediction probabilities for a model trained on time-encoded prenatal and adult skin and projected onto skin organoid data \u2014 one row per cell, columns per gestational-age bin, for overall cell states and per broad category. The largest file in the bundle (~95 MB, 396,880 rows).",
+      "columns": [
+        {
+          "name": "predicted"
+        },
+        {
+          "name": "12-14"
+        },
+        {
+          "name": "15-17"
+        },
+        {
+          "name": "7-8"
+        },
+        {
+          "name": "9-11"
+        },
+        {
+          "name": "999"
+        },
+        {
+          "name": "confident_calls"
+        },
+        {
+          "name": "12-14_fetal_Mural cell"
+        },
+        {
+          "name": "15-17_fetal_Mural cell"
+        },
+        {
+          "name": "7-8_fetal_Mural cell"
+        },
+        {
+          "name": "9-11_fetal_Mural cell"
+        },
+        {
+          "name": "999_adult_Mural cell"
+        },
+        {
+          "name": "orig_labels"
+        },
+        {
+          "name": "12-14_fetal_Schwann cell"
+        },
+        {
+          "name": "15-17_fetal_Schwann cell"
+        },
+        {
+          "name": "7-8_fetal_Schwann cell"
+        },
+        {
+          "name": "9-11_fetal_Schwann cell"
+        },
+        {
+          "name": "999_adult_Schwann cell"
+        },
+        {
+          "name": "12-14_fetal_Vascular endothelium"
+        },
+        {
+          "name": "15-17_fetal_Vascular endothelium"
+        },
+        {
+          "name": "7-8_fetal_Vascular endothelium"
+        },
+        {
+          "name": "9-11_fetal_Vascular endothelium"
+        },
+        {
+          "name": "999_adult_Vascular endothelium"
+        },
+        {
+          "name": "12-14_Fibroblast"
+        },
+        {
+          "name": "15-17_Fibroblast"
+        }
+      ],
+      "n_columns": 88,
+      "header_row": 2,
+      "n_rows": 396877,
+      "evidence": "legend_sheet"
+    },
+    {
+      "file_id": "41586_2024_8002_MOESM4_ESM.zip",
+      "member_path": "2023-08-13667B-s4/2023-08-13667B-s4/Supplementary Table 6.xlsx",
+      "locator": "Sheet1",
+      "table_label": "Supplementary Table 6",
+      "content_type": "deg_results",
+      "description": "Differential expression within prenatal epidermal cell states by gestational age group (PCW): two-sided Wilcoxon rank-sum, BH adjusted. Use for genes that change with developmental time rather than between cell types. Note some gene symbols have been mangled into dates by a spreadsheet (e.g. MARCH1 -> 2024-08-07).",
+      "columns": [
+        {
+          "name": "genes"
+        },
+        {
+          "name": "cluster"
+        },
+        {
+          "name": "top_frac"
+        },
+        {
+          "name": "frac_diff"
+        },
+        {
+          "name": "max_frac_diff"
+        },
+        {
+          "name": "top_mean_group"
+        },
+        {
+          "name": "top_mean"
+        },
+        {
+          "name": "mean_diff"
+        },
+        {
+          "name": "max_mean_diff"
+        },
+        {
+          "name": "logfoldchanges"
+        },
+        {
+          "name": "pvals"
+        },
+        {
+          "name": "pvals_adj"
+        }
+      ],
+      "n_columns": 13,
+      "header_row": 1,
+      "n_rows": 2984,
+      "evidence": "legend_sheet"
+    },
+    {
+      "file_id": "41586_2024_8002_MOESM4_ESM.zip",
+      "member_path": "2023-08-13667B-s4/2023-08-13667B-s4/Supplementary Table 7.xlsx",
+      "locator": "Sheet1",
+      "table_label": "Supplementary Table 7",
+      "content_type": "other",
+      "description": "CellRank output: lineage driver genes for the inferred epidermal, fibroblast and endothelial trajectories, as per-lineage correlation with p, q and confidence intervals in repeated column blocks.",
+      "columns": [
+        {
+          "name": "Capillaries_2_corr"
+        },
+        {
+          "name": "Capillaries_2_pval"
+        },
+        {
+          "name": "Capillaries_2_qval"
+        },
+        {
+          "name": "Capillaries_2_ci_low"
+        },
+        {
+          "name": "Capillaries_2_ci_high"
+        },
+        {
+          "name": "Capillary arterioles_2_corr"
+        },
+        {
+          "name": "Capillary arterioles_2_pval"
+        },
+        {
+          "name": "Capillary arterioles_2_qval"
+        },
+        {
+          "name": "Capillary arterioles_2_ci_low"
+        },
+        {
+          "name": "Capillary arterioles_2_ci_high"
+        },
+        {
+          "name": "Arterioles_2_corr"
+        },
+        {
+          "name": "Arterioles_2_pval"
+        },
+        {
+          "name": "Arterioles_2_qval"
+        },
+        {
+          "name": "Arterioles_2_ci_low"
+        },
+        {
+          "name": "Arterioles_2_ci_high"
+        },
+        {
+          "name": "Postcapillary venules_3_corr"
+        },
+        {
+          "name": "Postcapillary venules_3_pval"
+        },
+        {
+          "name": "Postcapillary venules_3_qval"
+        },
+        {
+          "name": "Postcapillary venules_3_ci_low"
+        },
+        {
+          "name": "Postcapillary venules_3_ci_high"
+        },
+        {
+          "name": "Venules_1_corr"
+        },
+        {
+          "name": "Venules_1_pval"
+        },
+        {
+          "name": "Venules_1_qval"
+        },
+        {
+          "name": "Venules_1_ci_low"
+        },
+        {
+          "name": "Venules_1_ci_high"
+        }
+      ],
+      "n_columns": 107,
+      "header_row": 1,
+      "n_rows": 1896,
+      "evidence": "legend_sheet"
+    },
+    {
+      "file_id": "41586_2024_8002_MOESM4_ESM.zip",
+      "member_path": "2023-08-13667B-s4/2023-08-13667B-s4/Supplementary Table 8.xlsx",
+      "locator": "Sheet1",
+      "table_label": "Supplementary Table 8",
+      "content_type": "other",
+      "description": "Summarised CellPhoneDB ligand-receptor interactions for prenatal skin cell types, split by early (<= 11 PCW) and late (>= 12 PCW) gestation and for skin organoid. Significance is mean receptor-ligand expression p < 0.05 by empirical shuffling, FDR-adjusted.",
+      "columns": [
+        {
+          "name": "gene_pair"
+        },
+        {
+          "name": "celltype_pair"
+        },
+        {
+          "name": "mean"
+        },
+        {
+          "name": "p"
+        },
+        {
+          "name": "padj"
+        }
+      ],
+      "n_columns": 53,
+      "header_row": 1,
+      "n_rows": 141215,
+      "evidence": "legend_sheet"
+    },
+    {
+      "file_id": "41586_2024_8002_MOESM4_ESM.zip",
+      "member_path": "2023-08-13667B-s4/2023-08-13667B-s4/Supplementary Table 9.xlsx",
+      "locator": "Sheet1",
+      "table_label": "Supplementary Table 9",
+      "content_type": "other",
+      "description": "Genes2Genes trajectory alignment between prenatal skin and skin organoid fibroblasts for all 1,369 transcription factors: alignment similarity percentage and the 5-state alignment string (M match, W compression warp, V expansion warp, I insertion, D deletion).",
+      "columns": [
+        {
+          "name": "Gene"
+        },
+        {
+          "name": "alignment_similarity_percentage"
+        },
+        {
+          "name": "opt_alignment_cost"
+        },
+        {
+          "name": "l2fc"
+        },
+        {
+          "name": "color"
+        },
+        {
+          "name": "abs_l2fc"
+        },
+        {
+          "name": "cluster_id"
+        },
+        {
+          "name": "alignment_string"
+        }
+      ],
+      "n_columns": 9,
+      "header_row": 0,
+      "n_rows": 1369,
+      "evidence": "legend_sheet"
+    },
+    {
+      "file_id": "41586_2024_8002_MOESM4_ESM.zip",
+      "member_path": "2023-08-13667B-s4/2023-08-13667B-s4/Supplementary Table 10.xlsx",
+      "locator": "Sheet1",
+      "table_label": "Supplementary Table 10",
+      "content_type": "cell_metadata",
+      "description": "Logistic regression prediction probabilities for a model trained on human prenatal skin and projected onto murine embryonic skin, at broad (low-resolution) cluster level. One row per murine cell, one column per human broad annotation.",
+      "columns": [
+        {
+          "name": "LR_assignment"
+        },
+        {
+          "name": "Adipocyte"
+        },
+        {
+          "name": "B cell"
+        },
+        {
+          "name": "DC"
+        },
+        {
+          "name": "Erythroid"
+        },
+        {
+          "name": "Fibroblast"
+        },
+        {
+          "name": "Haem progenitor"
+        },
+        {
+          "name": "ILC"
+        },
+        {
+          "name": "Keratinocyte"
+        },
+        {
+          "name": "Lymphatic endothelium"
+        },
+        {
+          "name": "Macrophage"
+        },
+        {
+          "name": "Mast cell"
+        },
+        {
+          "name": "Megakaryocyte"
+        },
+        {
+          "name": "Melanocyte"
+        },
+        {
+          "name": "Monocyte"
+        },
+        {
+          "name": "Mural cell"
+        },
+        {
+          "name": "Neuronal cells"
+        },
+        {
+          "name": "Neutrophil"
+        },
+        {
+          "name": "Schwann cell"
+        },
+        {
+          "name": "Skeletal muscle"
+        },
+        {
+          "name": "T cell"
+        },
+        {
+          "name": "Vascular endothelium"
+        },
+        {
+          "name": "original_labels"
+        }
+      ],
+      "n_columns": 24,
+      "header_row": 1,
+      "n_rows": 32194,
+      "evidence": "legend_sheet"
+    },
+    {
+      "file_id": "41586_2024_8002_MOESM4_ESM.zip",
+      "member_path": "2023-08-13667B-s4/2023-08-13667B-s4/Supplementary Table 11.xlsx",
+      "locator": "Sheet1",
+      "table_label": "Supplementary Table 11",
+      "content_type": "cell_metadata",
+      "description": "As Supplementary Table 10 but at refined (high-resolution) cell-state level: one row per murine cell, one column per human refined annotation. Use for cross-species correspondence of a specific fine cell state.",
+      "columns": [
+        {
+          "name": "LR_assignment"
+        },
+        {
+          "name": "ASDC"
+        },
+        {
+          "name": "Adipocytes"
+        },
+        {
+          "name": "Arterioles"
+        },
+        {
+          "name": "B cell"
+        },
+        {
+          "name": "CCL19+ fibroblast"
+        },
+        {
+          "name": "CD4 T cell"
+        },
+        {
+          "name": "CD8 T cell"
+        },
+        {
+          "name": "Capillaries"
+        },
+        {
+          "name": "Capillary arterioles"
+        },
+        {
+          "name": "Companion layer"
+        },
+        {
+          "name": "Cuticle/cortex"
+        },
+        {
+          "name": "DC1"
+        },
+        {
+          "name": "DC2"
+        },
+        {
+          "name": "DPYSL2+ basal"
+        },
+        {
+          "name": "Dermal condensate"
+        },
+        {
+          "name": "Dermal papilla"
+        },
+        {
+          "name": "Early LE"
+        },
+        {
+          "name": "Early endothelial cells"
+        },
+        {
+          "name": "Early erythroid"
+        },
+        {
+          "name": "Early erythroid (embryonic)"
+        },
+        {
+          "name": "Early myocytes"
+        },
+        {
+          "name": "Eo/baso/mast cell progenitor"
+        },
+        {
+          "name": "Erythroid (embryonic)"
+        },
+        {
+          "name": "Erythroid (fetal)"
+        }
+      ],
+      "n_columns": 89,
+      "header_row": 1,
+      "n_rows": 32194,
+      "evidence": "legend_sheet"
+    },
+    {
+      "file_id": "41586_2024_8002_MOESM4_ESM.zip",
+      "member_path": "2023-08-13667B-s4/2023-08-13667B-s4/Supplementary Table 12.xlsx",
+      "locator": "Sheet1",
+      "table_label": "Supplementary Table 12",
+      "content_type": "other",
+      "description": "Gene mutations implicated in genetic hair diseases found along the inner root sheath, outer root sheath/companion layer and hair fibroblast trajectories, with literature references.",
+      "columns": [
+        {
+          "name": "Gene"
+        },
+        {
+          "name": "Disease"
+        },
+        {
+          "name": "Reference"
+        }
+      ],
+      "n_columns": 3,
+      "header_row": 1,
+      "n_rows": 13,
+      "evidence": "legend_sheet"
+    },
+    {
+      "file_id": "41586_2024_8002_MOESM4_ESM.zip",
+      "member_path": "2023-08-13667B-s4/2023-08-13667B-s4/Supplementary Table 13.xlsx",
+      "locator": "Sheet1",
+      "table_label": "Supplementary Table 13",
+      "content_type": "deg_results",
+      "description": "Differential expression comparing prenatal skin fibroblasts against healthy adult skin fibroblasts (Wilcoxon, BH adjusted), as two column blocks.",
+      "columns": [
+        {
+          "name": "names"
+        },
+        {
+          "name": "pvals"
+        },
+        {
+          "name": "logfoldchanges"
+        },
+        {
+          "name": "scores"
+        }
+      ],
+      "n_columns": 10,
+      "header_row": 2,
+      "n_rows": 1000,
+      "evidence": "legend_sheet"
+    },
+    {
+      "file_id": "41586_2024_8002_MOESM4_ESM.zip",
+      "member_path": "2023-08-13667B-s4/2023-08-13667B-s4/Supplementary Table 14.xlsx",
+      "locator": "Sheet1",
+      "table_label": "Supplementary Table 14",
+      "content_type": "other",
+      "description": "Gene set enrichment for prenatal skin fibroblasts: Fisher exact test, BH adjusted, ranked by z-score, with the overlapping gene list per term.",
+      "columns": [
+        {
+          "name": "Gene_set"
+        },
+        {
+          "name": "Term"
+        },
+        {
+          "name": "Overlap"
+        },
+        {
+          "name": "P-value"
+        },
+        {
+          "name": "Adjusted P-value"
+        },
+        {
+          "name": "Old P-value"
+        },
+        {
+          "name": "Old Adjusted P-value"
+        },
+        {
+          "name": "Odds Ratio"
+        },
+        {
+          "name": "Combined Score"
+        },
+        {
+          "name": "Genes"
+        }
+      ],
+      "n_columns": 11,
+      "header_row": 1,
+      "n_rows": 3561,
+      "evidence": "legend_sheet"
+    },
+    {
+      "file_id": "41586_2024_8002_MOESM4_ESM.zip",
+      "member_path": "2023-08-13667B-s4/2023-08-13667B-s4/Supplementary Table 15.xlsx",
+      "locator": "Sheet1",
+      "table_label": "Supplementary Table 15",
+      "content_type": "other",
+      "description": "Gene set enrichment for healthy adult skin fibroblasts (the legend's title repeats 'prenatal', but the contents are the adult comparison). Same columns as Supplementary Table 14.",
+      "columns": [
+        {
+          "name": "Gene_set"
+        },
+        {
+          "name": "Term"
+        },
+        {
+          "name": "Overlap"
+        },
+        {
+          "name": "P-value"
+        },
+        {
+          "name": "Adjusted P-value"
+        },
+        {
+          "name": "Old P-value"
+        },
+        {
+          "name": "Old Adjusted P-value"
+        },
+        {
+          "name": "Odds Ratio"
+        },
+        {
+          "name": "Combined Score"
+        },
+        {
+          "name": "Genes"
+        }
+      ],
+      "n_columns": 11,
+      "header_row": 1,
+      "n_rows": 4054,
+      "evidence": "legend_sheet"
+    },
+    {
+      "file_id": "41586_2024_8002_MOESM4_ESM.zip",
+      "member_path": "2023-08-13667B-s4/2023-08-13667B-s4/Supplementary Table 16.xlsx",
+      "locator": "Sheet1",
+      "table_label": "Supplementary Table 16",
+      "content_type": "deg_results",
+      "description": "Differential expression between Milo-defined early- and late-gestation WNT2+ fibroblasts (Wilcoxon, BH adjusted).",
+      "columns": [
+        {
+          "name": "names"
+        },
+        {
+          "name": "pvals"
+        },
+        {
+          "name": "logfoldchanges"
+        },
+        {
+          "name": "scores"
+        }
+      ],
+      "n_columns": 10,
+      "header_row": 2,
+      "n_rows": 674,
+      "evidence": "legend_sheet"
+    },
+    {
+      "file_id": "41586_2024_8002_MOESM4_ESM.zip",
+      "member_path": "2023-08-13667B-s4/2023-08-13667B-s4/Supplementary Table 17.xlsx",
+      "locator": "Sheet1",
+      "table_label": "Supplementary Table 17",
+      "content_type": "other",
+      "description": "Gene set enrichment for WNT2+ fibroblasts enriched in early gestation (Milo early neighbourhoods).",
+      "columns": [
+        {
+          "name": "Gene_set"
+        },
+        {
+          "name": "Term"
+        },
+        {
+          "name": "Overlap"
+        },
+        {
+          "name": "P-value"
+        },
+        {
+          "name": "Adjusted P-value"
+        },
+        {
+          "name": "Old P-value"
+        },
+        {
+          "name": "Old Adjusted P-value"
+        },
+        {
+          "name": "Odds Ratio"
+        },
+        {
+          "name": "Combined Score"
+        },
+        {
+          "name": "Genes"
+        }
+      ],
+      "n_columns": 11,
+      "header_row": 1,
+      "n_rows": 2899,
+      "evidence": "legend_sheet"
+    },
+    {
+      "file_id": "41586_2024_8002_MOESM4_ESM.zip",
+      "member_path": "2023-08-13667B-s4/2023-08-13667B-s4/Supplementary Table 18.xlsx",
+      "locator": "Sheet1",
+      "table_label": "Supplementary Table 18",
+      "content_type": "other",
+      "description": "Gene set enrichment for WNT2+ fibroblasts enriched in late gestation (Milo late neighbourhoods).",
+      "columns": [
+        {
+          "name": "Gene_set"
+        },
+        {
+          "name": "Term"
+        },
+        {
+          "name": "Overlap"
+        },
+        {
+          "name": "P-value"
+        },
+        {
+          "name": "Adjusted P-value"
+        },
+        {
+          "name": "Old P-value"
+        },
+        {
+          "name": "Old Adjusted P-value"
+        },
+        {
+          "name": "Odds Ratio"
+        },
+        {
+          "name": "Combined Score"
+        },
+        {
+          "name": "Genes"
+        }
+      ],
+      "n_columns": 11,
+      "header_row": 1,
+      "n_rows": 1924,
+      "evidence": "legend_sheet"
+    },
+    {
+      "file_id": "41586_2024_8002_MOESM4_ESM.zip",
+      "member_path": "2023-08-13667B-s4/2023-08-13667B-s4/Supplementary Table 19.xlsx",
+      "locator": "Sheet1",
+      "table_label": "Supplementary Table 19",
+      "content_type": "cell_metadata",
+      "description": "Logistic regression probabilities from a model trained on reindeer skin fibroblast classes (antler velvet and back skin) projected onto human prenatal skin fibroblasts grouped by gestational age. One row per cell.",
+      "columns": [
+        {
+          "name": "Original grouping"
+        },
+        {
+          "name": "LR_assignment"
+        },
+        {
+          "name": "Mixed"
+        },
+        {
+          "name": "Proinflammatory"
+        },
+        {
+          "name": "Proregenerative"
+        }
+      ],
+      "n_columns": 6,
+      "header_row": 1,
+      "n_rows": 4000,
+      "evidence": "legend_sheet"
+    },
+    {
+      "file_id": "41586_2024_8002_MOESM4_ESM.zip",
+      "member_path": "2023-08-13667B-s4/2023-08-13667B-s4/Supplementary Table 20.xlsx",
+      "locator": "Sheet1",
+      "table_label": "Supplementary Table 20",
+      "content_type": "marker_list",
+      "description": "Pro-regenerative and pro-fibrotic gene lists published for reindeer skin (antler velvet and back), from Sinha et al. 2022 (PMID 36493752). Two columns, one gene list each.",
+      "columns": [
+        {
+          "name": "Pre-regenerative genes"
+        },
+        {
+          "name": "Pre-fibrotic genes"
+        }
+      ],
+      "n_columns": 2,
+      "header_row": 1,
+      "n_rows": 40,
+      "evidence": "legend_sheet"
+    },
+    {
+      "file_id": "41586_2024_8002_MOESM4_ESM.zip",
+      "member_path": "2023-08-13667B-s4/2023-08-13667B-s4/Supplementary Table 21.xlsx",
+      "locator": "Sheet1",
+      "table_label": "Supplementary Table 21",
+      "content_type": "cell_metadata",
+      "description": "Logistic regression probabilities from a model trained on reindeer skin macrophage clusters projected onto human prenatal skin macrophage subsets. One row per cell, carrying the original prenatal macrophage label alongside the predicted reindeer cluster. Column headers for the predicted classes are bare cluster numbers.",
+      "columns": [
+        {
+          "name": "Original_labels"
+        },
+        {
+          "name": "LR_assignment"
+        },
+        {
+          "name": "0"
+        },
+        {
+          "name": "1"
+        },
+        {
+          "name": "2"
+        },
+        {
+          "name": "3"
+        },
+        {
+          "name": "4"
+        },
+        {
+          "name": "5"
+        },
+        {
+          "name": "6"
+        }
+      ],
+      "n_columns": 10,
+      "header_row": 1,
+      "n_rows": 27563,
+      "evidence": "legend_sheet"
+    },
+    {
+      "file_id": "41586_2024_8002_MOESM4_ESM.zip",
+      "member_path": "2023-08-13667B-s4/2023-08-13667B-s4/Supplementary Table 22.xlsx",
+      "locator": "Sheet1",
+      "table_label": "Supplementary Table 22",
+      "content_type": "deg_results",
+      "description": "Differential expression between prenatal skin macrophage subsets \u2014 TLM, iron-recycling, LYVE1+ and MHC-II+ \u2014 each computed against the rest of the myeloid cells (Wilcoxon, BH adjusted). The marker table for any of the four macrophage subsets. Laid out as one five-column block per subset, with the subset name in the row above the header.",
+      "columns": [
+        {
+          "name": "names"
+        },
+        {
+          "name": "scores"
+        },
+        {
+          "name": "logfoldchanges"
+        },
+        {
+          "name": "pvals"
+        },
+        {
+          "name": "pvals_adj"
+        }
+      ],
+      "n_columns": 24,
+      "header_row": 2,
+      "n_rows": 550,
+      "evidence": "legend_sheet"
+    },
+    {
+      "file_id": "41586_2024_8002_MOESM4_ESM.zip",
+      "member_path": "2023-08-13667B-s4/2023-08-13667B-s4/Supplementary Table 23.xlsx",
+      "locator": "Sheet1",
+      "table_label": "Supplementary Table 23",
+      "content_type": "other",
+      "description": "Gene set enrichment for genes differentially expressed by TLM macrophages (Fisher exact, BH adjusted, ranked by z-score).",
+      "columns": [
+        {
+          "name": "Gene_set"
+        },
+        {
+          "name": "Term"
+        },
+        {
+          "name": "Overlap"
+        },
+        {
+          "name": "P-value"
+        },
+        {
+          "name": "Adjusted P-value"
+        },
+        {
+          "name": "Old P-value"
+        },
+        {
+          "name": "Old Adjusted P-value"
+        },
+        {
+          "name": "Odds Ratio"
+        },
+        {
+          "name": "Combined Score"
+        },
+        {
+          "name": "Genes"
+        }
+      ],
+      "n_columns": 11,
+      "header_row": 1,
+      "n_rows": 2027,
+      "evidence": "legend_sheet"
+    },
+    {
+      "file_id": "41586_2024_8002_MOESM4_ESM.zip",
+      "member_path": "2023-08-13667B-s4/2023-08-13667B-s4/Supplementary Table 24.xlsx",
+      "locator": "Sheet1",
+      "table_label": "Supplementary Table 24",
+      "content_type": "other",
+      "description": "Gene set enrichment for genes differentially expressed by iron-recycling macrophages (Fisher exact, BH adjusted, ranked by z-score). The functional-annotation counterpart to that subset's markers in Supplementary Table 22.",
+      "columns": [
+        {
+          "name": "Gene_set"
+        },
+        {
+          "name": "Term"
+        },
+        {
+          "name": "Overlap"
+        },
+        {
+          "name": "P-value"
+        },
+        {
+          "name": "Adjusted P-value"
+        },
+        {
+          "name": "Old P-value"
+        },
+        {
+          "name": "Old Adjusted P-value"
+        },
+        {
+          "name": "Odds Ratio"
+        },
+        {
+          "name": "Combined Score"
+        },
+        {
+          "name": "Genes"
+        }
+      ],
+      "n_columns": 11,
+      "header_row": 1,
+      "n_rows": 1030,
+      "evidence": "legend_sheet"
+    },
+    {
+      "file_id": "41586_2024_8002_MOESM4_ESM.zip",
+      "member_path": "2023-08-13667B-s4/2023-08-13667B-s4/Supplementary Table 25.xlsx",
+      "locator": "Sheet1",
+      "table_label": "Supplementary Table 25",
+      "content_type": "other",
+      "description": "Gene set enrichment for genes differentially expressed by LYVE1+ macrophages.",
+      "columns": [
+        {
+          "name": "Gene_set"
+        },
+        {
+          "name": "Term"
+        },
+        {
+          "name": "Overlap"
+        },
+        {
+          "name": "P-value"
+        },
+        {
+          "name": "Adjusted P-value"
+        },
+        {
+          "name": "Old P-value"
+        },
+        {
+          "name": "Old Adjusted P-value"
+        },
+        {
+          "name": "Odds Ratio"
+        },
+        {
+          "name": "Combined Score"
+        },
+        {
+          "name": "Genes"
+        }
+      ],
+      "n_columns": 11,
+      "header_row": 1,
+      "n_rows": 2642,
+      "evidence": "legend_sheet"
+    },
+    {
+      "file_id": "41586_2024_8002_MOESM4_ESM.zip",
+      "member_path": "2023-08-13667B-s4/2023-08-13667B-s4/Supplementary Table 26.xlsx",
+      "locator": "Sheet1",
+      "table_label": "Supplementary Table 26",
+      "content_type": "other",
+      "description": "Gene set enrichment for genes differentially expressed by MHC-II+ macrophages.",
+      "columns": [
+        {
+          "name": "Gene_set"
+        },
+        {
+          "name": "Term"
+        },
+        {
+          "name": "Overlap"
+        },
+        {
+          "name": "P-value"
+        },
+        {
+          "name": "Adjusted P-value"
+        },
+        {
+          "name": "Old P-value"
+        },
+        {
+          "name": "Old Adjusted P-value"
+        },
+        {
+          "name": "Odds Ratio"
+        },
+        {
+          "name": "Combined Score"
+        },
+        {
+          "name": "Genes"
+        }
+      ],
+      "n_columns": 11,
+      "header_row": 1,
+      "n_rows": 323,
+      "evidence": "legend_sheet"
+    },
+    {
+      "file_id": "41586_2024_8002_MOESM4_ESM.zip",
+      "member_path": "2023-08-13667B-s4/2023-08-13667B-s4/Supplementary Table 27.xlsx",
+      "locator": "Sheet1",
+      "table_label": "Supplementary Table 27",
+      "content_type": "other",
+      "description": "The angiogenesis gene sets (GO Biological Process 2021) used to compute angiogenesis module scores. Each column is one GO term, listing its genes down the column rather than one row per gene.",
+      "columns": [
+        {
+          "name": "positive regulation of angiogenesis (GO:0045766)"
+        },
+        {
+          "name": "positive regulation of sprouting angiogenesis (GO:1903672)"
+        },
+        {
+          "name": "positive regulation of endothelial cell chemotaxis (GO:2001028)"
+        },
+        {
+          "name": "positive regulation of endothelial cell proliferation (GO:0001938)"
+        },
+        {
+          "name": "blood vessel morphogenesis (GO:0048514)"
+        }
+      ],
+      "n_columns": 9,
+      "header_row": 1,
+      "n_rows": 117,
+      "evidence": "legend_sheet"
+    },
+    {
+      "file_id": "41586_2024_8002_MOESM4_ESM.zip",
+      "member_path": "2023-08-13667B-s4/2023-08-13667B-s4/Supplementary Table 28.xlsx",
+      "locator": "Sheet1",
+      "table_label": "Supplementary Table 28",
+      "content_type": "other",
+      "description": "Summarised CellPhoneDB ligand-receptor interactions across all prenatal skin cell states (not split by gestation, unlike Supplementary Table 8). Significance p < 0.05, FDR-adjusted.",
+      "columns": [
+        {
+          "name": "gene_pair"
+        },
+        {
+          "name": "celltype_pair"
+        },
+        {
+          "name": "mean"
+        },
+        {
+          "name": "p"
+        },
+        {
+          "name": "padj"
+        }
+      ],
+      "n_columns": 17,
+      "header_row": 1,
+      "n_rows": 137204,
+      "evidence": "legend_sheet"
+    },
+    {
+      "file_id": "41586_2024_8002_MOESM4_ESM.zip",
+      "member_path": "2023-08-13667B-s4/2023-08-13667B-s4/Supplementary Table 29.xlsx",
+      "locator": "Sheet1",
+      "table_label": "Supplementary Table 29",
+      "content_type": "other",
+      "description": "Gene lists used for the endothelial and hypoxia module scores; each column is one score's gene set.",
+      "columns": [
+        {
+          "name": "Tip score"
+        },
+        {
+          "name": "Stalk score"
+        },
+        {
+          "name": "Arterioles"
+        },
+        {
+          "name": "Capillaries"
+        },
+        {
+          "name": "Venules"
+        },
+        {
+          "name": "LE"
+        },
+        {
+          "name": "Hypoxia (Hallmark)"
+        }
+      ],
+      "n_columns": 10,
+      "header_row": 2,
+      "n_rows": 200,
+      "evidence": "legend_sheet"
+    },
+    {
+      "file_id": "41586_2024_8002_MOESM4_ESM.zip",
+      "member_path": "2023-08-13667B-s4/2023-08-13667B-s4/Supplementary Table 30.xlsx",
+      "locator": "Sheet1",
+      "table_label": "Supplementary Table 30",
+      "content_type": "deg_results",
+      "description": "Differential expression between prenatal skin and skin organoid for all cell states, grouped by dataset, as prenatal and organoid column blocks.",
+      "columns": [
+        {
+          "name": "prenatal names"
+        },
+        {
+          "name": "prenatal scores"
+        },
+        {
+          "name": "prenatal logfoldchanges"
+        },
+        {
+          "name": "prenatal pvals"
+        },
+        {
+          "name": "prenatal pvals_adj"
+        },
+        {
+          "name": "organoid names"
+        },
+        {
+          "name": "organoid scores"
+        },
+        {
+          "name": "organoid logfoldchanges"
+        },
+        {
+          "name": "organoid pvals"
+        },
+        {
+          "name": "organoid pvals_adj"
+        }
+      ],
+      "n_columns": 12,
+      "header_row": 1,
+      "n_rows": 36592,
+      "evidence": "legend_sheet"
+    },
+    {
+      "file_id": "41586_2024_8002_MOESM4_ESM.zip",
+      "member_path": "2023-08-13667B-s4/2023-08-13667B-s4/Supplementary Table 31.xlsx",
+      "locator": "Sheet1",
+      "table_label": "Supplementary Table 31",
+      "content_type": "deg_results",
+      "description": "A filtered list of genes encoding secreted proteins that differ between prenatal skin and skin organoid, with log fold change and adjusted p-value. Note the discrepancy: the legends document calls this the upregulated list, while the sheet's own title row says downregulated \u2014 check the sign of fetal_logfoldchanges before relying on either.",
+      "columns": [
+        {
+          "name": "fetal_names"
+        },
+        {
+          "name": "fetal_logfoldchanges"
+        },
+        {
+          "name": "fetal_pvals_adj"
+        }
+      ],
+      "n_columns": 4,
+      "header_row": 2,
+      "n_rows": 749,
+      "evidence": "legend_sheet"
+    },
+    {
+      "file_id": "41586_2024_8002_MOESM4_ESM.zip",
+      "member_path": "2023-08-13667B-s4/2023-08-13667B-s4/Supplementary Table 32.xlsx",
+      "locator": "Sheet1",
+      "table_label": "Supplementary Table 32",
+      "content_type": "deg_results",
+      "description": "The companion filtered list of secreted-protein genes for the opposite direction to Supplementary Table 31, same columns. Both sheets carry a 'downregulated' title row; use the fold-change sign rather than the label.",
+      "columns": [
+        {
+          "name": "fetal_names"
+        },
+        {
+          "name": "fetal_logfoldchanges"
+        },
+        {
+          "name": "fetal_pvals_adj"
+        }
+      ],
+      "n_columns": 4,
+      "header_row": 2,
+      "n_rows": 1002,
+      "evidence": "legend_sheet"
+    },
+    {
+      "file_id": "41586_2024_8002_MOESM4_ESM.zip",
+      "member_path": "2023-08-13667B-s4/2023-08-13667B-s4/Supplementary Table 33.xlsx",
+      "locator": "Sheet1",
+      "table_label": "Supplementary Table 33",
+      "content_type": "other",
+      "description": "Gene set enrichment for the secreted-protein genes upregulated in prenatal skin relative to skin organoid.",
+      "columns": [
+        {
+          "name": "Gene_set"
+        },
+        {
+          "name": "Term"
+        },
+        {
+          "name": "Overlap"
+        },
+        {
+          "name": "P-value"
+        },
+        {
+          "name": "Adjusted P-value"
+        },
+        {
+          "name": "Old P-value"
+        },
+        {
+          "name": "Old Adjusted P-value"
+        },
+        {
+          "name": "Odds Ratio"
+        },
+        {
+          "name": "Combined Score"
+        },
+        {
+          "name": "Genes"
+        }
+      ],
+      "n_columns": 11,
+      "header_row": 2,
+      "n_rows": 2676,
+      "evidence": "legend_sheet"
+    },
+    {
+      "file_id": "41586_2024_8002_MOESM4_ESM.zip",
+      "member_path": "2023-08-13667B-s4/2023-08-13667B-s4/Supplementary Table 34.xlsx",
+      "locator": "Sheet1",
+      "table_label": "Supplementary Table 34",
+      "content_type": "other",
+      "description": "Gene set enrichment for the secreted-protein genes downregulated in prenatal skin relative to skin organoid.",
+      "columns": [
+        {
+          "name": "Gene_set"
+        },
+        {
+          "name": "Term"
+        },
+        {
+          "name": "Overlap"
+        },
+        {
+          "name": "P-value"
+        },
+        {
+          "name": "Adjusted P-value"
+        },
+        {
+          "name": "Old P-value"
+        },
+        {
+          "name": "Old Adjusted P-value"
+        },
+        {
+          "name": "Odds Ratio"
+        },
+        {
+          "name": "Combined Score"
+        },
+        {
+          "name": "Genes"
+        }
+      ],
+      "n_columns": 11,
+      "header_row": 2,
+      "n_rows": 3164,
+      "evidence": "legend_sheet"
+    },
+    {
+      "file_id": "41586_2024_8002_MOESM4_ESM.zip",
+      "member_path": "2023-08-13667B-s4/2023-08-13667B-s4/Supplementary Table 35.xlsx",
+      "locator": "Sheet1",
+      "table_label": "Supplementary Table 35",
+      "content_type": "other",
+      "description": "NicheNet prioritised ligands, ranked by ligand activity score (auroc, aupr, corrected aupr, pearson, rank).",
+      "columns": [
+        {
+          "name": "test_ligand"
+        },
+        {
+          "name": "auroc"
+        },
+        {
+          "name": "aupr"
+        },
+        {
+          "name": "aupr_corrected"
+        },
+        {
+          "name": "pearson"
+        },
+        {
+          "name": "rank"
+        }
+      ],
+      "n_columns": 6,
+      "header_row": 1,
+      "n_rows": 103,
+      "evidence": "legend_sheet"
+    },
+    {
+      "file_id": "41586_2024_8002_MOESM4_ESM.zip",
+      "member_path": "2023-08-13667B-s4/2023-08-13667B-s4/Supplementary Table 36.xlsx",
+      "locator": "Sheet1",
+      "table_label": "Supplementary Table 36",
+      "content_type": "other",
+      "description": "NicheNet prioritised ligands with their active target genes and interaction weights \u2014 one row per ligand-target pair.",
+      "columns": [
+        {
+          "name": "ligand"
+        },
+        {
+          "name": "target"
+        },
+        {
+          "name": "weight"
+        }
+      ],
+      "n_columns": 3,
+      "header_row": 1,
+      "n_rows": 1052,
+      "evidence": "legend_sheet"
+    },
+    {
+      "file_id": "41586_2024_8002_MOESM4_ESM.zip",
+      "member_path": "2023-08-13667B-s4/2023-08-13667B-s4/Supplementary Table 37.xlsx",
+      "locator": "Sheet1",
+      "table_label": "Supplementary Table 37",
+      "content_type": "other",
+      "description": "NicheNet prioritised ligands against their receptors, filtered to bona fide ligand-receptor interactions. Ligands are columns, receptors are rows.",
+      "columns": [
+        {
+          "name": "IL1A"
+        },
+        {
+          "name": "IL1B"
+        },
+        {
+          "name": "ADAM17"
+        },
+        {
+          "name": "VCAM1"
+        },
+        {
+          "name": "VEGFA"
+        },
+        {
+          "name": "TNF"
+        },
+        {
+          "name": "TGFB1"
+        },
+        {
+          "name": "SEMA4D"
+        },
+        {
+          "name": "SELPLG"
+        },
+        {
+          "name": "ITGAM"
+        },
+        {
+          "name": "APOE"
+        },
+        {
+          "name": "BMP2"
+        }
+      ],
+      "n_columns": 15,
+      "header_row": 1,
+      "n_rows": 21,
+      "evidence": "legend_sheet"
+    },
+    {
+      "file_id": "41586_2024_8002_MOESM4_ESM.zip",
+      "member_path": "2023-08-13667B-s4/2023-08-13667B-s4/Supplementary Table 38.xlsx",
+      "locator": "Sheet1",
+      "table_label": "Supplementary Table 38",
+      "content_type": "other",
+      "description": "Antibodies used for immunofluorescence of prenatal skin and skin organoid cryosections: RRID, vendor, catalogue number, clonality, clone, dilution and application. Use it to check what a protein-level claim was stained with.",
+      "columns": [
+        {
+          "name": "RRID citation"
+        },
+        {
+          "name": "Antibody"
+        },
+        {
+          "name": "Vendor"
+        },
+        {
+          "name": "Cat no"
+        },
+        {
+          "name": "Clonality"
+        },
+        {
+          "name": "Clone"
+        },
+        {
+          "name": "Dilution"
+        },
+        {
+          "name": "Antibody application"
+        }
+      ],
+      "n_columns": 27,
+      "header_row": 1,
+      "n_rows": 27,
+      "evidence": "legend_sheet"
+    },
+    {
+      "file_id": "41586_2024_8002_MOESM4_ESM.zip",
+      "member_path": "2023-08-13667B-s4/2023-08-13667B-s4/Supplementary Table 39.xlsx",
+      "locator": "Sheet1",
+      "table_label": "Supplementary Table 39",
+      "content_type": "other",
+      "description": "The database of predicted secreted proteins and their encoding genes, with synonyms, Ensembl and UniProt identifiers, protein class and evidence level.",
+      "columns": [
+        {
+          "name": "Gene"
+        },
+        {
+          "name": "Gene synonym"
+        },
+        {
+          "name": "Ensembl"
+        },
+        {
+          "name": "Gene description"
+        },
+        {
+          "name": "Uniprot"
+        },
+        {
+          "name": "Chromosome"
+        },
+        {
+          "name": "Position"
+        },
+        {
+          "name": "Protein class"
+        },
+        {
+          "name": "Biological process"
+        },
+        {
+          "name": "Molecular function"
+        },
+        {
+          "name": "Disease involvement"
+        },
+        {
+          "name": "Evidence"
+        },
+        {
+          "name": "HPA evidence"
+        },
+        {
+          "name": "UniProt evidence"
+        },
+        {
+          "name": "NeXtProt evidence"
+        },
+        {
+          "name": "RNA tissue specificity"
+        },
+        {
+          "name": "RNA tissue distribution"
+        },
+        {
+          "name": "RNA tissue specificity score"
+        },
+        {
+          "name": "RNA tissue specific nTPM"
+        },
+        {
+          "name": "RNA single cell type specificity"
+        },
+        {
+          "name": "RNA single cell type distribution"
+        },
+        {
+          "name": "RNA single cell type specificity score"
+        },
+        {
+          "name": "RNA single cell type specific nTPM"
+        },
+        {
+          "name": "RNA cancer specificity"
+        },
+        {
+          "name": "RNA cancer distribution"
+        }
+      ],
+      "n_columns": 313,
+      "header_row": 1,
+      "n_rows": 1903,
+      "evidence": "legend_sheet"
+    },
+    {
+      "file_id": "41586_2024_8002_MOESM4_ESM.zip",
+      "member_path": "2023-08-13667B-s4/2023-08-13667B-s4/Supplementary Table 40.xlsx",
+      "locator": "Sheet1",
+      "table_label": "Supplementary Table 40",
+      "content_type": "cluster_annotation",
+      "description": "Microenvironment labels used for the spatial analysis, defined by predominant cell-type composition and/or spatial or age distribution. Maps a microenvironment number to its label.",
+      "columns": [
+        {
+          "name": "No."
+        },
+        {
+          "name": "Microenvironment label"
+        }
+      ],
+      "n_columns": 2,
+      "header_row": 0,
+      "n_rows": 11,
+      "evidence": "legend_sheet"
+    },
+    {
+      "file_id": "41586_2024_8002_MOESM4_ESM.zip",
+      "member_path": "2023-08-13667B-s4/Supplementary Table legends.docx",
+      "table_label": "Supplementary Table legends",
+      "content_type": "legend",
+      "description": "Prose legends for all 40 supplementary tables, one paragraph each: the table's title and what analysis produced it. Read this first \u2014 it characterises the whole bundle in ~11,000 characters, and the individual workbooks carry no descriptions of their own.",
+      "evidence": "rows_read"
+    },
+    {
+      "file_id": "41586_2024_8002_MOESM6_ESM.xlsx",
+      "locator": "Fig. 2b",
+      "content_type": "cell_metadata",
+      "description": "Source data for Fig. 2b: cell counts per refined annotation, per donor and gestational age. Use for how abundant a prenatal skin cell state is and how that changes across gestation.",
+      "columns": [
+        {
+          "name": "PCW"
+        },
+        {
+          "name": "Donor"
+        },
+        {
+          "name": "Annotation_Fine"
+        },
+        {
+          "name": "Counts"
+        }
+      ],
+      "n_columns": 13,
+      "header_row": 0,
+      "n_rows": 216,
+      "evidence": "headers"
+    },
+    {
+      "file_id": "41586_2024_8002_MOESM6_ESM.xlsx",
+      "locator": "Fig. 4c",
+      "content_type": "cell_metadata",
+      "description": "Source data for Fig. 4c: cell counts per refined annotation, per donor and gestational age, for the subset shown in that panel.",
+      "columns": [
+        {
+          "name": "PCW"
+        },
+        {
+          "name": "Donor"
+        },
+        {
+          "name": "Annotation_Fine"
+        },
+        {
+          "name": "Counts"
+        }
+      ],
+      "n_columns": 9,
+      "header_row": 0,
+      "n_rows": 144,
+      "evidence": "headers"
+    },
+    {
+      "file_id": "41586_2024_8002_MOESM6_ESM.xlsx",
+      "locator": "Fig. 4i",
+      "content_type": "other",
+      "description": "Source data for Fig. 4i: endothelial density per skin-organoid batch and condition, from image quantification.",
+      "columns": [
+        {
+          "name": "SkO batch"
+        },
+        {
+          "name": "Condition"
+        },
+        {
+          "name": "Endothelial density (%)"
+        }
+      ],
+      "n_columns": 26,
+      "header_row": 3,
+      "n_rows": 996,
+      "evidence": "headers"
+    },
+    {
+      "file_id": "41586_2024_8002_MOESM6_ESM.xlsx",
+      "locator": "ED Fig. 3c",
+      "content_type": "cell_metadata",
+      "description": "Source data for Extended Data Fig. 3c: cell counts per refined annotation, per donor and gestational age.",
+      "columns": [
+        {
+          "name": "PCW"
+        },
+        {
+          "name": "Donor"
+        },
+        {
+          "name": "Annotation_Fine"
+        },
+        {
+          "name": "Counts"
+        }
+      ],
+      "n_columns": 22,
+      "header_row": 0,
+      "n_rows": 360,
+      "evidence": "headers"
+    },
+    {
+      "file_id": "41586_2024_8002_MOESM6_ESM.xlsx",
+      "locator": "ED Fig. 3f",
+      "content_type": "other",
+      "description": "Source data for Extended Data Fig. 3f: FOXP3+ cell counts in hair-follicle versus non-hair-follicle regions.",
+      "columns": [
+        {
+          "name": "FOXP3+ HF regions"
+        },
+        {
+          "name": "FOXP3+ non-HF regions"
+        }
+      ],
+      "n_columns": 3,
+      "header_row": 2,
+      "n_rows": 997,
+      "evidence": "headers"
+    },
+    {
+      "file_id": "41586_2024_8002_MOESM6_ESM.xlsx",
+      "locator": "ED Fig. 7g",
+      "content_type": "other",
+      "description": "Source data for Extended Data Fig. 7g: per-experiment image quantification, laid out as one column block per experiment.",
+      "columns": [
+        {
+          "name": "Time (hours)"
+        },
+        {
+          "name": "well 1"
+        },
+        {
+          "name": "well 2"
+        },
+        {
+          "name": "well 3"
+        }
+      ],
+      "n_columns": 26,
+      "header_row": 4,
+      "n_rows": 995,
+      "evidence": "headers"
+    },
+    {
+      "file_id": "41586_2024_8002_MOESM6_ESM.xlsx",
+      "locator": "ED Fig. 8g",
+      "content_type": "other",
+      "description": "Source data for Extended Data Fig. 8g: per-experiment image quantification, one column block per experiment.",
+      "columns": [
+        {
+          "name": "Time (hours)"
+        },
+        {
+          "name": "well 1"
+        },
+        {
+          "name": "well 2"
+        },
+        {
+          "name": "well 3"
+        }
+      ],
+      "n_columns": 26,
+      "header_row": 4,
+      "n_rows": 995,
+      "evidence": "headers"
+    },
+    {
+      "file_id": "41586_2024_8002_MOESM6_ESM.xlsx",
+      "locator": "ED Fig. 10g",
+      "content_type": "other",
+      "description": "Source data for Extended Data Fig. 10g: timecourse quantification for endothelial-cell-only and co-culture conditions.",
+      "columns": [
+        {
+          "name": "Time"
+        },
+        {
+          "name": "ECs only"
+        },
+        {
+          "name": "ECs + Macs"
+        }
+      ],
+      "n_columns": 14,
+      "header_row": 3,
+      "n_rows": 996,
+      "evidence": "headers"
+    },
+    {
+      "file_id": "41586_2024_8002_MOESM6_ESM.xlsx",
+      "locator": "ED Fig. 11i",
+      "content_type": "other",
+      "description": "Source data for Extended Data Fig. 11i: timecourse quantification for endothelial-cell-only and co-culture conditions.",
+      "columns": [
+        {
+          "name": "Time"
+        },
+        {
+          "name": "ECs only"
+        },
+        {
+          "name": "ECs + Macs"
+        }
+      ],
+      "n_columns": 14,
+      "header_row": 3,
+      "n_rows": 996,
+      "evidence": "headers"
+    }
+  ],
+  "indexed_at": "2026-08-25T14:09:05+00:00"
+}

--- a/projects/test_projects/fetal_skin_atlas/supplements/papers/10.1038_s41586-024-08002-x/manifest.json
+++ b/projects/test_projects/fetal_skin_atlas/supplements/papers/10.1038_s41586-024-08002-x/manifest.json
@@ -2,8 +2,7 @@
   "manifest_version": 1,
   "paper": {
     "doi": "10.1038/s41586-024-08002-x",
-    "role": "atlas",
-    "access": "open"
+    "pmcid": "PMC11578897"
   },
   "files": [
     {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,9 @@ dev-dependencies = [
     "sphinx-autodoc-typehints>=1.25.0",
     "myst-parser>=2.0.0",
     "pre-commit>=3.7.0",
+    # Optional at runtime ([supplements] extra), required for the test suite so
+    # the spreadsheet tests run in CI rather than silently skipping.
+    "openpyxl>=3.1",
 ]
 
 [tool.pytest.ini_options]

--- a/src/atlas_chat/atlas_chat/cli_supplements.py
+++ b/src/atlas_chat/atlas_chat/cli_supplements.py
@@ -1,0 +1,23 @@
+"""CLI for the supplement store.
+
+Thin entry point so the store is usable without a Claude Code session:
+
+.. code-block:: bash
+
+    python -m atlas_chat.cli_supplements inventory --jats paper.jats.xml
+    python -m atlas_chat.cli_supplements adopt --store S --doi D --incoming DIR
+    python -m atlas_chat.cli_supplements unpack --store S --doi D
+    python -m atlas_chat.cli_supplements outline --file tables.xlsx
+    python -m atlas_chat.cli_supplements slice --file tables.xlsx --locator "Table 12"
+
+The implementation lives in :mod:`atlas_chat.services.supplement_store`.
+"""
+
+from __future__ import annotations
+
+from atlas_chat.services.supplement_store import build_parser, main
+
+__all__ = ["build_parser", "main"]
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/atlas_chat/atlas_chat/schemas/supplement_manifest.schema.json
+++ b/src/atlas_chat/atlas_chat/schemas/supplement_manifest.schema.json
@@ -1,0 +1,329 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "SupplementManifest",
+  "description": "What supplementary material exists for ONE paper, where it is on disk, and what each part of it contains. A fetch cache plus a content index: the fetch half records how each file arrived (including by hand), the index half names the tables worth reading and their columns, so a later reader can go straight to a sheet instead of re-scanning heterogeneous files. Not curated config \u2014 never merge this into cas.json.",
+  "type": "object",
+  "properties": {
+    "manifest_version": {
+      "type": "integer",
+      "description": "Bumped when the manifest shape changes in a way that invalidates existing stores.",
+      "const": 1
+    },
+    "paper": {
+      "$ref": "#/$defs/Paper"
+    },
+    "indexed_at": {
+      "type": "string",
+      "description": "ISO-8601 UTC timestamp of the last time the content index below was (re)written.",
+      "format": "date-time"
+    },
+    "files": {
+      "type": "array",
+      "description": "Every supplementary file known for this paper, whether or not it was retrieved. One entry per file as the publisher packages it; members of an archive are listed in `members`, not here.",
+      "items": {
+        "$ref": "#/$defs/SupplementFile"
+      }
+    },
+    "tables": {
+      "type": "array",
+      "description": "The content index: tables worth reading, wherever they live (a sheet in a workbook, a CSV inside a zip, a table in a document). This is what downstream steps consult to decide what to open.",
+      "items": {
+        "$ref": "#/$defs/TablePointer"
+      }
+    },
+    "gaps": {
+      "type": "array",
+      "description": "Things the indexer could not do, stated explicitly so an absence is never mistaken for a negative result. Read this before concluding a paper has no marker tables.",
+      "items": {
+        "$ref": "#/$defs/Gap"
+      }
+    }
+  },
+  "required": [
+    "manifest_version",
+    "paper",
+    "files"
+  ],
+  "additionalProperties": false,
+  "$defs": {
+    "Paper": {
+      "type": "object",
+      "description": "Which paper this manifest belongs to. `doi` is the store key.",
+      "properties": {
+        "doi": {
+          "type": "string",
+          "pattern": "^10\\.\\d{4,}(\\.\\d+)?/.+"
+        },
+        "title": {
+          "type": "string"
+        },
+        "pmcid": {
+          "type": "string"
+        },
+        "pmid": {
+          "type": "string"
+        },
+        "role": {
+          "type": "string",
+          "description": "What this paper is relative to the corpus. Mirrors evidence_summary.schema.json's `role`.",
+          "enum": [
+            "atlas",
+            "subatlas",
+            "external"
+          ]
+        },
+        "access": {
+          "type": "string",
+          "description": "Whether the supplements are reachable programmatically. 'closed' means retrieval is out of scope and files must be supplied by hand.",
+          "enum": [
+            "open",
+            "closed",
+            "unknown"
+          ]
+        }
+      },
+      "required": [
+        "doi"
+      ],
+      "additionalProperties": false
+    },
+    "SupplementFile": {
+      "type": "object",
+      "description": "One supplementary file as the publisher packages it, plus how (or whether) we got hold of it.",
+      "properties": {
+        "file_id": {
+          "type": "string",
+          "description": "Stable id for cross-referencing from TablePointer. The publisher's filename, e.g. '41586_2024_8002_MOESM4_ESM.zip'."
+        },
+        "label": {
+          "type": "string",
+          "description": "The publisher's label, verbatim, e.g. 'Supplementary Tables'. From JATS <supplementary-material><label>."
+        },
+        "caption": {
+          "type": "string",
+          "description": "The publisher's caption, verbatim, e.g. 'Supplementary Tables 1-40.'. From JATS <caption>. Often the cheapest description of the contents there is \u2014 read this before opening anything."
+        },
+        "media_type": {
+          "type": "string",
+          "description": "Extension-derived kind: xlsx, csv, tsv, docx, pdf, zip, txt, video, image, other."
+        },
+        "size_bytes": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "path": {
+          "type": "string",
+          "description": "Path to the file on disk, relative to the store root. Absent when status is not 'present'."
+        },
+        "retrieval": {
+          "$ref": "#/$defs/Retrieval"
+        },
+        "status": {
+          "type": "string",
+          "description": "'present' = on disk. 'listed' = we know it exists but have not fetched it. 'skipped' = deliberately not fetched (see retrieval.note \u2014 usually a size cap or a video). 'unavailable' = no route exists (closed access, needs a manual drop). 'failed' = a route was tried and errored.",
+          "enum": [
+            "present",
+            "listed",
+            "skipped",
+            "unavailable",
+            "failed"
+          ]
+        },
+        "members": {
+          "type": "array",
+          "description": "For archives: the unpacked member tree. Paths are relative to the archive root and are what TablePointer.member_path refers to.",
+          "items": {
+            "$ref": "#/$defs/ArchiveMember"
+          }
+        }
+      },
+      "required": [
+        "file_id",
+        "status"
+      ],
+      "additionalProperties": false
+    },
+    "Retrieval": {
+      "type": "object",
+      "description": "How this file arrived. A file dropped in by hand is a first-class route, not a failure \u2014 it is the only route for closed-access papers.",
+      "properties": {
+        "route": {
+          "type": "string",
+          "description": "'jats_listing' = known from the article XML but bytes not fetched by this route. 'publisher_direct' = fetched from the publisher's static host. 'europepmc_bundle' = from Europe PMC's supplementaryFiles zip. 'manual' = supplied by a user. 'none' = no route available.",
+          "enum": [
+            "jats_listing",
+            "publisher_direct",
+            "europepmc_bundle",
+            "manual",
+            "none"
+          ]
+        },
+        "url": {
+          "type": "string"
+        },
+        "retrieved_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "sha256": {
+          "type": "string",
+          "description": "Digest of the file as stored, so a re-index can tell whether the bytes changed.",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "note": {
+          "type": "string",
+          "description": "Why a route was skipped or how it failed. Free text."
+        }
+      },
+      "required": [
+        "route"
+      ],
+      "additionalProperties": false
+    },
+    "ArchiveMember": {
+      "type": "object",
+      "properties": {
+        "member_path": {
+          "type": "string"
+        },
+        "media_type": {
+          "type": "string"
+        },
+        "size_bytes": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "path": {
+          "type": "string",
+          "description": "Where the member was unpacked to, relative to the store root. Absent if it was not unpacked."
+        },
+        "extracted": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "member_path"
+      ],
+      "additionalProperties": false
+    },
+    "TablePointer": {
+      "type": "object",
+      "description": "A table worth reading, located precisely enough to slice without searching. Describes the table and its columns; it deliberately does NOT enumerate which cell types appear (that is the reader's job at query time).",
+      "properties": {
+        "file_id": {
+          "type": "string",
+          "description": "The SupplementFile.file_id this table lives in."
+        },
+        "member_path": {
+          "type": "string",
+          "description": "Path within the archive, when file_id names an archive."
+        },
+        "locator": {
+          "type": "string",
+          "description": "Where in the file: a worksheet name for xlsx, a page number for pdf, a heading for docx. Omit for a single-table file such as a CSV."
+        },
+        "table_label": {
+          "type": "string",
+          "description": "The authors' own name for it, verbatim where one exists, e.g. 'Supplementary Table 12'."
+        },
+        "content_type": {
+          "type": "string",
+          "description": "What kind of table this is. 'legend' is the manifest/contents sheet that describes the others \u2014 worth reading first.",
+          "enum": [
+            "deg_results",
+            "marker_list",
+            "cluster_annotation",
+            "cell_metadata",
+            "sample_metadata",
+            "legend",
+            "other"
+          ]
+        },
+        "description": {
+          "type": "string",
+          "description": "What the table contains and what a reader would use it for. One or two sentences, grounded in the caption, the legend sheet, or the headers actually seen."
+        },
+        "columns": {
+          "type": "array",
+          "description": "The table's columns in order, each with what it holds. The point of the manifest: a reader picks a table by its columns without opening it. For a very wide table (one column per cell state, say) this may be a prefix \u2014 compare its length against n_columns.",
+          "items": {
+            "$ref": "#/$defs/Column"
+          }
+        },
+        "n_columns": {
+          "type": "integer",
+          "description": "Total columns in the table. Greater than the length of `columns` when that list is a prefix of a very wide table.",
+          "minimum": 0
+        },
+        "header_row": {
+          "type": "integer",
+          "description": "0-based index of the header row, so a reader can slice correctly. Publisher tables often carry title rows above the header.",
+          "minimum": 0
+        },
+        "n_rows": {
+          "type": "integer",
+          "description": "Data rows excluding the header, where known.",
+          "minimum": 0
+        },
+        "evidence": {
+          "type": "string",
+          "description": "What this characterisation was based on: 'caption', 'legend_sheet', 'headers', or 'rows_read'. Distinguishes a table described from its caption from one actually opened.",
+          "enum": [
+            "caption",
+            "legend_sheet",
+            "headers",
+            "rows_read"
+          ]
+        }
+      },
+      "required": [
+        "file_id",
+        "content_type",
+        "description",
+        "evidence"
+      ],
+      "additionalProperties": false
+    },
+    "Column": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The column header verbatim."
+        },
+        "description": {
+          "type": "string",
+          "description": "What the column holds, where the header alone is not self-explanatory."
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "additionalProperties": false
+    },
+    "Gap": {
+      "type": "object",
+      "description": "Something the indexer could not do. Keeps 'we did not look' distinguishable from 'there is nothing there'.",
+      "properties": {
+        "file_id": {
+          "type": "string"
+        },
+        "member_path": {
+          "type": "string"
+        },
+        "reason": {
+          "type": "string",
+          "description": "Why it could not be characterised, e.g. 'archive member exceeds size cap', 'scanned PDF, no extractable text', 'no route to fetch (closed access)'."
+        },
+        "action": {
+          "type": "string",
+          "description": "What a human could do about it, e.g. 'drop the file into incoming/'. Omit if nothing would help."
+        }
+      },
+      "required": [
+        "reason"
+      ],
+      "additionalProperties": false
+    }
+  }
+}

--- a/src/atlas_chat/atlas_chat/schemas/supplement_manifest.schema.json
+++ b/src/atlas_chat/atlas_chat/schemas/supplement_manifest.schema.json
@@ -48,38 +48,15 @@
   "$defs": {
     "Paper": {
       "type": "object",
-      "description": "Which paper this manifest belongs to. `doi` is the store key.",
+      "description": "Which paper this manifest belongs to. `doi` is the store key. Deliberately minimal: role, title, organism and the rest belong to the CAS+ document that defines the corpus, and duplicating them into a fetch cache only creates something that can drift out of date.",
       "properties": {
         "doi": {
           "type": "string",
           "pattern": "^10\\.\\d{4,}(\\.\\d+)?/.+"
         },
-        "title": {
-          "type": "string"
-        },
         "pmcid": {
-          "type": "string"
-        },
-        "pmid": {
-          "type": "string"
-        },
-        "role": {
           "type": "string",
-          "description": "What this paper is relative to the corpus. Mirrors evidence_summary.schema.json's `role`.",
-          "enum": [
-            "atlas",
-            "subatlas",
-            "external"
-          ]
-        },
-        "access": {
-          "type": "string",
-          "description": "Whether the supplements are reachable programmatically. 'closed' means retrieval is out of scope and files must be supplied by hand.",
-          "enum": [
-            "open",
-            "closed",
-            "unknown"
-          ]
+          "description": "Cached because the fetch routes are keyed on it and resolving DOI -> PMCID costs a network call. A fetch detail, not curated metadata."
         }
       },
       "required": [

--- a/src/atlas_chat/atlas_chat/services/supplement_store.py
+++ b/src/atlas_chat/atlas_chat/services/supplement_store.py
@@ -93,6 +93,12 @@ OUTLINE_MAX_COLS = 40
 #: hold whole paragraphs of methods text.
 OUTLINE_CELL_CHARS = 200
 
+#: Rows always read when looking for the header, even when the caller asked for
+#: fewer sample rows. Header quality must not depend on how much the caller
+#: wanted to *see*: a table whose header sits on row 2 behind two title rows
+#: would otherwise be mis-detected by `--rows 2`.
+HEADER_SCAN_ROWS = 6
+
 _MEDIA_TYPES = {
     ".xlsx": "xlsx",
     ".xls": "xlsx",
@@ -271,8 +277,8 @@ def adopt_manual_files(
         incoming: Directory holding the dropped files.
         listed: Optional inventory from :func:`inventory_from_jats`, so labels
             and captions carry over to files matched by name.
-        paper: Optional extra ``paper`` fields for the manifest (title, pmcid,
-            role, access).
+        paper: Optional extra ``paper`` fields for the manifest. Only ``pmcid``
+            is carried; the corpus's own metadata lives in its CAS+ document.
 
     Returns:
         The manifest dict, already written to disk.
@@ -521,10 +527,17 @@ def outline_file(
         sample_rows: Rows to show per table.
         max_cols: Columns to show per row.
 
+    No limit here is silent. Each table reports its true ``n_rows`` and
+    ``n_cols`` alongside ``truncated_rows`` / ``truncated_cols``, so a caller
+    can always tell the difference between "this is the whole table" and "this
+    is the first few rows of it" — and knows to reach for :func:`read_slice`
+    rather than assuming it has seen everything.
+
     Returns:
         ``{"path", "media_type", "tables": [...]}`` where each table carries
-        ``locator``, ``n_rows``, ``n_cols``, ``header_row_guess`` and ``rows``.
-        Unsupported kinds return an empty ``tables`` list and a ``note``.
+        ``locator``, ``n_rows``, ``n_cols``, ``truncated_rows``,
+        ``truncated_cols``, ``header_row_guess`` and ``rows``. Unsupported kinds
+        return an empty ``tables`` list and a ``note``.
     """
     path = Path(path)
     if not path.is_file():
@@ -630,17 +643,20 @@ def _outline_xlsx(path: Path, sample_rows: int, max_cols: int) -> list[dict[str,
     workbook = load_workbook(path, read_only=True, data_only=True)
     tables: list[dict[str, Any]] = []
     try:
+        scan_rows = max(sample_rows, HEADER_SCAN_ROWS)
         for sheet in workbook.worksheets:
-            rows: list[list[str]] = []
-            for row in sheet.iter_rows(max_row=sample_rows, max_col=max_cols, values_only=True):
-                rows.append(_trim([_clip(cell) for cell in row]))
+            scanned: list[list[str]] = []
+            for row in sheet.iter_rows(max_row=scan_rows, max_col=max_cols, values_only=True):
+                scanned.append(_trim([_clip(cell) for cell in row]))
+            rows = scanned[:sample_rows]
             tables.append(
                 {
                     "locator": sheet.title,
                     "n_rows": sheet.max_row,
                     "n_cols": sheet.max_column,
                     "truncated_cols": bool(sheet.max_column and sheet.max_column > max_cols),
-                    "header_row_guess": _header_row_guess(rows),
+                    "truncated_rows": bool(sheet.max_row and sheet.max_row > len(rows)),
+                    "header_row_guess": _header_row_guess(scanned),
                     "rows": rows,
                 }
             )
@@ -664,14 +680,16 @@ def _outline_delimited(
     text = path.read_text(encoding="utf-8", errors="replace")
     delimiter = _sniff_delimiter(text[:8192], kind)
     reader = csv.reader(io.StringIO(text), delimiter=delimiter)
-    rows: list[list[str]] = []
+    scan_rows = max(sample_rows, HEADER_SCAN_ROWS)
+    scanned: list[list[str]] = []
     total = 0
     widest = 0
     for index, row in enumerate(reader):
         total = index + 1
         widest = max(widest, len(row))
-        if index < sample_rows:
-            rows.append(_trim([_clip(cell) for cell in row[:max_cols]]))
+        if index < scan_rows:
+            scanned.append(_trim([_clip(cell) for cell in row[:max_cols]]))
+    rows = scanned[:sample_rows]
     return [
         {
             "locator": path.name,
@@ -679,7 +697,8 @@ def _outline_delimited(
             "n_rows": total,
             "n_cols": widest,
             "truncated_cols": widest > max_cols,
-            "header_row_guess": _header_row_guess(rows),
+            "truncated_rows": total > len(rows),
+            "header_row_guess": _header_row_guess(scanned),
             "rows": rows,
         }
     ]
@@ -703,22 +722,25 @@ def _outline_docx(path: Path, sample_rows: int, max_cols: int) -> list[dict[str,
     ns = "{http://schemas.openxmlformats.org/wordprocessingml/2006/main}"
     root = ET.fromstring(xml)
     tables: list[dict[str, Any]] = []
+    scan_rows = max(sample_rows, HEADER_SCAN_ROWS)
     for index, table in enumerate(root.iter(f"{ns}tbl"), start=1):
-        rows: list[list[str]] = []
+        scanned: list[list[str]] = []
         all_rows = list(table.iter(f"{ns}tr"))
         widest = 0
         for row_index, row in enumerate(all_rows):
             cells = [_element_text(cell) for cell in row.iter(f"{ns}tc")]
             widest = max(widest, len(cells))
-            if row_index < sample_rows:
-                rows.append(_trim([_clip(cell) for cell in cells[:max_cols]]))
+            if row_index < scan_rows:
+                scanned.append(_trim([_clip(cell) for cell in cells[:max_cols]]))
+        rows = scanned[:sample_rows]
         tables.append(
             {
                 "locator": f"table {index}",
                 "n_rows": len(all_rows),
                 "n_cols": widest,
                 "truncated_cols": widest > max_cols,
-                "header_row_guess": _header_row_guess(rows),
+                "truncated_rows": len(all_rows) > len(rows),
+                "header_row_guess": _header_row_guess(scanned),
                 "rows": rows,
             }
         )
@@ -1016,6 +1038,8 @@ def corpus_papers(cas: dict[str, Any]) -> list[dict[str, Any]]:
 
     Returns:
         Dicts with ``doi``, ``role`` and (where known) ``title``, ``pmcid``.
+        This describes the corpus, not a manifest: ``role`` tells a caller which
+        papers to fetch for, and is deliberately not written into the store.
     """
     source = cas.get("source", {})
     papers: list[dict[str, Any]] = []
@@ -1051,10 +1075,8 @@ def _cmd_adopt(args: argparse.Namespace) -> int:
     if args.jats:
         listed = inventory_from_jats(Path(args.jats))
     paper: dict[str, Any] = {}
-    if args.role:
-        paper["role"] = args.role
-    if args.access:
-        paper["access"] = args.access
+    if args.pmcid:
+        paper["pmcid"] = args.pmcid
     manifest = adopt_manual_files(
         store_root=Path(args.store),
         doi=args.doi,
@@ -1171,8 +1193,7 @@ def build_parser() -> argparse.ArgumentParser:
     add_store(adopt)
     adopt.add_argument("--incoming", required=True, help="directory holding the dropped files")
     adopt.add_argument("--jats", help="JATS XML, to carry over labels and captions")
-    adopt.add_argument("--role", choices=["atlas", "subatlas", "external"])
-    adopt.add_argument("--access", choices=["open", "closed", "unknown"])
+    adopt.add_argument("--pmcid", help="cached for the fetch routes")
     adopt.set_defaults(func=_cmd_adopt)
 
     unpack = sub.add_parser("unpack", help="expand archives and record member trees")

--- a/src/atlas_chat/atlas_chat/services/supplement_store.py
+++ b/src/atlas_chat/atlas_chat/services/supplement_store.py
@@ -1,0 +1,1240 @@
+"""On-disk store of supplementary material for a set of papers.
+
+Supplementary material carries content a cell type report often cannot be
+written without — DEG tables, cluster-to-name mappings, the marker lists name
+resolution depends on. This module keeps that material on disk, one directory
+per paper, alongside a manifest saying what each file and table contains
+(schema: ``supplement_manifest.schema.json``).
+
+The division of labour is deliberate. Everything here is mechanical: list what
+exists, fetch bytes, unpack archives, describe the shape of a spreadsheet,
+slice a region out of one. Deciding *what a table is for* needs a model to read
+it, and that happens in the ``index-supplements`` skill, which drives the
+functions below and writes the manifest's ``tables`` section. Nothing in this
+module calls an LLM.
+
+Two operations matter for keeping large files out of an agent's context:
+
+``outline``
+    A compact description of a file's shape — worksheet names, dimensions, the
+    detected header row, a few sample rows. Bounded output regardless of how
+    big the file is.
+
+``slice``
+    A targeted read of one region, so a reader that has decided which sheet it
+    wants never loads the rest.
+
+Nothing here knows about atlas-reporter's directory layout: the store root is
+an argument, and paper identity comes from a CAS+ document or an explicit DOI.
+
+.. code-block:: python
+
+    from pathlib import Path
+    from atlas_chat.services.supplement_store import (
+        inventory_from_jats, adopt_manual_files, outline_file, read_slice,
+    )
+
+    files = inventory_from_jats(Path("paper.jats.xml"))
+    manifest = adopt_manual_files(
+        store_root=Path("supplements"),
+        doi="10.1038/s41586-024-08002-x",
+        incoming=Path("incoming/10.1038_s41586-024-08002-x"),
+        listed=files,
+    )
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import io
+import json
+import logging
+import re
+import shutil
+import sys
+import tarfile
+import xml.etree.ElementTree as ET
+import zipfile
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from atlas_chat.services.local_snippet_index import paper_slug
+
+logger = logging.getLogger(__name__)
+
+MANIFEST_VERSION = 1
+
+#: Non-tabular members above this are recorded but not unpacked. Supplementary
+#: videos and image stacks routinely run to hundreds of MB and never carry
+#: table content.
+DEFAULT_SIZE_CAP_BYTES = 80 * 1024 * 1024
+
+#: Tabular members get their own, far higher ceiling. A DEG table for a whole
+#: atlas legitimately runs to ~100 MB — in the prenatal skin atlas the largest
+#: supplementary table is also the one a marker query most needs, so a general
+#: size cap would exclude exactly the wrong file. ``outline`` reads workbooks
+#: in openpyxl's read-only mode, so a large table costs disk, not context.
+DEFAULT_TABULAR_SIZE_CAP_BYTES = 512 * 1024 * 1024
+
+#: Media kinds that hold tables, and so get the tabular ceiling above.
+TABULAR_MEDIA_TYPES = frozenset({"xlsx", "csv", "tsv", "txt", "docx"})
+
+#: Rows shown per sheet by ``outline``. Enough to see what a table holds and to
+#: spot a title row above the header, without pulling the table into context.
+OUTLINE_SAMPLE_ROWS = 8
+
+#: Columns shown per row by ``outline``. Cell-metadata tables can be very wide.
+OUTLINE_MAX_COLS = 40
+
+#: Truncation applied to every cell ``outline`` prints. Some supplement cells
+#: hold whole paragraphs of methods text.
+OUTLINE_CELL_CHARS = 200
+
+_MEDIA_TYPES = {
+    ".xlsx": "xlsx",
+    ".xls": "xlsx",
+    ".xlsm": "xlsx",
+    ".csv": "csv",
+    ".tsv": "tsv",
+    ".txt": "txt",
+    ".docx": "docx",
+    ".doc": "docx",
+    ".pdf": "pdf",
+    ".zip": "zip",
+    ".gz": "zip",
+    ".tgz": "zip",
+    ".tar": "zip",
+    ".mp4": "video",
+    ".mov": "video",
+    ".avi": "video",
+    ".png": "image",
+    ".jpg": "image",
+    ".jpeg": "image",
+    ".tif": "image",
+    ".tiff": "image",
+}
+
+_ARCHIVE_SUFFIXES = {".zip", ".tar", ".gz", ".tgz"}
+
+
+class SupplementStoreError(RuntimeError):
+    """Raised for unrecoverable store problems (bad paths, unreadable manifest)."""
+
+
+# ------------------------------------------------------------------
+# Store layout
+# ------------------------------------------------------------------
+
+
+def paper_dir(store_root: Path, doi: str) -> Path:
+    """Directory holding one paper's supplements, named by DOI slug."""
+    return Path(store_root) / "papers" / paper_slug(doi)
+
+
+def manifest_path(store_root: Path, doi: str) -> Path:
+    """Path to a paper's manifest JSON."""
+    return paper_dir(store_root, doi) / "manifest.json"
+
+
+def files_dir(store_root: Path, doi: str) -> Path:
+    """Directory holding the paper's supplement bytes (git-ignored)."""
+    return paper_dir(store_root, doi) / "files"
+
+
+def media_type(name: str) -> str:
+    """Extension-derived kind, matching the manifest's ``media_type`` vocabulary."""
+    return _MEDIA_TYPES.get(Path(name).suffix.lower(), "other")
+
+
+def _is_archive(name: str) -> bool:
+    return Path(name).suffix.lower() in _ARCHIVE_SUFFIXES
+
+
+def _now() -> str:
+    return datetime.now(UTC).isoformat(timespec="seconds")
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for block in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def _rel(store_root: Path, path: Path) -> str:
+    """Path relative to the store root, so a manifest survives being moved."""
+    try:
+        return str(path.resolve().relative_to(Path(store_root).resolve()))
+    except ValueError:
+        return str(path)
+
+
+# ------------------------------------------------------------------
+# Inventory: what supplements does this paper have?
+# ------------------------------------------------------------------
+
+_JATS_NS = {"xlink": "http://www.w3.org/1999/xlink"}
+
+
+def _element_text(element: ET.Element | None) -> str:
+    if element is None:
+        return ""
+    return re.sub(r"\s+", " ", "".join(element.itertext())).strip()
+
+
+def inventory_from_jats(jats_path: Path) -> list[dict[str, Any]]:
+    """List a paper's supplementary files from its JATS XML.
+
+    The article XML is the cheapest source of the file list *and* the only place
+    the publisher's labels and captions live. A caption like
+    "Supplementary Tables 1-40." often describes the contents better than
+    anything recoverable from the bytes, so it is worth reading before opening
+    a single file.
+
+    Args:
+        jats_path: Path to the article's JATS XML (e.g. Europe PMC fullTextXML).
+
+    Returns:
+        One dict per supplementary file with ``file_id``, ``label``,
+        ``caption``, ``media_type`` and ``status: "listed"`` — the ``files``
+        entries of a manifest, before anything has been fetched.
+    """
+    root = ET.parse(jats_path).getroot()
+    out: list[dict[str, Any]] = []
+    seen: set[str] = set()
+
+    for element in root.iter():
+        if not element.tag.endswith("supplementary-material"):
+            continue
+        href = element.get("{http://www.w3.org/1999/xlink}href") or element.get("href")
+        if not href:
+            # Some publishers attach the filename to a nested <media>.
+            for child in element.iter():
+                if child.tag.endswith("media"):
+                    href = child.get("{http://www.w3.org/1999/xlink}href") or child.get("href")
+                    if href:
+                        break
+        if not href or href in seen:
+            continue
+        seen.add(href)
+
+        label = ""
+        caption = ""
+        for child in element.iter():
+            if child.tag.endswith("label") and not label:
+                label = _element_text(child)
+            elif child.tag.endswith("caption") and not caption:
+                caption = _element_text(child)
+
+        entry: dict[str, Any] = {
+            "file_id": Path(href).name,
+            "media_type": media_type(href),
+            "status": "listed",
+            "retrieval": {"route": "jats_listing"},
+        }
+        if label:
+            entry["label"] = label
+        if caption:
+            entry["caption"] = caption
+        out.append(entry)
+
+    logger.info("JATS listed %d supplementary files in %s", len(out), jats_path)
+    return out
+
+
+# ------------------------------------------------------------------
+# Getting files into the store
+# ------------------------------------------------------------------
+
+
+def adopt_manual_files(
+    store_root: Path,
+    doi: str,
+    incoming: Path,
+    listed: list[dict[str, Any]] | None = None,
+    paper: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Take files a user dropped in by hand into the store.
+
+    This is the only route available for closed-access papers, so a manually
+    supplied file is recorded as a first-class retrieval route rather than as a
+    fallback. Files are copied (not moved), so the drop directory stays
+    reusable.
+
+    Args:
+        store_root: Store root; the paper's directory is created under it.
+        doi: DOI of the paper the files belong to.
+        incoming: Directory holding the dropped files.
+        listed: Optional inventory from :func:`inventory_from_jats`, so labels
+            and captions carry over to files matched by name.
+        paper: Optional extra ``paper`` fields for the manifest (title, pmcid,
+            role, access).
+
+    Returns:
+        The manifest dict, already written to disk.
+    """
+    incoming = Path(incoming)
+    if not incoming.is_dir():
+        raise SupplementStoreError(f"incoming directory does not exist: {incoming}")
+
+    target = files_dir(store_root, doi)
+    target.mkdir(parents=True, exist_ok=True)
+
+    by_id = {entry["file_id"]: dict(entry) for entry in (listed or [])}
+
+    for src in sorted(incoming.iterdir()):
+        if not src.is_file() or src.name.startswith(".") or src.name == "README.md":
+            continue
+        dest = target / src.name
+        if not dest.exists() or dest.stat().st_size != src.stat().st_size:
+            shutil.copy2(src, dest)
+        entry = by_id.setdefault(src.name, {"file_id": src.name})
+        entry.update(
+            {
+                "media_type": media_type(src.name),
+                "size_bytes": dest.stat().st_size,
+                "path": _rel(store_root, dest),
+                "status": "present",
+                "retrieval": {
+                    "route": "manual",
+                    "retrieved_at": _now(),
+                    "sha256": _sha256(dest),
+                    "note": f"copied from {incoming}",
+                },
+            }
+        )
+        logger.info("adopted %s (%d bytes)", src.name, entry["size_bytes"])
+
+    manifest = load_manifest(store_root, doi) or {
+        "manifest_version": MANIFEST_VERSION,
+        "paper": {"doi": doi},
+        "files": [],
+    }
+    manifest["paper"].update(paper or {})
+    manifest["files"] = _merge_files(manifest.get("files", []), list(by_id.values()))
+    write_manifest(store_root, doi, manifest)
+    return manifest
+
+
+def _merge_files(
+    existing: list[dict[str, Any]], incoming: list[dict[str, Any]]
+) -> list[dict[str, Any]]:
+    """Merge file entries by ``file_id``; a present file never regresses to listed."""
+    merged: dict[str, dict[str, Any]] = {entry["file_id"]: dict(entry) for entry in existing}
+    for entry in incoming:
+        current = merged.get(entry["file_id"])
+        if current is None:
+            merged[entry["file_id"]] = dict(entry)
+            continue
+        if current.get("status") == "present" and entry.get("status") == "listed":
+            # Keep the bytes we have; take any label/caption the listing adds.
+            for key in ("label", "caption"):
+                if key in entry and key not in current:
+                    current[key] = entry[key]
+            continue
+        current.update(entry)
+    return list(merged.values())
+
+
+# ------------------------------------------------------------------
+# Unpacking archives
+# ------------------------------------------------------------------
+
+
+def unpack_archives(
+    store_root: Path,
+    doi: str,
+    size_cap: int = DEFAULT_SIZE_CAP_BYTES,
+    tabular_size_cap: int = DEFAULT_TABULAR_SIZE_CAP_BYTES,
+) -> dict[str, Any]:
+    """Expand archive files in the store and record their member trees.
+
+    Nature-style supplements arrive as one zip holding dozens of workbooks, so
+    the members are the interesting unit, not the archive. Oversized members and
+    members that are themselves archives are listed but not expanded — a nested
+    archive is recorded as a gap rather than recursed into blindly.
+
+    Args:
+        store_root: Store root.
+        doi: Paper whose archives to expand.
+        size_cap: Ceiling for non-tabular members (video, images).
+        tabular_size_cap: Ceiling for spreadsheets and documents, which is much
+            higher because a large table is usually the one worth having.
+
+    Returns:
+        The updated manifest, written to disk.
+    """
+    manifest = load_manifest(store_root, doi)
+    if manifest is None:
+        raise SupplementStoreError(f"no manifest for {doi} in {store_root}")
+
+    # Gaps this run produces replace the previous run's gaps for the same
+    # archives — otherwise raising a cap leaves the old "above the cap" gap
+    # behind and the manifest reports a problem that no longer exists.
+    archives = {
+        entry["file_id"]
+        for entry in manifest.get("files", [])
+        if entry.get("status") == "present" and _is_archive(entry["file_id"])
+    }
+    gaps: list[dict[str, Any]] = [
+        gap for gap in manifest.get("gaps", []) if gap.get("file_id") not in archives
+    ]
+
+    for entry in manifest.get("files", []):
+        if entry.get("status") != "present" or not _is_archive(entry["file_id"]):
+            continue
+        archive = Path(store_root) / entry["path"]
+        out_dir = archive.parent / f"{archive.stem}__unpacked"
+        members, member_gaps = _extract(archive, out_dir, store_root, size_cap, tabular_size_cap)
+        entry["members"] = members
+        gaps.extend(member_gaps)
+        logger.info("unpacked %s → %d members", entry["file_id"], len(members))
+
+    manifest["gaps"] = _dedupe_gaps(gaps)
+    write_manifest(store_root, doi, manifest)
+    return manifest
+
+
+def _extract(
+    archive: Path,
+    out_dir: Path,
+    store_root: Path,
+    size_cap: int,
+    tabular_size_cap: int,
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    """Extract one archive; return (member entries, gaps)."""
+    members: list[dict[str, Any]] = []
+    gaps: list[dict[str, Any]] = []
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    for name, size in _archive_listing(archive):
+        if name.endswith("/"):
+            continue
+        kind = media_type(name)
+        entry: dict[str, Any] = {
+            "member_path": name,
+            "media_type": kind,
+            "size_bytes": size,
+            "extracted": False,
+        }
+        cap = tabular_size_cap if kind in TABULAR_MEDIA_TYPES else size_cap
+        cap_flag = "--tabular-size-cap" if kind in TABULAR_MEDIA_TYPES else "--size-cap"
+        if size > cap:
+            gaps.append(
+                {
+                    "file_id": archive.name,
+                    "member_path": name,
+                    "reason": f"member is {size} bytes, above the {cap}-byte cap; not unpacked",
+                    "action": f"re-run with a higher {cap_flag} if this file is needed",
+                }
+            )
+        elif _is_archive(name):
+            gaps.append(
+                {
+                    "file_id": archive.name,
+                    "member_path": name,
+                    "reason": "member is itself an archive; nested archives are not expanded",
+                    "action": "extract it by hand into incoming/ and re-run adopt",
+                }
+            )
+        else:
+            dest = _safe_extract_one(archive, name, out_dir)
+            if dest is None:
+                gaps.append(
+                    {
+                        "file_id": archive.name,
+                        "member_path": name,
+                        "reason": "member path escapes the archive root; refused",
+                    }
+                )
+            else:
+                entry["extracted"] = True
+                entry["path"] = _rel(store_root, dest)
+        members.append(entry)
+
+    return members, gaps
+
+
+def _archive_listing(archive: Path) -> list[tuple[str, int]]:
+    if zipfile.is_zipfile(archive):
+        with zipfile.ZipFile(archive) as zf:
+            return [(info.filename, info.file_size) for info in zf.infolist()]
+    if tarfile.is_tarfile(archive):
+        with tarfile.open(archive) as tf:
+            return [(m.name, m.size) for m in tf.getmembers() if m.isfile()]
+    raise SupplementStoreError(f"not a zip or tar archive: {archive}")
+
+
+def _safe_extract_one(archive: Path, name: str, out_dir: Path) -> Path | None:
+    """Extract one member, refusing paths that escape ``out_dir``."""
+    dest = (out_dir / name).resolve()
+    if not str(dest).startswith(str(out_dir.resolve())):
+        return None
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    if zipfile.is_zipfile(archive):
+        with zipfile.ZipFile(archive) as zf, zf.open(name) as src, dest.open("wb") as out:
+            shutil.copyfileobj(src, out)
+    else:
+        with tarfile.open(archive) as tf:
+            handle = tf.extractfile(name)
+            if handle is None:
+                return None
+            with handle, dest.open("wb") as out:
+                shutil.copyfileobj(handle, out)
+    return dest
+
+
+def _dedupe_gaps(gaps: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    seen: set[tuple[str, str, str]] = set()
+    out: list[dict[str, Any]] = []
+    for gap in gaps:
+        key = (gap.get("file_id", ""), gap.get("member_path", ""), gap["reason"])
+        if key not in seen:
+            seen.add(key)
+            out.append(gap)
+    return out
+
+
+# ------------------------------------------------------------------
+# Outline: the shape of a file, bounded
+# ------------------------------------------------------------------
+
+
+def outline_file(
+    path: Path,
+    sample_rows: int = OUTLINE_SAMPLE_ROWS,
+    max_cols: int = OUTLINE_MAX_COLS,
+) -> dict[str, Any]:
+    """Describe a file's shape without loading it into context.
+
+    Output size is bounded by ``sample_rows`` and ``max_cols`` however large
+    the file is. For a workbook this is one block per worksheet; the reader can
+    usually tell from the sheet names and the first rows which sheet is the
+    legend and which hold DEG results.
+
+    Args:
+        path: File to describe.
+        sample_rows: Rows to show per table.
+        max_cols: Columns to show per row.
+
+    Returns:
+        ``{"path", "media_type", "tables": [...]}`` where each table carries
+        ``locator``, ``n_rows``, ``n_cols``, ``header_row_guess`` and ``rows``.
+        Unsupported kinds return an empty ``tables`` list and a ``note``.
+    """
+    path = Path(path)
+    if not path.is_file():
+        # An empty table list for a path that does not exist would read as
+        # "this file holds nothing" — the absence-as-negative-result trap.
+        raise SupplementStoreError(f"no such file: {path}")
+    kind = media_type(path.name)
+    out: dict[str, Any] = {"path": str(path), "media_type": kind, "tables": []}
+
+    if kind == "xlsx":
+        out["tables"] = _outline_xlsx(path, sample_rows, max_cols)
+    elif kind in {"csv", "tsv", "txt"}:
+        out["tables"] = _outline_delimited(path, kind, sample_rows, max_cols)
+    elif kind == "docx":
+        out["tables"] = _outline_docx(path, sample_rows, max_cols)
+    else:
+        out["note"] = (
+            f"no outline support for {kind}; the manifest records this file without a content index"
+        )
+    return out
+
+
+def _clip(value: Any) -> str:
+    if value is None:
+        return ""
+    text = str(value).replace("\n", " ").strip()
+    return text[:OUTLINE_CELL_CHARS] + "…" if len(text) > OUTLINE_CELL_CHARS else text
+
+
+def _trim(row: list[str]) -> list[str]:
+    """Drop trailing empty cells.
+
+    Spreadsheet readers pad rows out to the sheet's width, and supplement
+    sheets are often declared far wider than their data. Padding every sampled
+    row with dozens of empty strings is noise a reader has to look past.
+    """
+    end = len(row)
+    while end and not row[end - 1]:
+        end -= 1
+    return row[:end]
+
+
+def _looks_numeric(cell: str) -> bool:
+    try:
+        float(cell.replace(",", ""))
+    except ValueError:
+        return False
+    return True
+
+
+def _header_row_guess(rows: list[list[str]], scan: int = 6) -> int:
+    """Index of the most plausible header row.
+
+    Publisher tables are rarely a bare grid. The prenatal skin supplements are
+    typical: a title row ("DEG analysis for macrophage subpopulations…"), then
+    sometimes a group-label row naming the block of columns beneath it, then the
+    real header, then data.
+
+    Two signals separate the header from everything above and below it. It is
+    the widest row near the top — wider than a title, which occupies one cell —
+    and its cells are *words*, where the data rows below are mostly numbers.
+    Column count alone picks the first data row for a table whose header is no
+    wider than its data, so both signals are needed.
+
+    Falls back to the widest row when no row looks textual (a table of gene
+    symbols with no header at all).
+    """
+    candidates: list[tuple[int, int]] = []  # (filled cells, index)
+    counts: list[int] = []
+
+    for row in rows[:scan]:
+        filled = [cell for cell in row if cell]
+        counts.append(len(filled))
+        if len(filled) < 2:
+            continue
+        textual = sum(1 for cell in filled if not _looks_numeric(cell))
+        if textual / len(filled) >= 0.6:
+            candidates.append((len(filled), len(counts) - 1))
+
+    if candidates:
+        # Widest textual row wins; ties go to the earliest, which is the header
+        # rather than a repeat of it.
+        return max(candidates, key=lambda pair: (pair[0], -pair[1]))[1]
+
+    if not counts:
+        return 0
+    # Nothing looked textual — a header whose column names are themselves
+    # numbers (cluster ids 0..4, timepoints). Take the earliest row that is
+    # within one cell of the widest: such a header is often one narrower than
+    # its data rows, because the index column's own header is blank.
+    threshold = max(counts) - 1
+    return next(index for index, count in enumerate(counts) if count >= threshold)
+
+
+def _outline_xlsx(path: Path, sample_rows: int, max_cols: int) -> list[dict[str, Any]]:
+    try:
+        from openpyxl import load_workbook  # type: ignore[import-untyped]
+    except ImportError as exc:  # pragma: no cover - dependency guard
+        raise SupplementStoreError(
+            "reading .xlsx needs openpyxl — install the [supplements] extra"
+        ) from exc
+
+    workbook = load_workbook(path, read_only=True, data_only=True)
+    tables: list[dict[str, Any]] = []
+    try:
+        for sheet in workbook.worksheets:
+            rows: list[list[str]] = []
+            for row in sheet.iter_rows(max_row=sample_rows, max_col=max_cols, values_only=True):
+                rows.append(_trim([_clip(cell) for cell in row]))
+            tables.append(
+                {
+                    "locator": sheet.title,
+                    "n_rows": sheet.max_row,
+                    "n_cols": sheet.max_column,
+                    "truncated_cols": bool(sheet.max_column and sheet.max_column > max_cols),
+                    "header_row_guess": _header_row_guess(rows),
+                    "rows": rows,
+                }
+            )
+    finally:
+        workbook.close()
+    return tables
+
+
+def _sniff_delimiter(sample: str, kind: str) -> str:
+    if kind == "tsv":
+        return "\t"
+    try:
+        return csv.Sniffer().sniff(sample, delimiters=",\t;|").delimiter
+    except csv.Error:
+        return "\t" if sample.count("\t") > sample.count(",") else ","
+
+
+def _outline_delimited(
+    path: Path, kind: str, sample_rows: int, max_cols: int
+) -> list[dict[str, Any]]:
+    text = path.read_text(encoding="utf-8", errors="replace")
+    delimiter = _sniff_delimiter(text[:8192], kind)
+    reader = csv.reader(io.StringIO(text), delimiter=delimiter)
+    rows: list[list[str]] = []
+    total = 0
+    widest = 0
+    for index, row in enumerate(reader):
+        total = index + 1
+        widest = max(widest, len(row))
+        if index < sample_rows:
+            rows.append(_trim([_clip(cell) for cell in row[:max_cols]]))
+    return [
+        {
+            "locator": path.name,
+            "delimiter": delimiter,
+            "n_rows": total,
+            "n_cols": widest,
+            "truncated_cols": widest > max_cols,
+            "header_row_guess": _header_row_guess(rows),
+            "rows": rows,
+        }
+    ]
+
+
+def _outline_docx(path: Path, sample_rows: int, max_cols: int) -> list[dict[str, Any]]:
+    """Tables in a .docx, read straight from the package XML.
+
+    Supplementary Information documents carry cluster-annotation tables often
+    available nowhere else. Parsing ``word/document.xml`` avoids a python-docx
+    dependency for what is a shallow read.
+    """
+    if not zipfile.is_zipfile(path):
+        return []
+    with zipfile.ZipFile(path) as zf:
+        try:
+            xml = zf.read("word/document.xml")
+        except KeyError:
+            return []
+
+    ns = "{http://schemas.openxmlformats.org/wordprocessingml/2006/main}"
+    root = ET.fromstring(xml)
+    tables: list[dict[str, Any]] = []
+    for index, table in enumerate(root.iter(f"{ns}tbl"), start=1):
+        rows: list[list[str]] = []
+        all_rows = list(table.iter(f"{ns}tr"))
+        widest = 0
+        for row_index, row in enumerate(all_rows):
+            cells = [_element_text(cell) for cell in row.iter(f"{ns}tc")]
+            widest = max(widest, len(cells))
+            if row_index < sample_rows:
+                rows.append(_trim([_clip(cell) for cell in cells[:max_cols]]))
+        tables.append(
+            {
+                "locator": f"table {index}",
+                "n_rows": len(all_rows),
+                "n_cols": widest,
+                "truncated_cols": widest > max_cols,
+                "header_row_guess": _header_row_guess(rows),
+                "rows": rows,
+            }
+        )
+    return tables
+
+
+# ------------------------------------------------------------------
+# Text: reading a legend document
+# ------------------------------------------------------------------
+
+
+def extract_text(path: Path, max_chars: int = 40_000) -> dict[str, Any]:
+    """Plain text of a document, truncated to a budget.
+
+    The reason this exists: a bundle of forty supplementary tables usually ships
+    with a legends document describing every one of them, and it is prose, not a
+    table — so :func:`outline_file` sees nothing in it. Reading that one file
+    characterises the whole bundle, which makes it the highest-leverage read in
+    the store.
+
+    Args:
+        path: A ``.docx``, ``.txt`` or other text-bearing file.
+        max_chars: Truncation budget. Legend documents run to a few tens of
+            thousands of characters; the default holds a typical one whole.
+
+    Returns:
+        ``{"path", "media_type", "text", "chars", "truncated"}``. Unsupported
+        kinds return empty text and a ``note`` rather than raising, so a caller
+        can record a gap and move on.
+    """
+    path = Path(path)
+    if not path.is_file():
+        raise SupplementStoreError(f"no such file: {path}")
+    kind = media_type(path.name)
+    out: dict[str, Any] = {"path": str(path), "media_type": kind}
+
+    if kind == "docx":
+        text = _docx_text(path)
+    elif kind in {"txt", "csv", "tsv"}:
+        text = path.read_text(encoding="utf-8", errors="replace")
+    else:
+        out.update(
+            {
+                "text": "",
+                "chars": 0,
+                "truncated": False,
+                "note": (
+                    f"no text extraction for {kind}; PDFs need the [local-index] "
+                    "extra and services._pdf_parser"
+                ),
+            }
+        )
+        return out
+
+    out["chars"] = len(text)
+    out["truncated"] = len(text) > max_chars
+    out["text"] = text[:max_chars]
+    return out
+
+
+def _docx_text(path: Path) -> str:
+    """Paragraph text of a .docx, one paragraph per line."""
+    if not zipfile.is_zipfile(path):
+        return ""
+    with zipfile.ZipFile(path) as zf:
+        try:
+            xml = zf.read("word/document.xml")
+        except KeyError:
+            return ""
+
+    ns = "{http://schemas.openxmlformats.org/wordprocessingml/2006/main}"
+    root = ET.fromstring(xml)
+    lines = [_element_text(para) for para in root.iter(f"{ns}p")]
+    return "\n".join(line for line in lines if line)
+
+
+# ------------------------------------------------------------------
+# Slice: a targeted read
+# ------------------------------------------------------------------
+
+
+def read_slice(
+    path: Path,
+    locator: str | None = None,
+    start: int = 0,
+    limit: int = 50,
+    columns: list[str] | None = None,
+    header_row: int | None = None,
+) -> dict[str, Any]:
+    """Read one region of a table.
+
+    The counterpart to :func:`outline_file`: once a reader knows which sheet it
+    wants, this pulls just that part. Row indices are 0-based over the file's
+    rows, header included, so they line up with ``outline``'s
+    ``header_row_guess``.
+
+    Args:
+        path: File to read.
+        locator: Worksheet name (xlsx) or table locator (docx). Ignored for
+            single-table files; defaults to the first table.
+        start: First row to return, 0-based, counted from the file's first row.
+        limit: Maximum rows to return.
+        columns: Restrict to these column names. Requires ``header_row`` (or
+            relies on the guess) so headers can be resolved.
+        header_row: 0-based header row index. Defaults to the guess.
+
+    Returns:
+        ``{"path", "locator", "header", "rows", "start", "returned", "n_rows"}``.
+    """
+    path = Path(path)
+    outline = outline_file(path, sample_rows=max(limit + start, OUTLINE_SAMPLE_ROWS))
+    tables = outline["tables"]
+    if not tables:
+        raise SupplementStoreError(f"nothing tabular to slice in {path}")
+
+    table = _pick_table(tables, locator)
+    effective_header = table["header_row_guess"] if header_row is None else header_row
+    rows = _read_rows(path, table, start, limit)
+    header = _read_header(path, table, effective_header)
+
+    if columns:
+        keep = [header.index(name) for name in columns if name in header]
+        missing = [name for name in columns if name not in header]
+        if missing:
+            raise SupplementStoreError(
+                f"columns not in header {header!r}: {missing!r}",
+            )
+        header = [header[i] for i in keep]
+        rows = [[row[i] if i < len(row) else "" for i in keep] for row in rows]
+
+    return {
+        "path": str(path),
+        "locator": table["locator"],
+        "header_row": effective_header,
+        "header": header,
+        "n_rows": table["n_rows"],
+        "start": start,
+        "returned": len(rows),
+        "rows": rows,
+    }
+
+
+def _pick_table(tables: list[dict[str, Any]], locator: str | None) -> dict[str, Any]:
+    if locator is None:
+        return tables[0]
+    for table in tables:
+        if table["locator"] == locator:
+            return table
+    available = [table["locator"] for table in tables]
+    raise SupplementStoreError(f"no table {locator!r}; available: {available!r}")
+
+
+def _read_rows(path: Path, table: dict[str, Any], start: int, limit: int) -> list[list[str]]:
+    kind = media_type(path.name)
+    if kind == "xlsx":
+        from openpyxl import load_workbook
+
+        workbook = load_workbook(path, read_only=True, data_only=True)
+        try:
+            sheet = workbook[table["locator"]]
+            rows: list[list[str]] = []
+            for index, row in enumerate(sheet.iter_rows(values_only=True)):
+                if index < start:
+                    continue
+                if len(rows) >= limit:
+                    break
+                rows.append(_trim([_clip(cell) for cell in row]))
+            return rows
+        finally:
+            workbook.close()
+
+    # Delimited and docx files are re-outlined with a large sample; cheap
+    # relative to the size of file that reaches this path.
+    full = outline_file(path, sample_rows=start + limit, max_cols=10_000)
+    picked = _pick_table(full["tables"], table["locator"])
+    return picked["rows"][start : start + limit]
+
+
+def _read_header(path: Path, table: dict[str, Any], header_row: int) -> list[str]:
+    rows = _read_rows(path, table, header_row, 1)
+    return rows[0] if rows else []
+
+
+# ------------------------------------------------------------------
+# Manifest IO
+# ------------------------------------------------------------------
+
+
+def load_manifest(store_root: Path, doi: str) -> dict[str, Any] | None:
+    """Read a paper's manifest, or None if the store has no entry for it."""
+    path = manifest_path(store_root, doi)
+    if not path.exists():
+        return None
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise SupplementStoreError(f"manifest is not valid JSON: {path}") from exc
+
+
+def write_manifest(store_root: Path, doi: str, manifest: dict[str, Any]) -> Path:
+    """Validate a manifest against its schema and write it.
+
+    Raises:
+        SupplementStoreError: If the manifest does not conform. Writing an
+            invalid manifest is worse than failing — downstream steps trust it.
+    """
+    validate_manifest(manifest)
+    path = manifest_path(store_root, doi)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
+    logger.info("wrote %s", path)
+    return path
+
+
+def validate_manifest(manifest: dict[str, Any]) -> None:
+    """Validate against ``supplement_manifest.schema.json``.
+
+    Raises:
+        SupplementStoreError: On the first schema violation, with the JSON path.
+    """
+    import jsonschema  # type: ignore[import-untyped]
+
+    from atlas_chat.schemas import load_schema
+
+    try:
+        jsonschema.validate(manifest, load_schema("supplement_manifest.schema.json"))
+    except jsonschema.ValidationError as exc:
+        location = "/".join(str(part) for part in exc.absolute_path) or "(root)"
+        raise SupplementStoreError(f"manifest invalid at {location}: {exc.message}") from exc
+
+
+def cross_check_manifest(manifest: dict[str, Any]) -> list[str]:
+    """Consistency rules the schema cannot express.
+
+    The schema pins the shape; these are the rules that make a manifest
+    *usable* — a table pointing at a file that isn't there, or a present file
+    with no path, both pass schema validation and fail a reader.
+
+    Returns:
+        Human-readable problems, empty if the manifest is consistent.
+    """
+    problems: list[str] = []
+    files = {entry["file_id"]: entry for entry in manifest.get("files", [])}
+
+    for entry in manifest.get("files", []):
+        if entry["status"] == "present" and not entry.get("path"):
+            problems.append(f"file {entry['file_id']} is 'present' but has no path")
+        if entry["status"] != "present" and entry.get("path"):
+            problems.append(f"file {entry['file_id']} is '{entry['status']}' but has a path")
+
+    for index, table in enumerate(manifest.get("tables", [])):
+        parent = files.get(table["file_id"])
+        if parent is None:
+            problems.append(f"tables[{index}] points at unknown file_id {table['file_id']!r}")
+            continue
+        if parent["status"] != "present":
+            problems.append(
+                f"tables[{index}] points at file {table['file_id']} "
+                f"with status '{parent['status']}'"
+            )
+        member = table.get("member_path")
+        if member:
+            known = {m["member_path"] for m in parent.get("members", [])}
+            if known and member not in known:
+                problems.append(
+                    f"tables[{index}] member_path {member!r} is not a member of {table['file_id']}"
+                )
+        elif parent.get("media_type") == "zip":
+            problems.append(
+                f"tables[{index}] is inside archive {table['file_id']} but names no member_path"
+            )
+    return problems
+
+
+def touch_indexed_at(store_root: Path, doi: str) -> dict[str, Any]:
+    """Stamp ``indexed_at`` after the content index has been (re)written."""
+    manifest = load_manifest(store_root, doi)
+    if manifest is None:
+        raise SupplementStoreError(f"no manifest for {doi} in {store_root}")
+    manifest["indexed_at"] = _now()
+    write_manifest(store_root, doi, manifest)
+    return manifest
+
+
+# ------------------------------------------------------------------
+# CAS+ helpers
+# ------------------------------------------------------------------
+
+
+def corpus_papers(cas: dict[str, Any]) -> list[dict[str, Any]]:
+    """The papers whose supplements a project needs, from a CAS+ document.
+
+    The atlas paper plus every subatlas paper that has a DOI. Takes the parsed
+    document, not a project name, so it works for any CAS+ source.
+
+    Returns:
+        Dicts with ``doi``, ``role`` and (where known) ``title``, ``pmcid``.
+    """
+    source = cas.get("source", {})
+    papers: list[dict[str, Any]] = []
+    if source.get("doi"):
+        entry = {"doi": source["doi"], "role": "atlas"}
+        for key in ("title", "pmcid", "pmid"):
+            if source.get(key):
+                entry[key] = source[key]
+        papers.append(entry)
+    for sub in source.get("subatlas_papers", []):
+        doi = sub.get("doi")
+        if doi:
+            papers.append({"doi": doi, "role": "subatlas", "title": sub.get("label", "")})
+    return papers
+
+
+# ------------------------------------------------------------------
+# CLI
+# ------------------------------------------------------------------
+
+
+def _print(payload: Any) -> None:
+    print(json.dumps(payload, indent=2))
+
+
+def _cmd_inventory(args: argparse.Namespace) -> int:
+    _print(inventory_from_jats(Path(args.jats)))
+    return 0
+
+
+def _cmd_adopt(args: argparse.Namespace) -> int:
+    listed = None
+    if args.jats:
+        listed = inventory_from_jats(Path(args.jats))
+    paper: dict[str, Any] = {}
+    if args.role:
+        paper["role"] = args.role
+    if args.access:
+        paper["access"] = args.access
+    manifest = adopt_manual_files(
+        store_root=Path(args.store),
+        doi=args.doi,
+        incoming=Path(args.incoming),
+        listed=listed,
+        paper=paper,
+    )
+    _print(
+        {
+            "manifest": str(manifest_path(Path(args.store), args.doi)),
+            "files": len(manifest["files"]),
+        }
+    )
+    return 0
+
+
+def _cmd_unpack(args: argparse.Namespace) -> int:
+    manifest = unpack_archives(
+        Path(args.store),
+        args.doi,
+        size_cap=args.size_cap,
+        tabular_size_cap=args.tabular_size_cap,
+    )
+    _print(
+        {
+            "files": [
+                {"file_id": f["file_id"], "members": len(f.get("members", []))}
+                for f in manifest["files"]
+            ],
+            "gaps": manifest.get("gaps", []),
+        }
+    )
+    return 0
+
+
+def _cmd_outline(args: argparse.Namespace) -> int:
+    _print(outline_file(Path(args.file), sample_rows=args.rows, max_cols=args.cols))
+    return 0
+
+
+def _cmd_text(args: argparse.Namespace) -> int:
+    _print(extract_text(Path(args.file), max_chars=args.max_chars))
+    return 0
+
+
+def _cmd_slice(args: argparse.Namespace) -> int:
+    _print(
+        read_slice(
+            Path(args.file),
+            locator=args.locator,
+            start=args.start,
+            limit=args.limit,
+            columns=args.columns,
+            header_row=args.header_row,
+        )
+    )
+    return 0
+
+
+def _cmd_show(args: argparse.Namespace) -> int:
+    manifest = load_manifest(Path(args.store), args.doi)
+    if manifest is None:
+        print(f"no manifest for {args.doi} in {args.store}", file=sys.stderr)
+        return 1
+    _print(manifest)
+    return 0
+
+
+def _cmd_check(args: argparse.Namespace) -> int:
+    manifest = load_manifest(Path(args.store), args.doi)
+    if manifest is None:
+        print(f"no manifest for {args.doi} in {args.store}", file=sys.stderr)
+        return 1
+    try:
+        validate_manifest(manifest)
+    except SupplementStoreError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+    problems = cross_check_manifest(manifest)
+    if problems:
+        for problem in problems:
+            print(problem, file=sys.stderr)
+        return 1
+    print("manifest OK")
+    return 0
+
+
+def _cmd_papers(args: argparse.Namespace) -> int:
+    cas = json.loads(Path(args.cas).read_text(encoding="utf-8"))
+    _print(corpus_papers(cas))
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="atlas_chat.cli_supplements",
+        description=(
+            "Supplement store: list, adopt, unpack, outline and slice a paper's "
+            "supplementary material. Deciding what a table is FOR is the "
+            "index-supplements skill's job; this is the mechanical half."
+        ),
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    def add_store(p: argparse.ArgumentParser) -> None:
+        p.add_argument("--store", required=True, help="store root directory")
+        p.add_argument("--doi", required=True, help="DOI of the paper")
+
+    inv = sub.add_parser("inventory", help="list supplementary files from a JATS XML")
+    inv.add_argument("--jats", required=True)
+    inv.set_defaults(func=_cmd_inventory)
+
+    adopt = sub.add_parser("adopt", help="take manually-dropped files into the store")
+    add_store(adopt)
+    adopt.add_argument("--incoming", required=True, help="directory holding the dropped files")
+    adopt.add_argument("--jats", help="JATS XML, to carry over labels and captions")
+    adopt.add_argument("--role", choices=["atlas", "subatlas", "external"])
+    adopt.add_argument("--access", choices=["open", "closed", "unknown"])
+    adopt.set_defaults(func=_cmd_adopt)
+
+    unpack = sub.add_parser("unpack", help="expand archives and record member trees")
+    add_store(unpack)
+    unpack.add_argument(
+        "--size-cap",
+        type=int,
+        default=DEFAULT_SIZE_CAP_BYTES,
+        help="ceiling for non-tabular members (video, images)",
+    )
+    unpack.add_argument(
+        "--tabular-size-cap",
+        type=int,
+        default=DEFAULT_TABULAR_SIZE_CAP_BYTES,
+        help="ceiling for spreadsheets and documents",
+    )
+    unpack.set_defaults(func=_cmd_unpack)
+
+    outline = sub.add_parser("outline", help="bounded description of a file's shape")
+    outline.add_argument("--file", required=True)
+    outline.add_argument("--rows", type=int, default=OUTLINE_SAMPLE_ROWS)
+    outline.add_argument("--cols", type=int, default=OUTLINE_MAX_COLS)
+    outline.set_defaults(func=_cmd_outline)
+
+    text = sub.add_parser("text", help="plain text of a document (e.g. a table-legends .docx)")
+    text.add_argument("--file", required=True)
+    text.add_argument("--max-chars", type=int, default=40_000)
+    text.set_defaults(func=_cmd_text)
+
+    sl = sub.add_parser("slice", help="read one region of one table")
+    sl.add_argument("--file", required=True)
+    sl.add_argument("--locator", help="worksheet name or table locator")
+    sl.add_argument("--start", type=int, default=0)
+    sl.add_argument("--limit", type=int, default=50)
+    sl.add_argument("--columns", nargs="*")
+    sl.add_argument("--header-row", type=int)
+    sl.set_defaults(func=_cmd_slice)
+
+    show = sub.add_parser("show", help="print a paper's manifest")
+    add_store(show)
+    show.set_defaults(func=_cmd_show)
+
+    check = sub.add_parser("check", help="validate a manifest against its schema")
+    add_store(check)
+    check.set_defaults(func=_cmd_check)
+
+    papers = sub.add_parser("papers", help="corpus papers from a CAS+ document")
+    papers.add_argument("--cas", required=True)
+    papers.set_defaults(func=_cmd_papers)
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
+    args = build_parser().parse_args(argv)
+    try:
+        return int(args.func(args))
+    except SupplementStoreError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/src/atlas_chat/pyproject.toml
+++ b/src/atlas_chat/pyproject.toml
@@ -30,6 +30,12 @@ local-index = [
     "pymupdf4llm>=0.0.17",
 ]
 
+# Reading supplementary spreadsheets in the supplement store. Small; kept
+# optional so the base install stays lean.
+supplements = [
+    "openpyxl>=3.1",
+]
+
 [project.scripts]
 atlas-report = "atlas_chat.cli:main"
 

--- a/tests/integration/test_supplement_store_live.py
+++ b/tests/integration/test_supplement_store_live.py
@@ -1,0 +1,259 @@
+"""Integration tests for the supplement store against real material.
+
+Two kinds of real:
+
+* Europe PMC — the article XML is fetched live, so a change in how they serve
+  ``<supplementary-material>`` surfaces here rather than in a run.
+* The prenatal skin atlas store in ``projects/test_projects/`` — real Nature
+  supplements, including the 95 MB / 396k-row table that motivated giving
+  spreadsheets their own size ceiling. Skipped when the files aren't on disk,
+  since they are git-ignored; see that project's ``supplements/incoming/README.md``.
+
+No mocks. The Europe PMC test fails hard if the network or the service is down.
+"""
+
+from __future__ import annotations
+
+import re
+
+import httpx
+import pytest
+
+from atlas_chat.services import supplement_store as store
+
+pytestmark = pytest.mark.integration
+
+ATLAS_DOI = "10.1038/s41586-024-08002-x"
+PMCID = "PMC11578897"
+EUROPEPMC = "https://www.ebi.ac.uk/europepmc/webservices/rest"
+
+REPO_ROOT = __import__("pathlib").Path(__file__).resolve().parents[2]
+STORE = REPO_ROOT / "projects" / "test_projects" / "fetal_skin_atlas" / "supplements"
+
+
+@pytest.fixture(scope="module")
+def live_jats(tmp_path_factory: pytest.TempPathFactory):
+    """The prenatal skin atlas article XML, fetched from Europe PMC."""
+    path = tmp_path_factory.mktemp("jats") / "paper.jats.xml"
+    response = httpx.get(f"{EUROPEPMC}/{PMCID}/fullTextXML", timeout=60)
+    response.raise_for_status()
+    path.write_text(response.text)
+    return path
+
+
+def test_inventory_against_live_europepmc(live_jats) -> None:
+    entries = store.inventory_from_jats(live_jats)
+
+    by_id = {entry["file_id"]: entry for entry in entries}
+    assert len(entries) == 6
+
+    tables = by_id["41586_2024_8002_MOESM4_ESM.zip"]
+    assert tables["label"] == "Supplementary Tables"
+    assert tables["caption"].startswith("Supplementary Tables 1")
+    assert tables["media_type"] == "zip"
+
+    # The video is listed so a later step can deliberately skip it rather than
+    # discovering half a gigabyte of MP4 the hard way.
+    assert by_id["41586_2024_8002_MOESM5_ESM.mp4"]["media_type"] == "video"
+
+
+def test_publisher_direct_serves_individual_files() -> None:
+    """The route the retrieval half will use.
+
+    Europe PMC's ``supplementaryFiles`` endpoint bundles every supplement into
+    one zip — over 445 MB for this paper, because of the video, with no way to
+    select files. The publisher's static host serves them individually, and the
+    filenames come from the article XML.
+    """
+    url = (
+        "https://static-content.springer.com/esm/"
+        "art%3A10.1038%2Fs41586-024-08002-x/MediaObjects/"
+        "41586_2024_8002_MOESM6_ESM.xlsx"
+    )
+    response = httpx.head(url, follow_redirects=True, timeout=60)
+
+    assert response.status_code == 200
+    assert int(response.headers["content-length"]) > 0
+
+
+# ------------------------------------------------------------------
+# The real store
+# ------------------------------------------------------------------
+
+needs_store = pytest.mark.skipif(
+    not store.manifest_path(STORE, ATLAS_DOI).exists(),
+    reason=(
+        "prenatal skin supplements not on disk (git-ignored); see "
+        "projects/test_projects/fetal_skin_atlas/supplements/incoming/README.md"
+    ),
+)
+
+
+@needs_store
+def test_real_manifest_is_valid_and_consistent() -> None:
+    manifest = store.load_manifest(STORE, ATLAS_DOI)
+
+    store.validate_manifest(manifest)
+    assert store.cross_check_manifest(manifest) == []
+
+
+@needs_store
+def test_real_bundle_unpacked_including_the_big_table() -> None:
+    manifest = store.load_manifest(STORE, ATLAS_DOI)
+    bundle = next(
+        entry for entry in manifest["files"] if entry["file_id"].endswith("MOESM4_ESM.zip")
+    )
+
+    members = {member["member_path"]: member for member in bundle["members"]}
+    assert len(members) > 30
+
+    # Supplementary Table 5 is ~95 MB — above any sensible general size cap, and
+    # the largest table in the bundle. A blanket cap would drop exactly the file
+    # a marker query most wants.
+    big = next(name for name in members if name.endswith("Supplementary Table 5.xlsx"))
+    assert members[big]["size_bytes"] > 80 * 1024 * 1024
+    assert members[big]["extracted"] is True
+
+
+@needs_store
+def test_outline_stays_bounded_on_a_396k_row_table() -> None:
+    manifest = store.load_manifest(STORE, ATLAS_DOI)
+    bundle = next(
+        entry for entry in manifest["files"] if entry["file_id"].endswith("MOESM4_ESM.zip")
+    )
+    big = next(
+        member
+        for member in bundle["members"]
+        if member["member_path"].endswith("Supplementary Table 5.xlsx")
+    )
+
+    outline = store.outline_file(STORE / big["path"], sample_rows=4, max_cols=10)
+
+    table = outline["tables"][0]
+    assert table["n_rows"] > 100_000
+    assert len(table["rows"]) == 4
+    assert all(len(row) <= 10 for row in table["rows"])
+
+
+@needs_store
+def test_header_row_guess_skips_a_publisher_title_row() -> None:
+    """Nature tables carry a title row above the header; slicing from row 0 is wrong."""
+    manifest = store.load_manifest(STORE, ATLAS_DOI)
+    bundle = next(
+        entry for entry in manifest["files"] if entry["file_id"].endswith("MOESM4_ESM.zip")
+    )
+    table_one = next(
+        member
+        for member in bundle["members"]
+        if member["member_path"].endswith("Supplementary Table 1.xlsx")
+    )
+    path = STORE / table_one["path"]
+
+    outline = store.outline_file(path)
+    guess = outline["tables"][0]["header_row_guess"]
+    assert guess == 1
+    assert outline["tables"][0]["rows"][0][0] == "Prenatal skin metadata"
+
+    sliced = store.read_slice(path, start=guess + 1, limit=2, header_row=guess)
+    assert sliced["header"][:3] == ["Sanger_id", "Donor", "PCW"]
+    assert sliced["returned"] == 2
+
+
+# ------------------------------------------------------------------
+# Are the manifest's pointers actually actionable?
+# ------------------------------------------------------------------
+
+
+@needs_store
+def test_every_table_pointer_resolves_to_its_recorded_columns() -> None:
+    """The manifest's whole purpose: go straight to a sheet without searching.
+
+    For each pointer, slice the file at the recorded header_row and check the
+    recorded column names really are that table's columns. A pointer whose
+    header_row is off by one sends a reader into the data.
+    """
+    manifest = store.load_manifest(STORE, ATLAS_DOI)
+    files = {entry["file_id"]: entry for entry in manifest["files"]}
+
+    checked = 0
+    for pointer in manifest["tables"]:
+        columns = pointer.get("columns")
+        if not columns:
+            continue  # the legends document carries no columns
+        parent = files[pointer["file_id"]]
+        if pointer.get("member_path"):
+            member = next(
+                m for m in parent["members"] if m["member_path"] == pointer["member_path"]
+            )
+            path = STORE / member["path"]
+        else:
+            path = STORE / parent["path"]
+
+        sliced = store.read_slice(
+            path,
+            locator=pointer.get("locator"),
+            start=pointer["header_row"] + 1,
+            limit=1,
+            header_row=pointer["header_row"],
+        )
+        header = [cell for cell in sliced["header"] if cell]
+        recorded = [column["name"] for column in columns]
+        assert header[: len(recorded)][:5] == recorded[:5], (
+            f"{pointer.get('table_label') or pointer.get('locator')}: "
+            f"recorded {recorded[:5]} but header row {pointer['header_row']} "
+            f"reads {header[:5]}"
+        )
+        checked += 1
+
+    assert checked > 40, f"only checked {checked} pointers"
+
+
+@needs_store
+def test_the_macrophage_marker_table_is_findable_and_readable() -> None:
+    """The end-to-end case: the test cell type's markers live in a supplement.
+
+    'Iron-recycling macrophage' is the project's reference cell type, and its
+    differential expression is in one sheet of a 40-table bundle. A reader
+    should reach it from the manifest alone.
+    """
+    manifest = store.load_manifest(STORE, ATLAS_DOI)
+
+    pointer = next(
+        p
+        for p in manifest["tables"]
+        if p["content_type"] == "deg_results" and "macrophage subsets" in p["description"]
+    )
+    assert pointer["table_label"] == "Supplementary Table 22"
+
+    bundle = next(entry for entry in manifest["files"] if entry["file_id"] == pointer["file_id"])
+    member = next(m for m in bundle["members"] if m["member_path"] == pointer["member_path"])
+
+    sliced = store.read_slice(
+        STORE / member["path"],
+        locator=pointer["locator"],
+        start=pointer["header_row"] + 1,
+        limit=5,
+        header_row=pointer["header_row"],
+    )
+
+    assert [c for c in sliced["header"] if c][:5] == [
+        "names",
+        "scores",
+        "logfoldchanges",
+        "pvals",
+        "pvals_adj",
+    ]
+    # Real gene symbols, not a title row (HGNC symbols carry digits: DAB2, RNASE1).
+    assert any(re.fullmatch(r"[A-Z][A-Z0-9.-]+", cell) for cell in sliced["rows"][0] if cell)
+
+
+@needs_store
+def test_gaps_explain_what_is_absent() -> None:
+    """An empty tables list with no gaps would read as 'nothing useful here'."""
+    manifest = store.load_manifest(STORE, ATLAS_DOI)
+
+    reasons = {gap["file_id"]: gap["reason"] for gap in manifest["gaps"]}
+    # The two PDFs and the video were never fetched; say so rather than implying
+    # they hold nothing.
+    assert "41586_2024_8002_MOESM5_ESM.mp4" in reasons
+    assert any("never retrieved" in reason for reason in reasons.values())

--- a/tests/unit/test_supplement_store.py
+++ b/tests/unit/test_supplement_store.py
@@ -138,7 +138,7 @@ def test_adopt_copies_files_and_carries_captions_over(
         doi="10.1038/test",
         incoming=incoming,
         listed=store.inventory_from_jats(jats_file),
-        paper={"role": "atlas", "access": "open"},
+        paper={"pmcid": "PMC11578897"},
     )
 
     by_id = {entry["file_id"]: entry for entry in manifest["files"]}
@@ -152,7 +152,7 @@ def test_adopt_copies_files_and_carries_captions_over(
     assert by_id["paper_MOESM2_ESM.mp4"]["status"] == "listed"
     # README and dotfiles are not supplements.
     assert "README.md" not in by_id and ".DS_Store" not in by_id
-    assert manifest["paper"]["role"] == "atlas"
+    assert manifest["paper"] == {"doi": "10.1038/test", "pmcid": "PMC11578897"}
     assert (tmp_path / "store" / adopted["path"]).exists()
 
 
@@ -844,3 +844,69 @@ def test_cli_text(tmp_path: Path, capsys: pytest.CaptureFixture) -> None:
     payload = json.loads(capsys.readouterr().out)
     assert payload["truncated"] is True
     assert len(payload["text"]) == 20
+
+
+def test_manifest_paper_block_stays_minimal(tmp_path: Path) -> None:
+    """Corpus metadata belongs to CAS+, not to a fetch cache that can drift."""
+    manifest = _minimal_manifest()
+    manifest["paper"]["role"] = "atlas"
+
+    with pytest.raises(store.SupplementStoreError):
+        store.write_manifest(tmp_path, "10.1038/test", manifest)
+
+
+# ------------------------------------------------------------------
+# No limit is silent
+# ------------------------------------------------------------------
+
+
+def test_outline_flags_both_truncations_against_true_size(tmp_path: Path) -> None:
+    """A caller must be able to tell a whole table from the top of a big one."""
+    openpyxl = pytest.importorskip("openpyxl")
+    path = tmp_path / "big.xlsx"
+    wb = openpyxl.Workbook()
+    sheet = wb.active
+    sheet.append([f"col{i}" for i in range(50)])
+    for row in range(100):
+        sheet.append([row] * 50)
+    wb.save(path)
+
+    table = store.outline_file(path, sample_rows=3, max_cols=5)["tables"][0]
+
+    assert table["truncated_rows"] is True
+    assert table["truncated_cols"] is True
+    assert table["n_rows"] == 101
+    assert table["n_cols"] == 50
+
+
+def test_outline_does_not_flag_truncation_for_a_small_table(tmp_path: Path) -> None:
+    path = tmp_path / "small.csv"
+    path.write_text("gene,lfc\nA,1\nB,2\n")
+
+    table = store.outline_file(path)["tables"][0]
+
+    assert table["truncated_rows"] is False
+    assert table["truncated_cols"] is False
+
+
+def test_header_detection_survives_a_small_sample(tmp_path: Path) -> None:
+    """Asking to *see* two rows must not degrade the header guess.
+
+    Real case: Supplementary Table 5 of the prenatal skin atlas has two title
+    rows above its header, so `--rows 2` would otherwise report row 0.
+    """
+    openpyxl = pytest.importorskip("openpyxl")
+    path = tmp_path / "titled.xlsx"
+    wb = openpyxl.Workbook()
+    sheet = wb.active
+    sheet.append(["LR: prediction probabilities"])
+    sheet.append(["Overall"])
+    sheet.append(["barcode", "predicted", "12-14", "15-17"])
+    sheet.append(["AAAC-1", "12-14", 0.37, 0.31])
+    wb.save(path)
+
+    table = store.outline_file(path, sample_rows=2)["tables"][0]
+
+    assert table["header_row_guess"] == 2
+    # Still only returns what was asked for.
+    assert len(table["rows"]) == 2

--- a/tests/unit/test_supplement_store.py
+++ b/tests/unit/test_supplement_store.py
@@ -1,0 +1,846 @@
+"""Unit tests for the supplement store's mechanical half.
+
+Everything here is in/out: JATS parsing, archive expansion, outlining a
+workbook, slicing a region, and the manifest cross-checks. Fixtures are built in
+tmp_path rather than committed, so the suite carries no binaries.
+"""
+
+from __future__ import annotations
+
+import json
+import zipfile
+from pathlib import Path
+
+import pytest
+
+from atlas_chat.services import supplement_store as store
+
+pytestmark = pytest.mark.unit
+
+
+# ------------------------------------------------------------------
+# Fixtures
+# ------------------------------------------------------------------
+
+JATS = """<?xml version="1.0"?>
+<article xmlns:xlink="http://www.w3.org/1999/xlink">
+  <body>
+    <supplementary-material id="MOESM1" xlink:href="paper_MOESM1_ESM.xlsx">
+      <label>Supplementary Tables</label>
+      <caption><p>Supplementary Tables 1-40.</p></caption>
+    </supplementary-material>
+    <supplementary-material id="MOESM2" xlink:href="paper_MOESM2_ESM.mp4">
+      <label>Supplementary Video 1</label>
+      <caption><p>3D view of
+      co-localization.</p></caption>
+    </supplementary-material>
+    <supplementary-material id="MOESM3">
+      <media xlink:href="paper_MOESM3_ESM.pdf"/>
+      <caption><p>Reporting Summary</p></caption>
+    </supplementary-material>
+    <supplementary-material id="dupe" xlink:href="paper_MOESM1_ESM.xlsx"/>
+  </body>
+</article>
+"""
+
+
+@pytest.fixture
+def jats_file(tmp_path: Path) -> Path:
+    path = tmp_path / "paper.jats.xml"
+    path.write_text(JATS)
+    return path
+
+
+@pytest.fixture
+def workbook(tmp_path: Path) -> Path:
+    """A workbook shaped like a real supplement: a title row above the header."""
+    openpyxl = pytest.importorskip("openpyxl")
+    path = tmp_path / "table.xlsx"
+    wb = openpyxl.Workbook()
+    legend = wb.active
+    legend.title = "Legend"
+    legend.append(["Sheet", "Contents"])
+    legend.append(["DEGs", "Differential expression per cluster"])
+
+    degs = wb.create_sheet("DEGs")
+    degs.append(["Supplementary Table 12 | DEGs by cluster", None, None])
+    degs.append(["gene", "avg_log2FC", "p_val_adj"])
+    for index in range(5):
+        degs.append([f"GENE{index}", 1.5 + index, 0.001])
+    wb.save(path)
+    return path
+
+
+def _minimal_manifest(doi: str = "10.1038/test") -> dict:
+    return {
+        "manifest_version": store.MANIFEST_VERSION,
+        "paper": {"doi": doi},
+        "files": [],
+    }
+
+
+# ------------------------------------------------------------------
+# Inventory
+# ------------------------------------------------------------------
+
+
+def test_inventory_reads_labels_and_captions(jats_file: Path) -> None:
+    entries = store.inventory_from_jats(jats_file)
+
+    assert [entry["file_id"] for entry in entries] == [
+        "paper_MOESM1_ESM.xlsx",
+        "paper_MOESM2_ESM.mp4",
+        "paper_MOESM3_ESM.pdf",
+    ]
+    tables = entries[0]
+    assert tables["label"] == "Supplementary Tables"
+    assert tables["caption"] == "Supplementary Tables 1-40."
+    assert tables["media_type"] == "xlsx"
+    assert tables["status"] == "listed"
+    assert tables["retrieval"] == {"route": "jats_listing"}
+
+
+def test_inventory_normalises_whitespace_in_captions(jats_file: Path) -> None:
+    entries = store.inventory_from_jats(jats_file)
+    video = next(e for e in entries if e["media_type"] == "video")
+    assert video["caption"] == "3D view of co-localization."
+
+
+def test_inventory_finds_href_on_nested_media(jats_file: Path) -> None:
+    entries = store.inventory_from_jats(jats_file)
+    pdf = next(e for e in entries if e["media_type"] == "pdf")
+    assert pdf["file_id"] == "paper_MOESM3_ESM.pdf"
+    assert "label" not in pdf
+
+
+def test_inventory_returns_empty_for_article_without_supplements(tmp_path: Path) -> None:
+    path = tmp_path / "bare.xml"
+    path.write_text('<?xml version="1.0"?><article><body/></article>')
+    assert store.inventory_from_jats(path) == []
+
+
+# ------------------------------------------------------------------
+# Adopting manual drops
+# ------------------------------------------------------------------
+
+
+def test_adopt_copies_files_and_carries_captions_over(
+    tmp_path: Path, jats_file: Path, workbook: Path
+) -> None:
+    incoming = tmp_path / "incoming"
+    incoming.mkdir()
+    (incoming / "paper_MOESM1_ESM.xlsx").write_bytes(workbook.read_bytes())
+    (incoming / "README.md").write_text("not a supplement")
+    (incoming / ".DS_Store").write_text("nor this")
+
+    manifest = store.adopt_manual_files(
+        store_root=tmp_path / "store",
+        doi="10.1038/test",
+        incoming=incoming,
+        listed=store.inventory_from_jats(jats_file),
+        paper={"role": "atlas", "access": "open"},
+    )
+
+    by_id = {entry["file_id"]: entry for entry in manifest["files"]}
+    adopted = by_id["paper_MOESM1_ESM.xlsx"]
+    assert adopted["status"] == "present"
+    assert adopted["retrieval"]["route"] == "manual"
+    assert len(adopted["retrieval"]["sha256"]) == 64
+    # The caption from the article XML survives adoption.
+    assert adopted["caption"] == "Supplementary Tables 1-40."
+    # Files we know of but never fetched stay listed.
+    assert by_id["paper_MOESM2_ESM.mp4"]["status"] == "listed"
+    # README and dotfiles are not supplements.
+    assert "README.md" not in by_id and ".DS_Store" not in by_id
+    assert manifest["paper"]["role"] == "atlas"
+    assert (tmp_path / "store" / adopted["path"]).exists()
+
+
+def test_adopt_is_idempotent(tmp_path: Path, workbook: Path) -> None:
+    incoming = tmp_path / "incoming"
+    incoming.mkdir()
+    (incoming / "table.xlsx").write_bytes(workbook.read_bytes())
+    root = tmp_path / "store"
+
+    first = store.adopt_manual_files(root, "10.1038/test", incoming)
+    second = store.adopt_manual_files(root, "10.1038/test", incoming)
+
+    assert len(second["files"]) == len(first["files"]) == 1
+    assert second["files"][0]["retrieval"]["sha256"] == (first["files"][0]["retrieval"]["sha256"])
+
+
+def test_adopt_rejects_missing_incoming(tmp_path: Path) -> None:
+    with pytest.raises(store.SupplementStoreError, match="does not exist"):
+        store.adopt_manual_files(tmp_path / "store", "10.1038/test", tmp_path / "nope")
+
+
+def test_present_file_does_not_regress_to_listed(tmp_path: Path) -> None:
+    existing = [{"file_id": "a.xlsx", "status": "present", "path": "p/a.xlsx"}]
+    incoming = [{"file_id": "a.xlsx", "status": "listed", "caption": "Tables 1-40"}]
+
+    merged = store._merge_files(existing, incoming)
+
+    assert merged[0]["status"] == "present"
+    assert merged[0]["path"] == "p/a.xlsx"
+    assert merged[0]["caption"] == "Tables 1-40"
+
+
+# ------------------------------------------------------------------
+# Unpacking
+# ------------------------------------------------------------------
+
+
+def _store_with_archive(tmp_path: Path, members: dict[str, bytes]) -> Path:
+    root = tmp_path / "store"
+    files = store.files_dir(root, "10.1038/test")
+    files.mkdir(parents=True)
+    archive = files / "bundle.zip"
+    with zipfile.ZipFile(archive, "w") as zf:
+        for name, payload in members.items():
+            zf.writestr(name, payload)
+    manifest = _minimal_manifest()
+    manifest["files"] = [
+        {
+            "file_id": "bundle.zip",
+            "media_type": "zip",
+            "status": "present",
+            "path": store._rel(root, archive),
+            "size_bytes": archive.stat().st_size,
+        }
+    ]
+    store.write_manifest(root, "10.1038/test", manifest)
+    return root
+
+
+def test_unpack_records_members_and_extracts(tmp_path: Path) -> None:
+    root = _store_with_archive(
+        tmp_path, {"tables/Table 1.csv": b"gene,lfc\nA,1\n", "notes.txt": b"hello"}
+    )
+
+    manifest = store.unpack_archives(root, "10.1038/test")
+
+    members = {m["member_path"]: m for m in manifest["files"][0]["members"]}
+    assert members["tables/Table 1.csv"]["extracted"] is True
+    assert (root / members["tables/Table 1.csv"]["path"]).read_text().startswith("gene")
+    assert manifest.get("gaps", []) == []
+
+
+def test_unpack_skips_oversized_media_but_keeps_big_tables(tmp_path: Path) -> None:
+    root = _store_with_archive(
+        tmp_path,
+        {"big.mp4": b"x" * 2048, "big_table.xlsx": b"y" * 2048},
+    )
+
+    manifest = store.unpack_archives(root, "10.1038/test", size_cap=1024, tabular_size_cap=4096)
+
+    members = {m["member_path"]: m for m in manifest["files"][0]["members"]}
+    assert members["big.mp4"]["extracted"] is False
+    # A large supplementary table is usually the one worth having.
+    assert members["big_table.xlsx"]["extracted"] is True
+    reasons = [gap["reason"] for gap in manifest["gaps"]]
+    assert any("above the 1024-byte cap" in reason for reason in reasons)
+    assert not any("big_table" in gap.get("member_path", "") for gap in manifest["gaps"])
+
+
+def test_unpack_records_nested_archive_as_gap(tmp_path: Path) -> None:
+    root = _store_with_archive(tmp_path, {"inner.zip": b"PK\x03\x04 not really"})
+
+    manifest = store.unpack_archives(root, "10.1038/test")
+
+    gap = next(g for g in manifest["gaps"] if g["member_path"] == "inner.zip")
+    assert "nested archives are not expanded" in gap["reason"]
+    assert "incoming/" in gap["action"]
+
+
+def test_re_unpacking_clears_stale_gaps(tmp_path: Path) -> None:
+    """Raising a cap must retire the gap the old cap produced."""
+    root = _store_with_archive(tmp_path, {"big_table.xlsx": b"y" * 2048})
+
+    tight = store.unpack_archives(root, "10.1038/test", tabular_size_cap=1024)
+    assert len(tight["gaps"]) == 1
+
+    loose = store.unpack_archives(root, "10.1038/test", tabular_size_cap=4096)
+    assert loose["gaps"] == []
+
+
+def test_unpack_refuses_path_traversal(tmp_path: Path) -> None:
+    root = _store_with_archive(tmp_path, {"../escape.csv": b"gene\n"})
+
+    manifest = store.unpack_archives(root, "10.1038/test")
+
+    member = manifest["files"][0]["members"][0]
+    assert member["extracted"] is False
+    assert any("escapes the archive root" in gap["reason"] for gap in manifest["gaps"])
+    assert not (tmp_path / "escape.csv").exists()
+
+
+# ------------------------------------------------------------------
+# Outline
+# ------------------------------------------------------------------
+
+
+def test_outline_xlsx_lists_sheets_and_guesses_header_row(workbook: Path) -> None:
+    outline = store.outline_file(workbook)
+
+    assert [table["locator"] for table in outline["tables"]] == ["Legend", "DEGs"]
+    degs = outline["tables"][1]
+    # Row 0 is the "Supplementary Table 12 | ..." title; the header is row 1.
+    assert degs["header_row_guess"] == 1
+    assert degs["rows"][1] == ["gene", "avg_log2FC", "p_val_adj"]
+    assert degs["n_rows"] == 7
+
+
+def test_outline_is_bounded_by_sample_size(tmp_path: Path) -> None:
+    openpyxl = pytest.importorskip("openpyxl")
+    path = tmp_path / "wide.xlsx"
+    wb = openpyxl.Workbook()
+    sheet = wb.active
+    sheet.append([f"col{i}" for i in range(60)])
+    for row in range(200):
+        sheet.append([row] * 60)
+    wb.save(path)
+
+    outline = store.outline_file(path, sample_rows=3, max_cols=5)
+
+    table = outline["tables"][0]
+    assert len(table["rows"]) == 3
+    assert all(len(row) <= 5 for row in table["rows"])
+    # The real dimensions are still reported.
+    assert table["n_rows"] == 201
+    assert table["n_cols"] == 60
+    assert table["truncated_cols"] is True
+
+
+def test_outline_clips_long_cells(tmp_path: Path) -> None:
+    path = tmp_path / "long.csv"
+    path.write_text("header\n" + "x" * 5000 + "\n")
+
+    table = store.outline_file(path)["tables"][0]
+
+    assert len(table["rows"][1][0]) <= store.OUTLINE_CELL_CHARS + 1
+
+
+def test_outline_delimited_sniffs_tabs(tmp_path: Path) -> None:
+    path = tmp_path / "degs.tsv"
+    path.write_text("gene\tlfc\nA\t1\nB\t2\n")
+
+    table = store.outline_file(path)["tables"][0]
+
+    assert table["delimiter"] == "\t"
+    assert table["n_rows"] == 3
+    assert table["rows"][0] == ["gene", "lfc"]
+
+
+def test_outline_docx_reads_tables(tmp_path: Path) -> None:
+    """Supplementary Information docs carry cluster-annotation tables."""
+    ns = "http://schemas.openxmlformats.org/wordprocessingml/2006/main"
+    document = f"""<?xml version="1.0"?>
+    <w:document xmlns:w="{ns}"><w:body><w:tbl>
+      <w:tr><w:tc><w:p><w:r><w:t>cluster</w:t></w:r></w:p></w:tc>
+             <w:tc><w:p><w:r><w:t>annotation</w:t></w:r></w:p></w:tc></w:tr>
+      <w:tr><w:tc><w:p><w:r><w:t>c1</w:t></w:r></w:p></w:tc>
+             <w:tc><w:p><w:r><w:t>Iron-recycling macrophage</w:t></w:r></w:p></w:tc></w:tr>
+    </w:tbl></w:body></w:document>"""
+    path = tmp_path / "si.docx"
+    with zipfile.ZipFile(path, "w") as zf:
+        zf.writestr("word/document.xml", document)
+
+    tables = store.outline_file(path)["tables"]
+
+    assert len(tables) == 1
+    assert tables[0]["rows"][0] == ["cluster", "annotation"]
+    assert tables[0]["rows"][1][1] == "Iron-recycling macrophage"
+
+
+def test_outline_unsupported_kind_says_so(tmp_path: Path) -> None:
+    path = tmp_path / "figure.png"
+    path.write_bytes(b"\x89PNG")
+
+    outline = store.outline_file(path)
+
+    assert outline["tables"] == []
+    assert "no outline support" in outline["note"]
+
+
+# ------------------------------------------------------------------
+# Slice
+# ------------------------------------------------------------------
+
+
+def test_slice_reads_one_region(workbook: Path) -> None:
+    result = store.read_slice(workbook, locator="DEGs", start=2, limit=2, header_row=1)
+
+    assert result["header"] == ["gene", "avg_log2FC", "p_val_adj"]
+    assert result["returned"] == 2
+    assert result["rows"][0][0] == "GENE0"
+
+
+def test_slice_selects_columns(workbook: Path) -> None:
+    result = store.read_slice(
+        workbook, locator="DEGs", start=2, limit=1, header_row=1, columns=["gene"]
+    )
+
+    assert result["header"] == ["gene"]
+    assert result["rows"] == [["GENE0"]]
+
+
+def test_slice_rejects_unknown_column(workbook: Path) -> None:
+    with pytest.raises(store.SupplementStoreError, match="columns not in header"):
+        store.read_slice(workbook, locator="DEGs", header_row=1, columns=["nope"])
+
+
+def test_slice_rejects_unknown_locator(workbook: Path) -> None:
+    with pytest.raises(store.SupplementStoreError, match="no table 'Missing'"):
+        store.read_slice(workbook, locator="Missing")
+
+
+def test_slice_defaults_to_first_table(tmp_path: Path) -> None:
+    path = tmp_path / "one.csv"
+    path.write_text("gene,lfc\nA,1\n")
+
+    result = store.read_slice(path, start=1, limit=1, header_row=0)
+
+    assert result["header"] == ["gene", "lfc"]
+    assert result["rows"] == [["A", "1"]]
+
+
+# ------------------------------------------------------------------
+# Manifest validation
+# ------------------------------------------------------------------
+
+
+def test_write_manifest_refuses_invalid(tmp_path: Path) -> None:
+    manifest = _minimal_manifest()
+    manifest["files"] = [{"file_id": "a.xlsx", "status": "invented"}]
+
+    with pytest.raises(store.SupplementStoreError, match="manifest invalid"):
+        store.write_manifest(tmp_path, "10.1038/test", manifest)
+
+    assert not store.manifest_path(tmp_path, "10.1038/test").exists()
+
+
+def test_write_manifest_rejects_unknown_field(tmp_path: Path) -> None:
+    manifest = _minimal_manifest()
+    manifest["surprise"] = True
+
+    with pytest.raises(store.SupplementStoreError):
+        store.write_manifest(tmp_path, "10.1038/test", manifest)
+
+
+def test_round_trip(tmp_path: Path) -> None:
+    manifest = _minimal_manifest()
+    manifest["files"] = [
+        {"file_id": "a.xlsx", "status": "present", "path": "papers/x/files/a.xlsx"}
+    ]
+
+    store.write_manifest(tmp_path, "10.1038/test", manifest)
+
+    assert store.load_manifest(tmp_path, "10.1038/test") == manifest
+    assert store.load_manifest(tmp_path, "10.1038/other") is None
+
+
+def test_load_manifest_reports_corrupt_json(tmp_path: Path) -> None:
+    path = store.manifest_path(tmp_path, "10.1038/test")
+    path.parent.mkdir(parents=True)
+    path.write_text("{not json")
+
+    with pytest.raises(store.SupplementStoreError, match="not valid JSON"):
+        store.load_manifest(tmp_path, "10.1038/test")
+
+
+@pytest.mark.parametrize(
+    ("mutate", "expected"),
+    [
+        pytest.param(
+            lambda m: m["files"].append({"file_id": "b.xlsx", "status": "present"}),
+            "no path",
+            id="present-without-path",
+        ),
+        pytest.param(
+            lambda m: m["files"].append(
+                {"file_id": "b.xlsx", "status": "listed", "path": "p/b.xlsx"}
+            ),
+            "but has a path",
+            id="listed-with-path",
+        ),
+        pytest.param(
+            lambda m: m["tables"].append(
+                {
+                    "file_id": "ghost.xlsx",
+                    "content_type": "deg_results",
+                    "description": "d",
+                    "evidence": "headers",
+                }
+            ),
+            "unknown file_id",
+            id="table-points-nowhere",
+        ),
+        pytest.param(
+            lambda m: m["tables"].append(
+                {
+                    "file_id": "bundle.zip",
+                    "content_type": "deg_results",
+                    "description": "d",
+                    "evidence": "headers",
+                }
+            ),
+            "names no member_path",
+            id="archive-without-member",
+        ),
+        pytest.param(
+            lambda m: m["tables"].append(
+                {
+                    "file_id": "bundle.zip",
+                    "member_path": "not/in/archive.xlsx",
+                    "content_type": "deg_results",
+                    "description": "d",
+                    "evidence": "headers",
+                }
+            ),
+            "is not a member of",
+            id="member-not-in-archive",
+        ),
+        pytest.param(
+            lambda m: m["tables"].append(
+                {
+                    "file_id": "missing.xlsx",
+                    "content_type": "marker_list",
+                    "description": "d",
+                    "evidence": "caption",
+                }
+            ),
+            "status 'unavailable'",
+            id="table-on-unavailable-file",
+        ),
+    ],
+)
+def test_cross_check_catches_unusable_manifests(mutate, expected: str) -> None:
+    manifest = _minimal_manifest()
+    manifest["files"] = [
+        {"file_id": "a.xlsx", "status": "present", "path": "p/a.xlsx"},
+        {
+            "file_id": "bundle.zip",
+            "media_type": "zip",
+            "status": "present",
+            "path": "p/bundle.zip",
+            "members": [{"member_path": "tables/Table 1.xlsx"}],
+        },
+        {"file_id": "missing.xlsx", "status": "unavailable"},
+    ]
+    manifest["tables"] = []
+    mutate(manifest)
+
+    # These all satisfy the schema; only the cross-check catches them.
+    store.validate_manifest(manifest)
+    problems = store.cross_check_manifest(manifest)
+
+    assert any(expected in problem for problem in problems), problems
+
+
+def test_cross_check_passes_a_good_manifest() -> None:
+    manifest = _minimal_manifest()
+    manifest["files"] = [
+        {
+            "file_id": "bundle.zip",
+            "media_type": "zip",
+            "status": "present",
+            "path": "p/bundle.zip",
+            "members": [{"member_path": "tables/Table 1.xlsx", "extracted": True}],
+        }
+    ]
+    manifest["tables"] = [
+        {
+            "file_id": "bundle.zip",
+            "member_path": "tables/Table 1.xlsx",
+            "locator": "DEGs",
+            "content_type": "deg_results",
+            "description": "DE of each fine cluster against its broad lineage.",
+            "columns": [{"name": "gene"}, {"name": "avg_log2FC"}],
+            "header_row": 1,
+            "evidence": "headers",
+        }
+    ]
+
+    store.validate_manifest(manifest)
+    assert store.cross_check_manifest(manifest) == []
+
+
+def test_touch_indexed_at(tmp_path: Path) -> None:
+    store.write_manifest(tmp_path, "10.1038/test", _minimal_manifest())
+
+    manifest = store.touch_indexed_at(tmp_path, "10.1038/test")
+
+    assert manifest["indexed_at"].endswith("+00:00")
+    assert store.load_manifest(tmp_path, "10.1038/test")["indexed_at"]
+
+
+# ------------------------------------------------------------------
+# CAS+ integration
+# ------------------------------------------------------------------
+
+
+def test_corpus_papers_takes_atlas_and_subatlases() -> None:
+    cas = {
+        "source": {
+            "doi": "10.1038/atlas",
+            "title": "An atlas",
+            "pmcid": "PMC1",
+            "subatlas_papers": [
+                {"label": "Suo 2022", "doi": "10.1126/science.abo0510"},
+                {"label": "No DOI yet", "status": "unresolved"},
+            ],
+        }
+    }
+
+    papers = store.corpus_papers(cas)
+
+    assert papers[0] == {
+        "doi": "10.1038/atlas",
+        "role": "atlas",
+        "title": "An atlas",
+        "pmcid": "PMC1",
+    }
+    # A subatlas paper with no DOI cannot be keyed, so it is not a store entry.
+    assert [p["doi"] for p in papers] == ["10.1038/atlas", "10.1126/science.abo0510"]
+    assert papers[1]["role"] == "subatlas"
+
+
+def test_corpus_papers_tolerates_a_bare_cas() -> None:
+    assert store.corpus_papers({}) == []
+
+
+# ------------------------------------------------------------------
+# Store layout
+# ------------------------------------------------------------------
+
+
+def test_layout_is_keyed_by_doi_slug(tmp_path: Path) -> None:
+    root = tmp_path / "supplements"
+
+    assert store.paper_dir(root, "10.1038/s41586-024-08002-x").name == (
+        "10.1038_s41586-024-08002-x"
+    )
+    assert store.manifest_path(root, "10.1038/X").name == "manifest.json"
+    assert store.files_dir(root, "10.1038/X").name == "files"
+
+
+@pytest.mark.parametrize(
+    ("name", "expected"),
+    [
+        ("Table 1.xlsx", "xlsx"),
+        ("data.CSV", "csv"),
+        ("notes.tsv", "tsv"),
+        ("si.docx", "docx"),
+        ("bundle.zip", "zip"),
+        ("movie.mp4", "video"),
+        ("panel.tiff", "image"),
+        ("weird.h5ad", "other"),
+    ],
+)
+def test_media_type(name: str, expected: str) -> None:
+    assert store.media_type(name) == expected
+
+
+# ------------------------------------------------------------------
+# CLI
+# ------------------------------------------------------------------
+
+
+def test_cli_inventory(jats_file: Path, capsys: pytest.CaptureFixture) -> None:
+    assert store.main(["inventory", "--jats", str(jats_file)]) == 0
+
+    entries = json.loads(capsys.readouterr().out)
+    assert len(entries) == 3
+
+
+def test_cli_check_reports_bad_manifest(tmp_path: Path, capsys: pytest.CaptureFixture) -> None:
+    path = store.manifest_path(tmp_path, "10.1038/test")
+    path.parent.mkdir(parents=True)
+    manifest = _minimal_manifest()
+    manifest["tables"] = [
+        {
+            "file_id": "ghost.xlsx",
+            "content_type": "other",
+            "description": "d",
+            "evidence": "caption",
+        }
+    ]
+    path.write_text(json.dumps(manifest))
+
+    code = store.main(["check", "--store", str(tmp_path), "--doi", "10.1038/test"])
+
+    assert code == 1
+    assert "unknown file_id" in capsys.readouterr().err
+
+
+def test_cli_check_passes_good_manifest(tmp_path: Path, capsys: pytest.CaptureFixture) -> None:
+    store.write_manifest(tmp_path, "10.1038/test", _minimal_manifest())
+
+    code = store.main(["check", "--store", str(tmp_path), "--doi", "10.1038/test"])
+
+    assert code == 0
+    assert "manifest OK" in capsys.readouterr().out
+
+
+def test_cli_show_missing_manifest_fails(tmp_path: Path, capsys: pytest.CaptureFixture) -> None:
+    code = store.main(["show", "--store", str(tmp_path), "--doi", "10.1038/test"])
+
+    assert code == 1
+    assert "no manifest" in capsys.readouterr().err
+
+
+def test_cli_papers(tmp_path: Path, capsys: pytest.CaptureFixture) -> None:
+    cas = tmp_path / "cas.json"
+    cas.write_text(json.dumps({"source": {"doi": "10.1038/atlas"}}))
+
+    assert store.main(["papers", "--cas", str(cas)]) == 0
+    assert json.loads(capsys.readouterr().out)[0]["role"] == "atlas"
+
+
+# ------------------------------------------------------------------
+# Header detection — shapes taken from real publisher supplements
+# ------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("rows", "expected", "note"),
+    [
+        pytest.param(
+            [
+                ["Prenatal skin metadata"],
+                ["Sanger_id", "Donor", "PCW", "Sorting"],
+                ["4834STDY7002879", "F16", "8", "CD45P"],
+            ],
+            1,
+            "title row above the header",
+            id="title-then-header",
+        ),
+        pytest.param(
+            [
+                ["DEG analysis for macrophage subpopulations"],
+                ["", "LYVE1+ macrophages", "", "", "", "", "", "MHCII macrophages"],
+                ["", "names", "scores", "logfoldchanges", "pvals", "pvals_adj"],
+                ["", "DAB2", "150.68", "4.18", "0", "0"],
+            ],
+            2,
+            "title, then a group-label row, then the header",
+            id="title-group-header",
+        ),
+        pytest.param(
+            [
+                ["Prenatal skin cell DEGs"],
+                ["", "All celltypes, annotation fine"],
+                ["", "genes", "cluster", "top_frac", "frac_diff", "logfoldchanges"],
+                ["0", "AC007381.1", "ASDC", "0.4657", "0.2263", "9.89"],
+            ],
+            2,
+            "header no wider than its data — column count alone picks the data row",
+            id="header-same-width-as-data",
+        ),
+        pytest.param(
+            [
+                ["LR: Reindeer trained_to_Prenatal skin prediction probabilities"],
+                ["", "Original_labels", "LR_assignment", "0", "1", "2", "3", "4"],
+                [
+                    "AAACCTGG-1",
+                    "LYVE1++ macrophage",
+                    "1",
+                    "2.9e-11",
+                    "0.80",
+                    "0.0009",
+                    "0.09",
+                    "0.04",
+                ],
+            ],
+            1,
+            "header whose own column names are numbers",
+            id="numeric-header",
+        ),
+        pytest.param(
+            [["GENE1", "1.2", "0.05"], ["GENE2", "2.4", "0.01"]],
+            0,
+            "no header at all",
+            id="headerless",
+        ),
+        pytest.param([], 0, "empty sample", id="empty"),
+    ],
+)
+def test_header_row_guess(rows: list[list[str]], expected: int, note: str) -> None:
+    assert store._header_row_guess(rows) == expected, note
+
+
+# ------------------------------------------------------------------
+# Text extraction
+# ------------------------------------------------------------------
+
+
+def _docx(path: Path, paragraphs: list[str]) -> Path:
+    ns = "http://schemas.openxmlformats.org/wordprocessingml/2006/main"
+    body = "".join(f"<w:p><w:r><w:t>{text}</w:t></w:r></w:p>" for text in paragraphs)
+    with zipfile.ZipFile(path, "w") as zf:
+        zf.writestr(
+            "word/document.xml",
+            f'<?xml version="1.0"?><w:document xmlns:w="{ns}"><w:body>{body}</w:body></w:document>',
+        )
+    return path
+
+
+def test_extract_text_reads_a_legends_document(tmp_path: Path) -> None:
+    """The legends doc characterises a whole bundle and is prose, not a table."""
+    path = _docx(
+        tmp_path / "legends.docx",
+        [
+            "Supplementary Table 22: DEGs between macrophage subsets.",
+            "Differential expression analysis results between macrophage subsets.",
+        ],
+    )
+
+    result = store.extract_text(path)
+
+    assert "Supplementary Table 22" in result["text"]
+    assert result["truncated"] is False
+    assert result["chars"] == len(result["text"])
+    # outline sees nothing in it, which is why extract_text exists.
+    assert store.outline_file(path)["tables"] == []
+
+
+def test_extract_text_truncates_to_budget(tmp_path: Path) -> None:
+    path = _docx(tmp_path / "long.docx", ["word " * 500] * 20)
+
+    result = store.extract_text(path, max_chars=100)
+
+    assert len(result["text"]) == 100
+    assert result["truncated"] is True
+    assert result["chars"] > 100
+
+
+def test_extract_text_declines_unsupported_kinds(tmp_path: Path) -> None:
+    path = tmp_path / "scan.pdf"
+    path.write_bytes(b"%PDF-1.4")
+
+    result = store.extract_text(path)
+
+    assert result["text"] == ""
+    assert "no text extraction for pdf" in result["note"]
+
+
+@pytest.mark.parametrize("op", ["outline", "text"])
+def test_missing_file_is_an_error_not_an_empty_result(tmp_path: Path, op: str) -> None:
+    """An empty result for a bad path would read as 'this file holds nothing'."""
+    missing = tmp_path / "nope.xlsx"
+
+    with pytest.raises(store.SupplementStoreError, match="no such file"):
+        if op == "outline":
+            store.outline_file(missing)
+        else:
+            store.extract_text(missing)
+
+
+def test_cli_text(tmp_path: Path, capsys: pytest.CaptureFixture) -> None:
+    path = _docx(tmp_path / "legends.docx", ["Supplementary Table 1: Sample metadata."])
+
+    assert store.main(["text", "--file", str(path), "--max-chars", "20"]) == 0
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["truncated"] is True
+    assert len(payload["text"]) == 20

--- a/uv.lock
+++ b/uv.lock
@@ -21,6 +21,7 @@ members = [
 dev = [
     { name = "mypy", specifier = ">=1.10.0" },
     { name = "myst-parser", specifier = ">=2.0.0" },
+    { name = "openpyxl", specifier = ">=3.1" },
     { name = "pre-commit", specifier = ">=3.7.0" },
     { name = "pytest", specifier = ">=8.0.0" },
     { name = "pytest-cov", specifier = ">=4.1.0" },
@@ -254,6 +255,9 @@ local-index = [
     { name = "pymupdf4llm" },
     { name = "sentence-transformers" },
 ]
+supplements = [
+    { name = "openpyxl" },
+]
 
 [package.metadata]
 requires-dist = [
@@ -263,6 +267,7 @@ requires-dist = [
     { name = "jsonschema", specifier = ">=4.22.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.10.0" },
     { name = "numpy", marker = "extra == 'local-index'", specifier = ">=1.26" },
+    { name = "openpyxl", marker = "extra == 'supplements'", specifier = ">=3.1" },
     { name = "pydantic", specifier = ">=2.7.0" },
     { name = "pydantic-ai", specifier = ">=1.16.0" },
     { name = "pymupdf4llm", marker = "extra == 'local-index'", specifier = ">=0.0.17" },
@@ -273,7 +278,7 @@ requires-dist = [
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.5.0" },
     { name = "sentence-transformers", marker = "extra == 'local-index'", specifier = ">=5.0" },
 ]
-provides-extras = ["dev", "local-index"]
+provides-extras = ["dev", "local-index", "supplements"]
 
 [[package]]
 name = "atlas-chat-validation-tools"
@@ -1007,6 +1012,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/f5/22/900cb125c76b7aaa450ce02fd727f452243f2e91a61af068b40adba60ea9/email_validator-2.3.0.tar.gz", hash = "sha256:9fc05c37f2f6cf439ff414f8fc46d917929974a82244c20eb10231ba60c54426", size = 51238, upload-time = "2025-08-26T13:09:06.831Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/de/15/545e2b6cf2e3be84bc1ed85613edd75b8aea69807a71c26f4ca6a9258e82/email_validator-2.3.0-py3-none-any.whl", hash = "sha256:80f13f623413e6b197ae73bb10bf4eb0908faf509ad8362c5edeb0be7fd450b4", size = 35604, upload-time = "2025-08-26T13:09:05.858Z" },
+]
+
+[[package]]
+name = "et-xmlfile"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/38/af70d7ab1ae9d4da450eeec1fa3918940a5fafb9055e934af8d6eb0c2313/et_xmlfile-2.0.0.tar.gz", hash = "sha256:dab3f4764309081ce75662649be815c4c9081e88f0837825f90fd28317d4da54", size = 17234, upload-time = "2024-10-25T17:25:40.039Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/8b/5fe2cc11fee489817272089c4203e679c63b570a5aaeb18d852ae3cbba6a/et_xmlfile-2.0.0-py3-none-any.whl", hash = "sha256:7a91720bc756843502c3b7504c77b8fe44217c85c537d85037f0f536151b2caa", size = 18059, upload-time = "2024-10-25T17:25:39.051Z" },
 ]
 
 [[package]]
@@ -2704,6 +2718,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/02/2e/58d83848dd1a79cb92ed8e63f6ba901ca282c5f09d04af9423ec26c56fd7/openapi_pydantic-0.5.1.tar.gz", hash = "sha256:ff6835af6bde7a459fb93eb93bb92b8749b754fc6e51b2f1590a19dc3005ee0d", size = 60892, upload-time = "2025-01-08T19:29:27.083Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/12/cf/03675d8bd8ecbf4445504d8071adab19f5f993676795708e36402ab38263/openapi_pydantic-0.5.1-py3-none-any.whl", hash = "sha256:a3a09ef4586f5bd760a8df7f43028b60cafb6d9f61de2acba9574766255ab146", size = 96381, upload-time = "2025-01-08T19:29:25.275Z" },
+]
+
+[[package]]
+name = "openpyxl"
+version = "3.1.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "et-xmlfile" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3d/f9/88d94a75de065ea32619465d2f77b29a0469500e99012523b91cc4141cd1/openpyxl-3.1.5.tar.gz", hash = "sha256:cf0e3cf56142039133628b5acffe8ef0c12bc902d2aadd3e0fe5878dc08d1050", size = 186464, upload-time = "2024-06-28T14:03:44.161Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c0/da/977ded879c29cbd04de313843e76868e6e13408a94ed6b987245dc7c8506/openpyxl-3.1.5-py2.py3-none-any.whl", hash = "sha256:5282c12b107bffeef825f4617dc029afaf41d0ea60823bbb665ef3079dc79de2", size = 250910, upload-time = "2024-06-28T14:03:41.161Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Supplement store: index a paper's supplementary material to disk (#21 phase 1)

Supplements carry the DEG tables, cluster-to-name mappings and marker lists a report often can't be written without, and today they're fetched mid-run into agent context. This adds the store half: material on disk, one directory per paper, plus a manifest saying which file, sheet or page holds what.

**Indexing before retrieval, deliberately.** The hard part is knowing what a bundle of forty workbooks contains, and that can be built against files fetched by hand. Retrieval later becomes another route populating the same directory — and a manually supplied file is a first-class route, not a failure, which is the only route available for closed-access papers.

### What's in it

- **`schemas/supplement_manifest.schema.json`** — its own file, not part of `cas.json`: a fetch cache plus a content index, with a `gaps` list so "we didn't look" stays distinguishable from "there's nothing there".
- **`services/supplement_store.py`** behind `python -m atlas_chat.cli_supplements` — `inventory` (from JATS), `adopt`, `unpack`, `outline`, `text`, `slice`, `show`, `check`, `papers`. Store root is an argument and paper identity comes from a DOI or a CAS+ document, so nothing knows this repo's layout. No LLM in the service.
- **`.claude/skills/index-supplements/`** — the reading half: captions → legend document → headers → rows, recording which rung each pointer stopped on.
- **`check_supplement_manifest.py`** — validates on write, importing the schema and cross-field rules from the service rather than restating them. Fires only on `manifest.json` under `supplements/`, so `local_index/` is untouched.
- **`projects/test_projects/`** — the fixture skeleton from the query-decomposer branch plus an `incoming/` drop directory. Manifests tracked, supplement bytes ignored (383 MB on disk vs a 68 KB manifest).

`outline` and `slice` are what keep large files out of context: a 396,880-row table describes itself in bounded output in ~2 s, and a reader that has picked its sheet never loads the rest.

### What running it on Gopee et al. 2024 changed

- A blanket size cap excluded a **95 MB spreadsheet** — both the largest table in the bundle and the one a marker query most wants. Caps are now media-aware (videos 80 MB, spreadsheets 512 MB).
- `outline` returned "no tables" for a **path that didn't exist** — the absence-as-negative-result trap in the code itself. Missing paths now raise.
- The bundle's `Supplementary Table legends.docx` was invisible, because `outline` only read docx *tables*. Added `text`: one ~11k-character read characterises all forty tables, and the workbooks carry no descriptions of their own.
- Header detection now scores text against numbers instead of counting columns. It was picking a *data* row for 6 of 40 tables, because these tables have a title row, sometimes a group-label row, then the header.

Two content findings are recorded in the pointers rather than smoothed over: Supplementary Table 31's legend calls it the upregulated gene list while the sheet's own title row says downregulated, and Supplementary Table 6 has gene symbols mangled into dates (`MARCH1` → `2024-08-07`).

### Testing

64 unit tests (172 in the suite, all passing) and 9 integration tests — live Europe PMC plus the real store, no mocks. Ruff and mypy clean on the new files. The load-bearing test is `test_every_table_pointer_resolves_to_its_recorded_columns`: for all 49 pointers it slices at the recorded `header_row` and checks the recorded columns really are that table's columns. That's the manifest's whole promise, and an off-by-one silently sends a reader into the data.

`openpyxl` is an optional `[supplements]` extra at runtime but also a dev dependency, so the spreadsheet tests run in CI instead of skipping.
