### PR TITLE
Supplement retrieval waterfall (#21 phase 2)

### DIFF
--- a/.claude/skills/index-supplements/SKILL.md
+++ b/.claude/skills/index-supplements/SKILL.md
@@ -60,9 +60,20 @@ uv run python -m atlas_chat.cli_supplements slice \
 uv run python -m atlas_chat.cli_supplements show  --store <store> --doi <doi>
 uv run python -m atlas_chat.cli_supplements check --store <store> --doi <doi>
 
+# Retrieve: article XML -> Europe PMC bundle -> publisher -> manual.
+uv run python -m atlas_chat.cli_supplements fetch \
+  --store <store> --doi <doi> | --cas <cas.json> [--retry] [--no-bundle]
+
+# Judge which stored files could describe cell types, from their columns.
+uv run python -m atlas_chat.cli_supplements triage --store <store> --doi <doi>
+
 # Which papers does a project need supplements for?
 uv run python -m atlas_chat.cli_supplements papers --cas <cas.json>
 ```
+
+The order is **fetch → unpack → triage → index**. Unpacking before triage
+matters: a bundle of forty tables is one opaque item until it is expanded, and
+its members are what get judged.
 
 ## Size limits, and why none of them are silent
 
@@ -104,6 +115,33 @@ Three routes, cheapest first:
    the publisher's static host usually serves them individually. Automated
    retrieval is deliberately out of scope for this skill — if files are missing,
    record a gap saying which ones and let the operator drop them in.
+
+## Triage first: only index what could describe a cell type
+
+The aim is describing cell types, their properties, and the data supporting
+them. Most of a supplement bundle does not bear on that, and deep indexing is
+the expensive step, so run `triage` before you open anything.
+
+Triage writes `relevance` and `relevance_note` on every file and archive member:
+
+- **`irrelevant`** — ruled out, with the reason. Either its caption says what it
+  is ("Reporting Summary", "Peer Review file") or its columns do (a reagent list
+  with a vendor and a catalogue number). Do **not** index these, and do not
+  treat them as gaps: nothing is missing.
+- **`relevant`** — its columns match a known kind: differential expression in any
+  of the usual dialects, cluster-to-name mappings, per-cell tables, enrichment
+  results, cell-cell interactions, sample metadata. The note names the kind, so
+  you start from a hypothesis rather than a blank sheet.
+- **`unknown`** — the cheap signals did not settle it. **Index these.** Roughly
+  40% of a real corpus lands here, mostly PDFs whose columns cannot be read at
+  all. Unknown means "look", never "skip".
+
+The asymmetry is deliberate and worth preserving if you touch `SIGNATURES`: a
+wrong `relevant` costs one wasted inspection, a wrong `irrelevant` silently
+drops evidence. So anything unrecognised is `unknown`.
+
+Expect triage to exclude only around 10% of items by count. Its larger value is
+that it hands you a kind and a reason for about half of what remains.
 
 ## How to index — cheapest evidence first
 

--- a/.claude/skills/index-supplements/SKILL.md
+++ b/.claude/skills/index-supplements/SKILL.md
@@ -67,6 +67,11 @@ uv run python -m atlas_chat.cli_supplements fetch \
 # Judge which stored files could describe cell types, from their columns.
 uv run python -m atlas_chat.cli_supplements triage --store <store> --doi <doi>
 
+# Draft pointers, one per SHEET, with everything mechanical already filled in:
+# locator, header row, dimensions, columns, a suggested kind and a relevance
+# verdict. Add a description to each and that is your `tables` section.
+uv run python -m atlas_chat.cli_supplements triage --store <store> --doi <doi> --sheets
+
 # Which papers does a project need supplements for?
 uv run python -m atlas_chat.cli_supplements papers --cas <cas.json>
 ```
@@ -122,7 +127,11 @@ The aim is describing cell types, their properties, and the data supporting
 them. Most of a supplement bundle does not bear on that, and deep indexing is
 the expensive step, so run `triage` before you open anything.
 
-Triage writes `relevance` and `relevance_note` on every file and archive member:
+Triage writes `relevance` and `relevance_note` at two levels — on each file and
+archive member, and (with `--sheets`) on each **sheet**. Sheet level is the one
+that matters: a 42-sheet supplement routinely holds the DEG table a report needs
+and the antibody list it never will, and a verdict on the file cannot say that.
+Verdicts mean:
 
 - **`irrelevant`** — ruled out, with the reason. Either its caption says what it
   is ("Reporting Summary", "Peer Review file") or its columns do (a reagent list
@@ -142,6 +151,24 @@ drops evidence. So anything unrecognised is `unknown`.
 
 Expect triage to exclude only around 10% of items by count. Its larger value is
 that it hands you a kind and a reason for about half of what remains.
+
+## Start from `--sheets`
+
+`triage --sheets` gives you a draft pointer per sheet with every mechanical field
+already correct: `file_id`, `member_path`, `locator`, `header_row`, `n_rows`,
+`n_columns`, `columns`, a suggested `content_type` and its `relevance`. What is
+missing is `description` — what the table is *for* — which is the judgement you
+are here to make. Add it, set `evidence` to the rung you stopped on, and write
+the list back as `tables`.
+
+Carry the `relevance` through onto the pointer, including for the irrelevant
+ones. A pointer that says "this sheet is an antibody list, irrelevant" is worth
+having: it accounts for the sheet, so a later reader knows it was looked at.
+
+Do check the suggested `content_type` rather than trusting it. It comes from
+column-name patterns, and the patterns collide: a TF-IDF marker table carrying a
+`secondBestClusterName` column was once labelled a cluster-to-name mapping. The
+`relevance_note` names the columns that drove the guess, so it is quick to check.
 
 ## How to index — cheapest evidence first
 

--- a/.claude/skills/index-supplements/SKILL.md
+++ b/.claude/skills/index-supplements/SKILL.md
@@ -32,7 +32,7 @@ querying happens later, against a specific cell type.
 
 Everything that touches bytes is in `atlas_chat.services.supplement_store`,
 behind a CLI. Use it rather than reading supplement files directly: a
-supplementary table can be 400,000 rows wide, and `Read` on one of those wrecks
+supplementary table can run to hundreds of thousands of rows, and `Read` on one wrecks
 your context for no gain.
 
 ```bash
@@ -82,9 +82,9 @@ its members are what get judged.
 
 ## Size limits, and why none of them are silent
 
-Supplementary tables are big — the prenatal skin bundle contains a 95 MB
-spreadsheet of 396,880 rows — so every read here is bounded. That is only safe
-if a bound never looks like an absence, so each one leaves a trace:
+Supplementary tables run to hundreds of thousands of rows, so every read here is
+bounded. That is only safe if a bound never looks like an absence, so each one
+leaves a trace:
 
 | Limit | What it does | The trace it leaves |
 |---|---|---|
@@ -127,30 +127,29 @@ The aim is describing cell types, their properties, and the data supporting
 them. Most of a supplement bundle does not bear on that, and deep indexing is
 the expensive step, so run `triage` before you open anything.
 
-Triage writes `relevance` and `relevance_note` at two levels — on each file and
-archive member, and (with `--sheets`) on each **sheet**. Sheet level is the one
-that matters: a 42-sheet supplement routinely holds the DEG table a report needs
-and the antibody list it never will, and a verdict on the file cannot say that.
-Verdicts mean:
+Triage writes `relevance` and `relevance_note` on each file and archive member,
+and with `--sheets` on each **sheet**. Sheet level is the one that matters: one
+workbook can hold both the DEG table a report needs and an antibody list it
+never will, and a verdict on the file cannot express that. Verdicts mean:
 
-- **`irrelevant`** — ruled out, with the reason. Either its caption says what it
+- **`irrelevant`** — ruled out, with the reason: either its caption says what it
   is ("Reporting Summary", "Peer Review file") or its columns do (a reagent list
-  with a vendor and a catalogue number). Do **not** index these, and do not
-  treat them as gaps: nothing is missing.
-- **`relevant`** — its columns match a known kind: differential expression in any
-  of the usual dialects, cluster-to-name mappings, per-cell tables, enrichment
-  results, cell-cell interactions, sample metadata. The note names the kind, so
-  you start from a hypothesis rather than a blank sheet.
-- **`unknown`** — the cheap signals did not settle it. **Index these.** Roughly
-  40% of a real corpus lands here, mostly PDFs whose columns cannot be read at
-  all. Unknown means "look", never "skip".
+  with a vendor and a catalogue number). Do **not** index these, and do not treat
+  them as gaps — nothing is missing.
+- **`relevant`** — its columns match a known kind: differential expression,
+  marker lists, cluster-to-name mappings, per-cell tables, enrichment,
+  cell-cell interactions, sample metadata. The note names the kind, so you start
+  from a hypothesis rather than a blank sheet.
+- **`unknown`** — the cheap signals did not settle it, most often because the
+  format has no readable columns. **Index these.** Unknown means "look", never
+  "skip".
 
-The asymmetry is deliberate and worth preserving if you touch `SIGNATURES`: a
+Expect triage to rule out only a small fraction outright. Its value is less in
+exclusion than in handing you a kind and a reason for much of what remains.
+
+The asymmetry is deliberate, and worth preserving if you touch `SIGNATURES`: a
 wrong `relevant` costs one wasted inspection, a wrong `irrelevant` silently
 drops evidence. So anything unrecognised is `unknown`.
-
-Expect triage to exclude only around 10% of items by count. Its larger value is
-that it hands you a kind and a reason for about half of what remains.
 
 ## Start from `--sheets`
 
@@ -162,13 +161,12 @@ are here to make. Add it, set `evidence` to the rung you stopped on, and write
 the list back as `tables`.
 
 Carry the `relevance` through onto the pointer, including for the irrelevant
-ones. A pointer that says "this sheet is an antibody list, irrelevant" is worth
-having: it accounts for the sheet, so a later reader knows it was looked at.
+ones. A pointer that says "this sheet is an antibody list, irrelevant" accounts
+for the sheet, so a later reader knows it was looked at.
 
-Do check the suggested `content_type` rather than trusting it. It comes from
-column-name patterns, and the patterns collide: a TF-IDF marker table carrying a
-`secondBestClusterName` column was once labelled a cluster-to-name mapping. The
-`relevance_note` names the columns that drove the guess, so it is quick to check.
+Check the suggested `content_type` rather than trusting it: it comes from
+column-name patterns, and patterns collide. The `relevance_note` names the
+columns that drove the guess, which makes it quick to check.
 
 ## How to index — cheapest evidence first
 

--- a/planning/supplement_corpus_findings_2026-08.md
+++ b/planning/supplement_corpus_findings_2026-08.md
@@ -365,3 +365,46 @@ python -m atlas_chat.cli_supplements triage --store S --doi <doi>
 Manifests are the durable artifact and are committed; the supplement bytes are
 git-ignored. The store used for this report was built at `/tmp/repro_v2` from
 the 22 DOIs listed above and is reproducible from that one `fetch` command.
+
+---
+
+## Appendix: the corpus in full
+
+All 22 papers, in the order they appear in
+`projects/HCA_reproductive_atlas_v1/subatlas_pubs` (the atlas paper first).
+`devcel.2025.09.011` is listed twice in that file; it is counted once here.
+
+*Files* counts supplements retrieved; *skip* those ruled out by caption before
+fetching (reporting summaries, peer review files); *sheets* the sheet-level
+candidates triage produced.
+
+| # | DOI | Publisher | PMCID | Files | Skip | Sheets | Note |
+|---:|---|---|---|---:|---:|---:|---|
+| 1 | `10.64898/2026.06.10.731198` | bioRxiv | — | — | — | — | atlas preprint; non-standard DOI prefix, no PMC record |
+| 2 | `10.1172/jci.insight.195254` | JCI | PMC12892900 | 10 | — | 12 |  |
+| 3 | `10.1038/s41588-021-00972-2` | Springer Nature | PMC8648563 | 4 | 1 | 49 |  |
+| 4 | `10.1038/s41586-022-04918-4` | Springer Nature | PMC9300467 | 4 | 1 | 31 |  |
+| 5 | `10.1126/science.adx0659` | AAAS | — | — | — | — | no PMC record |
+| 6 | `10.1038/s42003-022-04384-8` | Springer Nature | PMC9812973 | 4 | 2 | 5 |  |
+| 7 | `10.1002/ctm2.1219` | Wiley | PMC10040725 | 1 | — | — |  |
+| 8 | `10.1093/cei/uxad029` | Oxford | — | — | — | — | no PMC record |
+| 9 | `10.1126/sciadv.adm7506` | AAAS | PMC10997207 | 2 | — | 16 |  |
+| 10 | `10.1016/j.devcel.2025.09.011` | Cell Press | — | — | — | — | no PMC record (recent) |
+| 11 | `10.1038/s41467-020-20358-y` | Springer Nature | PMC7782707 | 10 | 2 | 56 |  |
+| 12 | `10.1038/s41586-025-09875-2` | Springer Nature | PMC12893920 | 9 | 1 | 37 |  |
+| 13 | `10.1038/s41588-024-01873-w` | Springer Nature | PMC11387200 | 2 | 1 | 9 |  |
+| 14 | `10.1172/jci.insight.153921` | JCI | PMC8983148 | 10 | — | 11 |  |
+| 15 | `10.1016/j.devcel.2024.01.006` | Cell Press | PMC10898717 | 9 | — | 7 |  |
+| 16 | `10.1038/s41556-022-00961-5` | Springer Nature | PMC9901845 | — | — | — | PMC record, no open full text |
+| 17 | `10.1016/j.devcel.2022.02.017` | Cell Press | PMC9007916 | — | — | — | PMC record, no open full text |
+| 18 | `10.1073/pnas.2404775121` | PNAS | PMC11551439 | 17 | — | 64 |  |
+| 19 | `10.1038/s41467-020-14936-3` | Springer Nature | PMC7052271 | 5 | 1 | 9 |  |
+| 20 | `10.1016/j.devcel.2023.07.014` | Cell Press | PMC10615783 | — | — | — | PMC record, no open full text |
+| 21 | `10.1038/s41591-020-1040-z` | Springer Nature | — | — | — | — | no PMC record |
+| 22 | `10.1038/s41467-024-55440-2` | Springer Nature | PMC11698969 | 16 | 2 | 88 |  |
+
+**Totals.** 22 papers, 14 reachable; 103 files retrieved, 11 skipped, 394 sheet candidates.
+
+Titles are omitted deliberately — the DOIs resolve, and Europe PMC is the
+source of record for the metadata. `cli_supplements fetch --cas` over the
+project's CAS+ document reproduces every row.

--- a/planning/supplement_corpus_findings_2026-08.md
+++ b/planning/supplement_corpus_findings_2026-08.md
@@ -1,0 +1,338 @@
+# Supplementary material: what a real corpus looks like
+
+**August 2026.** Findings from building supplement retrieval and indexing (#21)
+against the HCA reproductive atlas corpus — 22 papers across eight publishers —
+with the prenatal skin atlas (Gopee et al. 2024) as a second reference. Every
+number below was measured, not estimated; the code that produced them is
+`services/supplement_{store,fetch,triage}.py` on `feature/supplement-retrieval`.
+
+Written to be reusable: for tuning retrieval and indexing, for the retrieval
+strategy evaluation (ROADMAP §5 B0), and as a source of concrete numbers if any
+of this is published.
+
+---
+
+## 1. The corpus
+
+The atlas paper plus the 21 subatlas DOIs in
+`projects/HCA_reproductive_atlas_v1/subatlas_pubs`:
+
+| Publisher | Papers |
+|---|---|
+| Springer Nature | 10 |
+| Elsevier / Cell Press | 4 |
+| JCI | 2 |
+| AAAS | 2 |
+| Wiley, Oxford, PNAS, bioRxiv | 1 each |
+
+Deliberately not a single-publisher sample — the failure modes below are almost
+all publisher-specific, and two examples from one journal is how we became
+over-confident before.
+
+---
+
+## 2. What is reachable
+
+| Stage | Papers |
+|---|---|
+| In the corpus | 22 |
+| Have a PMC record | 17 |
+| Have a served article XML (so filenames **and** captions) | **14** |
+| Fully retrieved, nothing missing | **14** |
+
+Of 114 files listed across those papers: **103 retrieved, 11 deliberately
+skipped, 0 missing**. 434 MB on disk.
+
+The 8 unreachable papers split into two kinds, and the distinction matters
+because only one of them is fixable by us:
+
+- **5 have no PMC record at all** (a 2025 Science paper, an Oxford paper, a very
+  recent Cell Press paper, a Nature Medicine paper, and the atlas preprint
+  itself). No programmatic route exists.
+- **3 have a PMC record but no open full text.** Europe PMC knows them and flags
+  `hasSuppl`, but serves neither article XML nor supplements.
+
+**Implication.** A corpus of recent, high-profile papers will sit around 60-65%
+programmatic reachability. Setup must treat manual supply as a normal route, not
+an error path, and must say per paper which one it is — "no PMC record" needs a
+human, whereas "closed full text" may open later.
+
+---
+
+## 3. Retrieval routes: what works
+
+Measured route by route.
+
+| Route | Verdict | Evidence |
+|---|---|---|
+| **Article XML** (`fullTextXML`) | Essential, first | The only source of publisher captions; reaches 14/22 |
+| **Europe PMC bundle** (`supplementaryFiles`) | The workhorse | Produced **102 of 103** retrieved files, with no publisher-specific code |
+| **Publisher-direct** | Necessary fallback | Produced 1 file — the one the bundle served corrupt |
+| **NCBI OA package** (`oa.fcgi` → tar.gz) | **Dead** | Advertised for 14/17 PMC papers; every URL 404s over https regardless of licence, ftp returns nothing |
+| **PNAS suppl URLs** | Blocked | HTTP 403 behind bot protection; would need TLS impersonation |
+
+The bundle's virtue is that it needs no per-publisher knowledge: its members are
+named exactly as the article XML lists them, so wanted files can be extracted
+and the figure images that make up most of its bulk discarded. Its costs are
+that it is all-or-nothing per article and occasionally corrupt (§4).
+
+Springer's ESM filename stem turns out to be derivable from the DOI alone
+(`10.1038/s41586-024-08002-x` → `41586_2024_8002_`), verified on 8 of 8 Springer
+papers. That is what makes publisher-direct viable as a fallback without a
+scraping step.
+
+**Bundle sizes** (why there is a cap): most are 10-30 MB; a 34-file PNAS article
+is 197 MB, mostly figure images we discard; the prenatal skin atlas exceeds
+445 MB because of a supplementary video. The cap is 250 MB, and bytes spool to
+disk past 32 MB so a generous cap costs disk rather than RAM.
+
+---
+
+## 4. Failure modes found by running it
+
+None of these are in any documentation. All were found against real papers, and
+each one would have produced a plausible-looking wrong answer.
+
+1. **Europe PMC serves corrupt files.** Its copy of
+   `41588_2021_972_MOESM3_ESM.xlsx` is 18,480,936 bytes where the publisher
+   serves 35,702,391 — truncated so that no zip reader can open it. The bundle
+   member *declares* the truncated size, so extraction succeeds and the file is
+   stored with a checksum. **Every retrieved payload is now verified to be
+   structurally the format it claims**, and a failed check falls through to the
+   next route, which recovered the intact file.
+2. **`HTTP 200` with an empty body.** For a PMC paper whose full text is not
+   open, `supplementaryFiles` returns 165 bytes of non-zip. Stored naively that
+   is an empty archive recorded as success, and the paper looks as though it has
+   no supplements.
+3. **A `.xlsx` extension is a claim, not a fact.** One truncated file raised
+   `BadZipFile` out of openpyxl and killed a whole corpus run.
+4. **Declared spreadsheet dimensions lie in two directions.** openpyxl reports
+   `max_row` as `None` when a workbook carries no dimension record; and a
+   workbook can declare a round extent (`A1:Z1000`) because formatting was
+   applied past the data — a 9-row table claiming 1000 rows. Since `n_rows` is
+   what tells a reader whether to slice or read whole, small declarations are
+   now verified by streaming and large ones trusted (a 396,880-row sheet costs
+   18 s to scan and its declaration is accurate).
+5. **A paper with no article XML was never offered the bundle**, because nothing
+   was listed to want — so closed-full-text-but-open-supplements could not be
+   discovered.
+6. **Header detection degraded with sample size.** Asking to *see* two rows made
+   the header guess look at two rows, so a sheet with two title rows above its
+   header reported row 0. How much a caller wants displayed must not change what
+   is found.
+
+---
+
+## 5. Where the evidence actually is
+
+### Captions
+
+| Caption length | Files | Share |
+|---|---|---|
+| under 40 chars ("Supplementary Information") | 88 | 77% |
+| 40-200 chars | 22 | 19% |
+| 200-1000 | 2 | 2% |
+| over 1000 — effectively a legend | 2 | 2% |
+
+Captions are weak **on average** and occasionally decisive. The caption for
+Garcia-Alonso et al. 2021's supplementary workbook is **6,108 characters and
+describes all 19 tables individually**, which was enough to write pointers for
+all 42 sheets of that file without opening a single one beyond reading headers.
+
+**Implication.** Always read captions — they arrive free with the article XML —
+but never depend on them. And never read an uninformative caption as evidence of
+irrelevance: 77% of files would be wrongly discarded.
+
+### Sheet names
+
+Sheet names are the most consistently useful cheap signal, because they name the
+comparison or the subset: `SupplementalTable2_early-vs-pro`, `MΦ subtype`,
+`FIB subtype`, `SE_up_proliferative`, `jasin_male_filtered_markers_mnn`. Where
+they are uninformative (`Table1`…`Table19c`), a legend usually exists elsewhere.
+
+A separate legends **document** inside the bundle — the Gopee case, where
+`Supplementary Table legends.docx` describes all forty tables in ~11,000
+characters — is rare. Only 13 of 107 spreadsheets have an index-like sheet at
+all, and 12 of those are the same `Abbreviations` sheet repeated across one
+paper's files (a genuine `Column | Description` data dictionary, worth one read
+for all its siblings).
+
+### Column headers
+
+The workhorse. A sheet headed `names / scores / logfoldchanges / pvals_adj` is
+differential expression; `cluster / gene / avg_log2FC / pct.1 / pct.2` is
+per-cell-type markers; `RRID citation / Antibody / Vendor / Cat no` is a reagent
+list. **Dialects matter**: Seurat says `avg_log2FC`, scanpy `logfoldchanges`,
+edgeR/limma `logFC` with `F` and `FDR`, DESeq2 `log2FoldChange` with `baseMean`.
+Matching one dialect leaves most real DEG tables unrecognised — this was the
+first thing the corpus corrected.
+
+---
+
+## 6. What the corpus contains
+
+Recognised content, by paper (of the 14 retrievable):
+
+| Content | Papers |
+|---|---|
+| Differential expression | **11** |
+| Sample / donor metadata | 8 |
+| Per-cell tables (label transfer, predictions) | 2 |
+| Enrichment results | 1 |
+| Marker list | 1 |
+| Cluster-to-name mapping | **1** |
+| Abundance per cell type | 1 |
+
+**The important asymmetry: 11 papers have DEG tables, one has a cluster-to-name
+mapping.** Marker evidence is abundant in supplements; cell-type *naming* is
+almost absent from them. Since name resolution is what the whole downstream flow
+depends on, this is the most consequential finding here.
+
+### Are the mappings in the PDFs?
+
+Tested directly: text extracted from all 21 supplementary PDFs and searched.
+Five showed a cluster-to-name signal; on inspection three were methods prose or
+figure legends about clustering. **Two were real**:
+
+> "Clusters 0 and 9 were annotated as Stromal-1 and Stromal-2; clusters 12, 17,
+> and 20 were annotated as SMC-1, SMC-2 and SMC-3"
+> — jci.insight.153921 supplement
+
+> "According to cell identity annotation and known marker genes … we confirmed
+> that mCL2, mCL6, and mCL14 were Sertoli cells"
+> — devcel.2024.01.006 supplement
+
+The second is exactly the opaque-label case the roadmap names (`mCL2` → Sertoli
+cells). Both are **prose, not tables**.
+
+**Implication.** PDF supplements do not need table extraction; they need their
+text in the snippet index, which already exists for PDFs
+(`services/local_snippet_index.py`). That is a much cheaper mechanism than
+layout reconstruction, and it is the right home for naming evidence. Hit rate is
+low (2/21), so priority stays low — but the payoff is the hardest case in the
+workflow.
+
+---
+
+## 7. Cost
+
+The expensive-looking part is cheap; the cheap-looking part is slow.
+
+| Quantity | Value |
+|---|---|
+| Spreadsheet items to index | 107 (of 131 relevant-or-unknown) |
+| Sheets within them | 394 |
+| Combined rows | 3,299,043 |
+| Digest for the **whole corpus** (names, dimensions, header row, 2 sample rows) | **133 KB ≈ 34k tokens** |
+| Mean digest per file | 1.2 KB ≈ 320 tokens |
+| Largest single file (42 sheets) | 15 KB |
+
+So indexing a 22-paper corpus is **one modest model call per file** — about 107
+calls and 34k tokens of input in total. Retrieval, by contrast, took minutes of
+wall clock, almost all of it waiting on bundle downloads.
+
+**Implication.** Do not price indexing per sheet (394) — price it per file
+(107). And do not optimise indexing cost before retrieval throughput; the
+bottleneck is I/O, and `fetch_corpus` is still serial.
+
+Bounded reads are what make this possible: a 396,880-row × 88-column sheet
+describes itself in about 2 seconds, and no supplement file is ever loaded whole
+into a model's context.
+
+---
+
+## 8. Triage: what it is and isn't worth
+
+Two-stage relevance judgement — captions before fetching, column signatures
+after.
+
+| Verdict | Reproductive atlas | Prenatal skin |
+|---|---|---|
+| relevant | 53% | 65% |
+| unknown | 39% | 24% |
+| irrelevant | **8%** | **13%** |
+
+**Triage excludes little.** On the reproductive corpus the exclusions are 11
+files (8%) and all of them from captions — Reporting Summaries and Peer Review
+files. The column-signature stage excluded nothing there, because that corpus has
+no reagent or gene-set tables; on the prenatal skin bundle it excluded three
+(antibody list, gene-set definitions, and one more).
+
+Its real value is different, and worth stating plainly so it isn't oversold as a
+cost saver: **it hands the indexer a kind and a reason for about half the
+items**, so the model starts from a hypothesis instead of a blank sheet. Roughly
+40% remains `unknown`, most of it PDFs whose columns cannot be read at all.
+
+**The asymmetry to preserve.** A wrong `relevant` costs one wasted inspection; a
+wrong `irrelevant` silently loses evidence. So anything unrecognised is
+`unknown`, and `unknown` is indexed. One near-miss proved the point: the Human
+Protein Atlas secreted-protein table has an `Antibody` column and was ruled a
+reagent list — a wrong answer for a plausible reason. A reagent list now needs a
+supplier column too.
+
+---
+
+## 9. Indexing output, and one schema limitation
+
+Four papers indexed as a sample, chosen to stress different shapes:
+
+| Paper | Files | Pointers | Route to the description |
+|---|---|---|---|
+| jci.insight.195254 | 10 | 10 | Sheet names carried the comparison |
+| s41588-021-00972-2 | 3 | **42** | The 6 KB caption legend, all 42 sheets matched |
+| devcel.2024.01.006 | 7 | 7 | Captions carried the table titles |
+| s41467-024-55440-2 | 18 | 88 | Sheet names plus an `Abbreviations` dictionary |
+
+147 pointers, every manifest schema-valid and cross-check clean.
+
+**Limitation found:** `content_type` is too coarse. Of the 42 pointers for
+Garcia-Alonso, 34 came out `other` — TF activity scores, CellPhoneDB
+interactions, confusion matrices, reagent lists and enrichment results all
+collapse into one value. Descriptions carry the meaning, but the enum cannot be
+used to filter, which is what a query-time consumer will want. Worth extending
+with at least `enrichment`, `interaction` and `reagents`.
+
+**Also:** relevance is recorded per file and per archive member, but not per
+sheet — and a 42-sheet workbook mixes DEG tables with antibody lists. Pointers
+currently carry that distinction implicitly via `content_type` and description.
+If sheet-level filtering matters, relevance belongs on `TablePointer`.
+
+---
+
+## 10. What this says about the strategy
+
+1. **Bundle-first, publisher-direct as a verified fallback.** 102 of 103 files
+   came from a route that needs no publisher-specific code. Resist adding
+   templates until a corpus demands one.
+2. **Verify every payload.** A route returning bytes is not a route returning
+   the file. This is cheap and caught a real corruption.
+3. **Expect a third of a corpus to need a human**, and design setup to say which
+   third and why.
+4. **Captions are free, weak, and occasionally decisive** — always read, never
+   depend, never read silence as irrelevance.
+5. **Indexing is cheap; batch per file.** 34k tokens for 22 papers.
+6. **Retrieval is the bottleneck.** Parallelising `fetch_corpus` is the next real
+   speed-up; it is currently serial.
+7. **Supplements are a marker source, not a naming source.** For naming, route
+   PDF text into the snippet index rather than building table extraction.
+8. **For the retrieval evaluation (§5 B0):** supplements are now on disk for 14
+   of 22 papers, so marker recall can finally be scored per source. Score body
+   text and supplements separately — and stratify by whether the paper was
+   reachable at all, or the arm that happened to draw the 8 unreachable papers
+   will lose for the wrong reason.
+
+---
+
+## Reproducing this
+
+```bash
+# retrieve a corpus from its CAS+ document
+python -m atlas_chat.cli_supplements fetch --store S --cas projects/<p>/cas.json
+python -m atlas_chat.cli_supplements unpack --store S --doi <doi>
+python -m atlas_chat.cli_supplements triage --store S --doi <doi>
+# then the index-supplements skill over what triage returns
+```
+
+Manifests are the durable artifact and are committed; the supplement bytes are
+git-ignored. The store used for this report was built at `/tmp/repro_v2` from
+the 22 DOIs listed above and is reproducible from that one `fetch` command.

--- a/planning/supplement_corpus_findings_2026-08.md
+++ b/planning/supplement_corpus_findings_2026-08.md
@@ -180,13 +180,20 @@ Recognised content, by paper (of the 14 retrievable):
 | Per-cell tables (label transfer, predictions) | 2 |
 | Enrichment results | 1 |
 | Marker list | 1 |
-| Cluster-to-name mapping | **1** |
+| Cluster-to-name mapping | **0** |
 | Abundance per cell type | 1 |
 
-**The important asymmetry: 11 papers have DEG tables, one has a cluster-to-name
+**The important asymmetry: 11 papers have DEG tables, none has a cluster-to-name
 mapping.** Marker evidence is abundant in supplements; cell-type *naming* is
-almost absent from them. Since name resolution is what the whole downstream flow
-depends on, this is the most consequential finding here.
+absent from them entirely. Since name resolution is what the whole downstream
+flow depends on, this is the most consequential finding here.
+
+The count was briefly "1", from a TF-IDF marker table whose
+`secondBestClusterName` column matched a substring test for naming columns. That
+is worth recording as a methodological warning as much as a bug: the field this
+corpus is short of is exactly the field where a loose match manufactures a false
+positive, and a false positive here would have closed the question. Collision-prone
+tokens are now matched against whole column names (`Signature.exact_any_of`).
 
 ### Are the mappings in the PDFs?
 
@@ -246,11 +253,26 @@ into a model's context.
 Two-stage relevance judgement — captions before fetching, column signatures
 after.
 
+Per file / archive member:
+
 | Verdict | Reproductive atlas | Prenatal skin |
 |---|---|---|
 | relevant | 53% | 65% |
 | unknown | 39% | 24% |
 | irrelevant | **8%** | **13%** |
+
+Per **sheet** — 394 of them across the corpus, which is the unit that matters
+for usability:
+
+| Verdict | Sheets | Share |
+|---|---|---|
+| relevant | 231 | 59% |
+| unknown | 151 | 38% |
+| irrelevant | 12 | 3% |
+
+By kind: 148 differential expression, 32 sample metadata, 15 per-cell, 13
+interaction, 12 legend/data-dictionary, 10 reagents, 6 enrichment, 5 marker
+lists, 2 gene-set definitions, 151 unclassified.
 
 **Triage excludes little.** On the reproductive corpus the exclusions are 11
 files (8%) and all of them from captions — Reporting Summaries and Peer Review
@@ -285,17 +307,24 @@ Four papers indexed as a sample, chosen to stress different shapes:
 
 147 pointers, every manifest schema-valid and cross-check clean.
 
-**Limitation found:** `content_type` is too coarse. Of the 42 pointers for
-Garcia-Alonso, 34 came out `other` — TF activity scores, CellPhoneDB
-interactions, confusion matrices, reagent lists and enrichment results all
-collapse into one value. Descriptions carry the meaning, but the enum cannot be
-used to filter, which is what a query-time consumer will want. Worth extending
-with at least `enrichment`, `interaction` and `reagents`.
+**Both limitations found here have since been closed.**
 
-**Also:** relevance is recorded per file and per archive member, but not per
-sheet — and a 42-sheet workbook mixes DEG tables with antibody lists. Pointers
-currently carry that distinction implicitly via `content_type` and description.
-If sheet-level filtering matters, relevance belongs on `TablePointer`.
+`content_type` was too coarse: of the 42 pointers for Garcia-Alonso, 34 came out
+`other`, collapsing TF activity scores, CellPhoneDB interactions, confusion
+matrices, reagent lists and enrichment results into one value. The enum gained
+`enrichment`, `interaction`, `gene_set` and `reagents`, and with signatures for
+the shapes those take (regulon activity via `NES`; interaction matrices whose
+columns are cell-type *pairs*, `SOX9_LGR5--Preciliated`; CellPhoneDB's
+`partner_a`/`partner_b` schema; reagent lists that say "Company" rather than
+"Vendor") the same file now yields 25 `other` out of 49 sheets rather than 34 out
+of 42, and `relevant` rose from 8 sheets to 17.
+
+Relevance is now recorded per **sheet**, on `TablePointer`, as well as per file
+and member. This is the change that makes the manifest usable: the alternative
+was a single verdict for a workbook that holds both a DEG table and an antibody
+list. Irrelevant sheets still get a pointer, so they are accounted for rather
+than silently absent, and `triage --sheets` emits a draft pointer per sheet with
+every mechanical field filled in — the indexer supplies only the description.
 
 ---
 

--- a/src/atlas_chat/atlas_chat/schemas/supplement_manifest.schema.json
+++ b/src/atlas_chat/atlas_chat/schemas/supplement_manifest.schema.json
@@ -216,7 +216,7 @@
     },
     "TablePointer": {
       "type": "object",
-      "description": "A table worth reading, located precisely enough to slice without searching. Describes the table and its columns; it deliberately does NOT enumerate which cell types appear (that is the reader's job at query time).",
+      "description": "A table worth reading, located precisely enough to slice without searching, and carrying its own relevance verdict. One pointer per table \u2014 a sheet, not a workbook \u2014 because a 42-sheet supplement routinely mixes differential expression with antibody lists, and a verdict on the file as a whole cannot express that. Describes the table and its columns; it deliberately does NOT enumerate which cell types appear (a query-time question).",
       "properties": {
         "file_id": {
           "type": "string",
@@ -236,16 +236,33 @@
         },
         "content_type": {
           "type": "string",
-          "description": "What kind of table this is. 'legend' is the manifest/contents sheet that describes the others \u2014 worth reading first.",
+          "description": "What kind of table this is. 'deg_results' differential expression; 'marker_list' asserted markers; 'cluster_annotation' a cluster-to-name mapping; 'cell_metadata' one row per cell; 'sample_metadata' one row per sample or donor; 'enrichment' GSEA/GO results; 'interaction' ligand-receptor or cell-cell interactions; 'gene_set' the gene lists an analysis consumed (an input, not a finding); 'reagents' antibodies, primers and probes; 'legend' the contents or data-dictionary sheet that describes the others \u2014 worth reading first. 'other' is a real answer, not a default: use it when the table is none of these.",
           "enum": [
             "deg_results",
             "marker_list",
             "cluster_annotation",
             "cell_metadata",
             "sample_metadata",
+            "enrichment",
+            "interaction",
+            "gene_set",
+            "reagents",
             "legend",
             "other"
           ]
+        },
+        "relevance": {
+          "type": "string",
+          "description": "Whether THIS TABLE bears on describing cell types, their properties or the data supporting them. Recorded per table because relevance varies within a file: the same workbook holds the DEG table a report needs and the antibody list it never will. 'irrelevant' is a positive finding \u2014 the pointer still exists so the table is accounted for rather than silently absent.",
+          "enum": [
+            "relevant",
+            "irrelevant",
+            "unknown"
+          ]
+        },
+        "relevance_note": {
+          "type": "string",
+          "description": "What the verdict was based on, e.g. 'caption: Peer Review file', 'columns: names/logfoldchanges/pvals_adj -> DEG results'. Keeps the judgement auditable and re-runnable."
         },
         "description": {
           "type": "string",

--- a/src/atlas_chat/atlas_chat/schemas/supplement_manifest.schema.json
+++ b/src/atlas_chat/atlas_chat/schemas/supplement_manifest.schema.json
@@ -142,6 +142,11 @@
           "type": "string",
           "format": "date-time"
         },
+        "attempted_at": {
+          "type": "string",
+          "format": "date-time",
+          "description": "When a route was last tried and did NOT produce bytes. This is the negative cache: a file that is 'unavailable' or 'failed' with this set is not retried on a later run unless a retry is asked for, which is what stops a missing supplement being re-requested on every pass."
+        },
         "sha256": {
           "type": "string",
           "description": "Digest of the file as stored, so a re-index can tell whether the bytes changed.",

--- a/src/atlas_chat/atlas_chat/schemas/supplement_manifest.schema.json
+++ b/src/atlas_chat/atlas_chat/schemas/supplement_manifest.schema.json
@@ -112,6 +112,19 @@
           "items": {
             "$ref": "#/$defs/ArchiveMember"
           }
+        },
+        "relevance": {
+          "type": "string",
+          "description": "Whether this file bears on describing cell types, their properties, or the data supporting them \u2014 the only reason this store exists. 'irrelevant' is a positive finding, not a failure to look: it is what stops a 13 MB peer-review PDF being re-examined on every pass and explains why a stored file has no table pointers. 'unknown' means the cheap signals did not settle it and a reader should.",
+          "enum": [
+            "relevant",
+            "irrelevant",
+            "unknown"
+          ]
+        },
+        "relevance_note": {
+          "type": "string",
+          "description": "What the verdict was based on, e.g. 'caption: Peer Review file', 'columns: names/logfoldchanges/pvals_adj -> DEG results'. Keeps the judgement auditable and re-runnable."
         }
       },
       "required": [
@@ -181,6 +194,19 @@
         },
         "extracted": {
           "type": "boolean"
+        },
+        "relevance": {
+          "type": "string",
+          "description": "Whether this file bears on describing cell types, their properties, or the data supporting them \u2014 the only reason this store exists. 'irrelevant' is a positive finding, not a failure to look: it is what stops a 13 MB peer-review PDF being re-examined on every pass and explains why a stored file has no table pointers. 'unknown' means the cheap signals did not settle it and a reader should.",
+          "enum": [
+            "relevant",
+            "irrelevant",
+            "unknown"
+          ]
+        },
+        "relevance_note": {
+          "type": "string",
+          "description": "What the verdict was based on, e.g. 'caption: Peer Review file', 'columns: names/logfoldchanges/pvals_adj -> DEG results'. Keeps the judgement auditable and re-runnable."
         }
       },
       "required": [

--- a/src/atlas_chat/atlas_chat/services/supplement_fetch.py
+++ b/src/atlas_chat/atlas_chat/services/supplement_fetch.py
@@ -54,6 +54,7 @@ import re
 import tempfile
 import urllib.parse
 import zipfile
+from collections import Counter
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
@@ -95,6 +96,7 @@ BUNDLE_SPOOL_TO_DISK_BYTES = 32 * 1024 * 1024
 #: Never treated as supplementary content worth storing. Europe PMC's bundle
 #: includes the article's figure images, which are most of its bulk.
 FIGURE_SUFFIXES = {".gif", ".jpg", ".jpeg", ".png", ".tif", ".tiff"}
+
 
 TIMEOUT = httpx.Timeout(30.0, read=180.0)
 
@@ -220,6 +222,60 @@ def fetch_bundle(
 
 def _is_figure(name: str) -> bool:
     return Path(name).suffix.lower() in FIGURE_SUFFIXES
+
+
+#: Formats whose first bytes let us check that a payload is what it claims.
+#: xlsx and docx are zip containers; a PDF starts with %PDF.
+ZIP_CONTAINER_TYPES = {"xlsx", "docx", "zip"}
+
+
+def verify_payload(path: Path, media: str) -> tuple[bool, str]:
+    """Check that retrieved bytes are structurally the format they claim.
+
+    A route can hand back a file that is the wrong size and unopenable, and
+    Europe PMC does: its bundle for PMC8648563 carries an 18.5 MB copy of a
+    workbook the publisher serves at 35.7 MB, truncated so that no zip reader
+    can open it. Extracted faithfully and recorded with a checksum, that looks
+    authoritative and only fails much later, during indexing.
+
+    Cheap enough to run on every file — it reads a header, or a zip's central
+    directory, not the payload.
+
+    Returns:
+        ``(ok, note)``; the note names the problem when ok is False.
+    """
+    try:
+        size = path.stat().st_size
+    except OSError as exc:
+        return False, f"not readable: {exc}"
+    if size == 0:
+        return False, "zero bytes"
+
+    if media in ZIP_CONTAINER_TYPES:
+        if not zipfile.is_zipfile(path):
+            return False, (
+                f"claims to be {media} but is not a readable zip container "
+                f"({size} bytes) — truncated or corrupt at source"
+            )
+    elif media == "pdf":
+        with path.open("rb") as handle:
+            if handle.read(5) != b"%PDF-":
+                return False, f"claims to be a PDF but has no %PDF header ({size} bytes)"
+    return True, "ok"
+
+
+def is_non_evidence(entry: dict[str, Any]) -> bool:
+    """Whether a file's own caption rules it out before any bytes move.
+
+    Only the certain cases — a Reporting Summary or a Peer Review file cannot
+    describe a cell type. The list lives in
+    :mod:`atlas_chat.services.supplement_triage`, which owns what counts as
+    relevant; this is the same judgement applied earlier, where it saves a
+    download rather than an inspection.
+    """
+    from atlas_chat.services.supplement_triage import classify_caption
+
+    return classify_caption(entry) is not None
 
 
 # ------------------------------------------------------------------
@@ -398,10 +454,26 @@ def _fetch(
     if listed:
         manifest["files"] = _merge_files(manifest.get("files", []), listed)
 
+    skipped = 0
+    for entry in manifest.get("files", []):
+        if entry.get("status") == "listed" and is_non_evidence(entry):
+            entry["status"] = "skipped"
+            entry["retrieval"] = {
+                "route": "none",
+                "note": "publishing artefact by its own caption, not evidence",
+            }
+            entry["relevance"] = "irrelevant"
+            entry["relevance_note"] = f"caption: {entry.get('caption') or entry.get('label')}"
+            skipped += 1
+    if skipped:
+        logger.info("%s: skipping %d process artefact(s)", doi, skipped)
+
     wanted = [
         entry
         for entry in manifest.get("files", [])
-        if should_attempt(entry, retry) and media_type(entry["file_id"]) != "video"
+        if should_attempt(entry, retry)
+        and entry.get("status") != "skipped"
+        and media_type(entry["file_id"]) != "video"
     ]
     logger.info("%s: %d file(s) to fetch", doi, len(wanted))
 
@@ -423,6 +495,18 @@ def _fetch(
                     dest.parent.mkdir(parents=True, exist_ok=True)
                     with archive.open(info) as src, dest.open("wb") as out:
                         out.write(src.read())
+                    ok, note = verify_payload(dest, media_type(entry["file_id"]))
+                    if not ok:
+                        # Leave it for the next route rather than storing bytes
+                        # nothing can open.
+                        logger.warning("  %s from bundle: %s", entry["file_id"], note)
+                        dest.unlink(missing_ok=True)
+                        entry["retrieval"] = {
+                            "route": "europepmc_bundle",
+                            "attempted_at": _now(),
+                            "note": note,
+                        }
+                        continue
                     _mark_present(entry, store_root, doi, dest, "europepmc_bundle", url=None)
                 # Files in the bundle the article XML never mentioned: keep them,
                 # since a supplement absent from the listing is still a supplement.
@@ -444,8 +528,11 @@ def _fetch(
         dest = files_dir(store_root, doi) / entry["file_id"]
         ok, note = fetch_one_file(client, url, dest)
         if ok:
+            ok, note = verify_payload(dest, media_type(entry["file_id"]))
+        if ok:
             _mark_present(entry, store_root, doi, dest, "publisher_direct", url=url)
         else:
+            dest.unlink(missing_ok=True)
             entry["status"] = "failed"
             entry["retrieval"] = {
                 "route": "publisher_direct",
@@ -573,14 +660,19 @@ def fetch_corpus(
                     retry=retry,
                     client=client,
                 )
+                files = manifest.get("files", [])
+                counted = Counter(f.get("status", "?") for f in files)
                 out.append(
                     {
                         "doi": paper["doi"],
                         "role": paper.get("role"),
-                        "files": len(manifest.get("files", [])),
-                        "present": sum(
-                            1 for f in manifest.get("files", []) if f.get("status") == "present"
-                        ),
+                        "files": len(files),
+                        "present": counted["present"],
+                        # Deliberately skipped is not a shortfall: counting it as
+                        # one makes a paper whose only miss was a peer-review PDF
+                        # look incomplete.
+                        "skipped": counted["skipped"],
+                        "missing": counted["failed"] + counted["unavailable"] + counted["listed"],
                         "gaps": len(manifest.get("gaps", [])),
                     }
                 )

--- a/src/atlas_chat/atlas_chat/services/supplement_fetch.py
+++ b/src/atlas_chat/atlas_chat/services/supplement_fetch.py
@@ -1,0 +1,590 @@
+"""Retrieve a paper's supplementary material into the supplement store.
+
+The companion to :mod:`atlas_chat.services.supplement_store`, which owns disk
+layout and the manifest. This module only gets bytes, and records how it got
+them (or why it couldn't) in the manifest the store already defines.
+
+The waterfall
+-------------
+
+The order below is not a guess; it comes from probing the 22 papers of the
+reproductive-atlas corpus (Springer Nature, Cell Press, AAAS, JCI, Wiley,
+Oxford, PNAS, and a bioRxiv preprint):
+
+1. **Article XML** (``jats_listing``). Europe PMC's ``fullTextXML`` yields the
+   filenames *and* the publisher's captions, which exist nowhere else and often
+   describe the contents better than anything recoverable from the bytes.
+   Available for 14 of 22.
+2. **Europe PMC bundle** (``europepmc_bundle``). One zip per article, whose
+   members are named exactly as the article XML lists them, so wanted files can
+   be extracted and the figure images that bloat the zip skipped. Its virtue is
+   that it needs no per-publisher knowledge at all. Streamed under a byte cap:
+   observed 14–28 MB for most papers, but a 34-file PNAS paper exceeded 60 MB
+   and the prenatal skin atlas exceeds 445 MB because of a supplementary video.
+3. **Publisher-direct** (``publisher_direct``). Per-file, needing a URL template
+   per publisher. Only Springer Nature is implemented, because its ESM stem is
+   derivable from the DOI alone (verified on 8 of 8 Springer papers in the
+   corpus) — for others, a template can be added when a corpus needs it.
+4. **Manual** (``manual``). Recorded as a gap naming the file and where to get
+   it. The only route for the 5 corpus papers with no PMC record at all, and for
+   closed-access papers generally.
+
+Two traps this module exists to avoid
+-------------------------------------
+
+*The bundle endpoint returns HTTP 200 with an empty body* for a PMC paper whose
+full text is not open — 165 bytes, not a zip. Written naively that is an empty
+archive recorded as a success, and the paper looks like it has no supplements.
+It is detected and recorded as ``unavailable``.
+
+*A missing supplement asked for on every run.* Every route that fails stamps
+``retrieval.attempted_at``, and a later run skips it unless a retry is
+requested. That is the negative cache.
+
+.. code-block:: bash
+
+    python -m atlas_chat.cli_supplements fetch --store S --doi 10.1038/...
+    python -m atlas_chat.cli_supplements fetch --store S --cas projects/X/cas.json
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import tempfile
+import urllib.parse
+import zipfile
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import httpx
+
+from atlas_chat.services.supplement_store import (
+    MANIFEST_VERSION,
+    SupplementStoreError,
+    _dedupe_gaps,
+    _merge_files,
+    _rel,
+    _sha256,
+    files_dir,
+    inventory_from_jats,
+    load_manifest,
+    media_type,
+    paper_dir,
+    write_manifest,
+)
+
+logger = logging.getLogger(__name__)
+
+EUROPEPMC = "https://www.ebi.ac.uk/europepmc/webservices/rest"
+
+#: Ceiling on the Europe PMC bundle. Measured over the reproductive-atlas
+#: corpus: most bundles are 10-30 MB, a 34-file PNAS article is 197 MB (mostly
+#: figure images, which we then discard), and the prenatal skin atlas exceeds
+#: 445 MB because of a supplementary video. 250 MB therefore keeps every corpus
+#: paper reachable while still refusing the video outliers, which are better
+#: served per-file. Above the cap the download is abandoned and the next route
+#: takes over.
+DEFAULT_BUNDLE_CAP_BYTES = 250 * 1024 * 1024
+
+#: Bundle bytes are spooled to disk beyond this, so a generous cap costs disk
+#: rather than RAM.
+BUNDLE_SPOOL_TO_DISK_BYTES = 32 * 1024 * 1024
+
+#: Never treated as supplementary content worth storing. Europe PMC's bundle
+#: includes the article's figure images, which are most of its bulk.
+FIGURE_SUFFIXES = {".gif", ".jpg", ".jpeg", ".png", ".tif", ".tiff"}
+
+TIMEOUT = httpx.Timeout(30.0, read=180.0)
+
+
+class SupplementFetchError(RuntimeError):
+    """Raised when a fetch cannot proceed at all (bad DOI, no network)."""
+
+
+def _now() -> str:
+    return datetime.now(UTC).isoformat(timespec="seconds")
+
+
+# ------------------------------------------------------------------
+# Identifiers and the article XML
+# ------------------------------------------------------------------
+
+
+def resolve_pmcid(client: httpx.Client, doi: str) -> tuple[str, str]:
+    """Resolve a DOI to its PMCID via Europe PMC.
+
+    Returns:
+        ``(pmcid, title)``; the PMCID is empty when Europe PMC has no PMC record,
+        which is the signal that only a manual route remains.
+    """
+    resp = client.get(
+        f"{EUROPEPMC}/search",
+        params={"query": f'DOI:"{doi}"', "format": "json", "pageSize": 1, "resultType": "core"},
+    )
+    resp.raise_for_status()
+    results = resp.json().get("resultList", {}).get("result", [])
+    if not results:
+        logger.info("%s: not in Europe PMC", doi)
+        return "", ""
+    record = results[0]
+    pmcid = record.get("pmcid") or ""
+    logger.info("%s -> %s", doi, pmcid or "(no PMCID)")
+    return pmcid, record.get("title") or ""
+
+
+def fetch_jats(client: httpx.Client, pmcid: str, dest: Path) -> Path | None:
+    """Save the article XML, the source of both filenames and captions.
+
+    Returns None when Europe PMC has the record but not its full text — a real
+    case in the corpus (3 of 17 PMC papers), and the point at which the caption
+    route is gone even though a PMCID exists.
+    """
+    resp = client.get(f"{EUROPEPMC}/{pmcid}/fullTextXML")
+    if resp.status_code != 200:
+        logger.info("%s: fullTextXML %s — no article XML, so no captions", pmcid, resp.status_code)
+        return None
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    dest.write_text(resp.text, encoding="utf-8")
+    return dest
+
+
+# ------------------------------------------------------------------
+# Route: Europe PMC bundle
+# ------------------------------------------------------------------
+
+
+class BundleResult:
+    """Outcome of one bundle attempt.
+
+    ``archive`` is None unless bytes arrived and parsed as a zip; ``reason``
+    always explains what happened, because that string ends up in the manifest.
+    """
+
+    def __init__(self, archive: zipfile.ZipFile | None, reason: str, size: int = 0):
+        self.archive = archive
+        self.reason = reason
+        self.size = size
+
+
+def fetch_bundle(
+    client: httpx.Client, pmcid: str, cap: int = DEFAULT_BUNDLE_CAP_BYTES
+) -> BundleResult:
+    """Stream the article's supplement bundle, abandoning it above ``cap``.
+
+    Europe PMC serves every supplement for an article as one zip with no way to
+    select files, so the only protection against a half-gigabyte download is to
+    stop reading. The stream spools to a temporary file past
+    ``BUNDLE_SPOOL_TO_DISK_BYTES``, so a 197 MB bundle costs disk rather than
+    RAM and the cap can stay generous.
+    """
+    # Not a context manager: on success the buffer is handed to a ZipFile that
+    # the caller reads from, so it must outlive this function. The ZipFile keeps
+    # it alive and closing that releases it.
+    buffer = tempfile.SpooledTemporaryFile(  # noqa: SIM115
+        max_size=BUNDLE_SPOOL_TO_DISK_BYTES
+    )
+    url = f"{EUROPEPMC}/{pmcid}/supplementaryFiles"
+    with client.stream("GET", url) as resp:
+        if resp.status_code != 200:
+            return BundleResult(None, f"bundle returned HTTP {resp.status_code}")
+        for chunk in resp.iter_bytes(1 << 20):
+            buffer.write(chunk)
+            if buffer.tell() > cap:
+                return BundleResult(
+                    None,
+                    f"bundle exceeds the {cap}-byte cap (still growing at "
+                    f"{buffer.tell()} bytes); abandoned",
+                    buffer.tell(),
+                )
+
+    size = buffer.tell()
+    if size == 0:
+        return BundleResult(None, "bundle is empty (HTTP 200, zero bytes)", 0)
+
+    buffer.seek(0)
+    if not zipfile.is_zipfile(buffer):
+        # The endpoint answers 200 with a short non-zip body for PMC papers whose
+        # full text is not open. Recording that as success would make the paper
+        # look as though it has no supplements.
+        return BundleResult(
+            None,
+            f"bundle is not a zip ({size} bytes) — Europe PMC has no open "
+            "supplementary files for this article",
+            size,
+        )
+    buffer.seek(0)
+    return BundleResult(zipfile.ZipFile(buffer), "ok", size)
+
+
+def _is_figure(name: str) -> bool:
+    return Path(name).suffix.lower() in FIGURE_SUFFIXES
+
+
+# ------------------------------------------------------------------
+# Route: publisher-direct
+# ------------------------------------------------------------------
+
+
+def springer_url(doi: str, filename: str) -> str | None:
+    """Springer Nature's static host, which serves ESM files individually.
+
+    Worth having even though the bundle needs no templates: Springer articles
+    are the bulk of most corpora, and this fetches one 122 KB workbook where the
+    bundle would fetch everything around it.
+    """
+    if not doi.startswith("10.1038/"):
+        return None
+    quoted = urllib.parse.quote(f"art:{doi}", safe="")
+    return f"https://static-content.springer.com/esm/{quoted}/MediaObjects/{filename}"
+
+
+def springer_esm_stem(doi: str) -> str | None:
+    """The ESM filename stem implied by a Springer DOI.
+
+    ``10.1038/s41586-024-08002-x`` -> ``41586_2024_8002_``. The DOI carries a
+    three-digit year and a zero-padded article number, both of which the
+    filename renders differently; verified against 8 of 8 Springer papers in the
+    reproductive-atlas corpus. Only needed when the article XML is unavailable
+    and filenames must be guessed rather than read.
+    """
+    match = re.match(r"10\.1038/s(\d+)-(\d{3})-(\d+)-", doi)
+    if not match:
+        return None
+    journal, year, article = match.groups()
+    return f"{journal}_2{year}_{int(article)}_"
+
+
+#: DOI prefix -> URL builder. Add a publisher when a corpus needs one; the
+#: bundle route covers most cases without any of this.
+PUBLISHER_URL_BUILDERS = {"10.1038": springer_url}
+
+
+def publisher_direct_url(doi: str, filename: str) -> str | None:
+    """URL for one supplement on its publisher's host, if we know the shape."""
+    builder = PUBLISHER_URL_BUILDERS.get(doi.split("/")[0])
+    return builder(doi, filename) if builder else None
+
+
+def fetch_one_file(client: httpx.Client, url: str, dest: Path) -> tuple[bool, str]:
+    """Download one file. Returns ``(ok, note)``."""
+    try:
+        with client.stream("GET", url) as resp:
+            if resp.status_code != 200:
+                return False, f"HTTP {resp.status_code}"
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            with dest.open("wb") as handle:
+                for chunk in resp.iter_bytes(1 << 20):
+                    handle.write(chunk)
+    except httpx.HTTPError as exc:
+        return False, f"{type(exc).__name__}: {exc}"
+    return True, "ok"
+
+
+# ------------------------------------------------------------------
+# The negative cache
+# ------------------------------------------------------------------
+
+
+def should_attempt(entry: dict[str, Any], retry: bool) -> bool:
+    """Whether to try fetching this file now.
+
+    A file already on disk is never re-fetched. A file whose routes were tried
+    and failed is not retried either, unless asked — that is what keeps a
+    permanently missing supplement from being requested on every run. Passing
+    ``retry`` ignores the cache, which is what you want after a publisher fixes
+    a broken link or a paper goes open access.
+    """
+    if entry.get("status") == "present":
+        return False
+    if retry:
+        return True
+    return not entry.get("retrieval", {}).get("attempted_at")
+
+
+# ------------------------------------------------------------------
+# The waterfall
+# ------------------------------------------------------------------
+
+
+def fetch_supplements(
+    store_root: Path,
+    doi: str,
+    bundle_cap: int = DEFAULT_BUNDLE_CAP_BYTES,
+    use_bundle: bool = True,
+    retry: bool = False,
+    client: httpx.Client | None = None,
+) -> dict[str, Any]:
+    """Retrieve what can be retrieved for one paper, and record the rest.
+
+    Walks the routes in the module docstring's order, writing every outcome into
+    the paper's manifest: bytes on disk with the route that produced them, or a
+    status and a ``gaps`` entry saying what a human would have to do. It never
+    raises for an unreachable paper — being unable to fetch a closed-access
+    supplement is an expected result, not an error.
+
+    Args:
+        store_root: Store root; the paper's directory is created under it.
+        doi: Paper to fetch for.
+        bundle_cap: Byte ceiling on the Europe PMC bundle.
+        use_bundle: Set False to skip the bundle route entirely (useful when you
+            know the article is one of the video-carrying outliers).
+        retry: Ignore the negative cache and try previously failed files again.
+        client: An open httpx client, for callers batching many papers.
+
+    Returns:
+        The manifest, written to disk.
+    """
+    owns_client = client is None
+    client = client or httpx.Client(follow_redirects=True, timeout=TIMEOUT)
+    try:
+        return _fetch(store_root, doi, bundle_cap, use_bundle, retry, client)
+    finally:
+        if owns_client:
+            client.close()
+
+
+def _fetch(
+    store_root: Path,
+    doi: str,
+    bundle_cap: int,
+    use_bundle: bool,
+    retry: bool,
+    client: httpx.Client,
+) -> dict[str, Any]:
+    manifest = load_manifest(store_root, doi) or {
+        "manifest_version": MANIFEST_VERSION,
+        "paper": {"doi": doi},
+        "files": [],
+    }
+    # Gaps carry over between runs, so they are deduplicated on write and any
+    # gap about a file we have since retrieved is retired. A marker field would
+    # be cleaner but the schema (rightly) rejects unknown keys.
+    prior_gaps: list[dict[str, Any]] = list(manifest.get("gaps", []))
+    gaps: list[dict[str, Any]] = []
+    bundle_failure: str | None = None
+
+    pmcid, _title = resolve_pmcid(client, doi)
+    if pmcid:
+        manifest["paper"]["pmcid"] = pmcid
+
+    # --- route 1: the article XML, for filenames and captions ---------
+    listed: list[dict[str, Any]] = []
+    if pmcid:
+        jats = fetch_jats(client, pmcid, paper_dir(store_root, doi) / "source" / "paper.jats.xml")
+        if jats is not None:
+            listed = inventory_from_jats(jats)
+        else:
+            gaps.append(
+                {
+                    "file_id": doi,
+                    "reason": (
+                        f"Europe PMC has {pmcid} but serves no article XML, so the "
+                        "publisher's supplement filenames and captions are unavailable"
+                    ),
+                    "action": "drop the supplements into incoming/ and run adopt",
+                }
+            )
+    else:
+        gaps.append(
+            {
+                "file_id": doi,
+                "reason": "no PMC record in Europe PMC, so no programmatic route exists",
+                "action": f"download from https://doi.org/{doi} into incoming/ and run adopt",
+            }
+        )
+
+    if listed:
+        manifest["files"] = _merge_files(manifest.get("files", []), listed)
+
+    wanted = [
+        entry
+        for entry in manifest.get("files", [])
+        if should_attempt(entry, retry) and media_type(entry["file_id"]) != "video"
+    ]
+    logger.info("%s: %d file(s) to fetch", doi, len(wanted))
+
+    # --- route 2: the bundle ------------------------------------------
+    # Try it when there are files to get, and *also* when the article XML gave us
+    # no listing at all: a paper with no open full text can still have open
+    # supplements, and the bundle is the only way to find out. Without this the
+    # unlisted-adoption path below is unreachable.
+    if pmcid and use_bundle and (wanted or not listed):
+        result = fetch_bundle(client, pmcid, cap=bundle_cap)
+        if result.archive is not None:
+            with result.archive as archive:
+                members = {Path(info.filename).name: info for info in archive.infolist()}
+                for entry in wanted:
+                    info = members.get(entry["file_id"])
+                    if info is None or _is_figure(info.filename):
+                        continue
+                    dest = files_dir(store_root, doi) / entry["file_id"]
+                    dest.parent.mkdir(parents=True, exist_ok=True)
+                    with archive.open(info) as src, dest.open("wb") as out:
+                        out.write(src.read())
+                    _mark_present(entry, store_root, doi, dest, "europepmc_bundle", url=None)
+                # Files in the bundle the article XML never mentioned: keep them,
+                # since a supplement absent from the listing is still a supplement.
+                if not listed:
+                    _adopt_unlisted(archive, members, manifest, store_root, doi)
+        else:
+            logger.info("%s: bundle unusable — %s", doi, result.reason)
+            # Held rather than recorded now: if a later route gets the files, the
+            # bundle's failure is a detail of how, not a gap in what we have.
+            bundle_failure = result.reason
+
+    # --- route 3: publisher-direct ------------------------------------
+    for entry in wanted:
+        if entry.get("status") == "present":
+            continue
+        url = publisher_direct_url(doi, entry["file_id"])
+        if url is None:
+            continue
+        dest = files_dir(store_root, doi) / entry["file_id"]
+        ok, note = fetch_one_file(client, url, dest)
+        if ok:
+            _mark_present(entry, store_root, doi, dest, "publisher_direct", url=url)
+        else:
+            entry["status"] = "failed"
+            entry["retrieval"] = {
+                "route": "publisher_direct",
+                "url": url,
+                "attempted_at": _now(),
+                "note": note,
+            }
+
+    # --- route 4: nothing left but a person --------------------------
+    for entry in wanted:
+        if entry.get("status") == "present":
+            continue
+        if entry.get("status") != "failed":
+            entry["status"] = "unavailable"
+            entry["retrieval"] = {
+                "route": "none",
+                "attempted_at": _now(),
+                "note": "no route reached this file",
+            }
+        gaps.append(
+            {
+                "file_id": entry["file_id"],
+                "reason": f"not retrieved: {entry['retrieval'].get('note', 'no route')}",
+                "action": "drop it into incoming/ and run adopt",
+            }
+        )
+
+    still_missing = [f for f in manifest.get("files", []) if f.get("status") != "present"]
+    if bundle_failure and (still_missing or not manifest.get("files")):
+        gaps.append(
+            {
+                "file_id": doi,
+                "reason": bundle_failure,
+                "action": "add a publisher-direct template, or drop the files into incoming/",
+            }
+        )
+
+    retrieved = {f["file_id"] for f in manifest.get("files", []) if f.get("status") == "present"}
+    kept = [gap for gap in prior_gaps if gap.get("file_id") not in retrieved]
+    manifest["gaps"] = _dedupe_gaps(kept + gaps)
+    write_manifest(store_root, doi, manifest)
+    present = sum(1 for f in manifest["files"] if f.get("status") == "present")
+    logger.info("%s: %d/%d file(s) present", doi, present, len(manifest["files"]))
+    return manifest
+
+
+def _mark_present(
+    entry: dict[str, Any],
+    store_root: Path,
+    doi: str,
+    dest: Path,
+    route: str,
+    url: str | None,
+) -> None:
+    entry.update(
+        {
+            "media_type": media_type(entry["file_id"]),
+            "size_bytes": dest.stat().st_size,
+            "path": _rel(store_root, dest),
+            "status": "present",
+            "retrieval": {
+                "route": route,
+                "retrieved_at": _now(),
+                "sha256": _sha256(dest),
+            },
+        }
+    )
+    if url:
+        entry["retrieval"]["url"] = url
+    logger.info("  %s via %s (%d bytes)", entry["file_id"], route, entry["size_bytes"])
+
+
+def _adopt_unlisted(
+    archive: zipfile.ZipFile,
+    members: dict[str, Any],
+    manifest: dict[str, Any],
+    store_root: Path,
+    doi: str,
+) -> None:
+    """Take bundle members when the article XML gave us no listing to match.
+
+    Without the XML there are no captions and no filenames, so the bundle is all
+    we have. Figures are skipped; everything else is stored under the name the
+    bundle used.
+    """
+    extra: list[dict[str, Any]] = []
+    for name, info in members.items():
+        if _is_figure(name):
+            continue
+        dest = files_dir(store_root, doi) / name
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        with archive.open(info) as src, dest.open("wb") as out:
+            out.write(src.read())
+        entry: dict[str, Any] = {"file_id": name, "status": "listed"}
+        _mark_present(entry, store_root, doi, dest, "europepmc_bundle", url=None)
+        extra.append(entry)
+    if extra:
+        manifest["files"] = _merge_files(manifest.get("files", []), extra)
+
+
+def fetch_corpus(
+    store_root: Path,
+    cas: dict[str, Any],
+    bundle_cap: int = DEFAULT_BUNDLE_CAP_BYTES,
+    use_bundle: bool = True,
+    retry: bool = False,
+) -> list[dict[str, Any]]:
+    """Fetch supplements for every paper a CAS+ document names.
+
+    One client is shared across the corpus. A paper that cannot be fetched does
+    not stop the others: the failure lands in that paper's manifest.
+    """
+    from atlas_chat.services.supplement_store import corpus_papers
+
+    papers = corpus_papers(cas)
+    out: list[dict[str, Any]] = []
+    with httpx.Client(follow_redirects=True, timeout=TIMEOUT) as client:
+        for paper in papers:
+            try:
+                manifest = fetch_supplements(
+                    store_root,
+                    paper["doi"],
+                    bundle_cap=bundle_cap,
+                    use_bundle=use_bundle,
+                    retry=retry,
+                    client=client,
+                )
+                out.append(
+                    {
+                        "doi": paper["doi"],
+                        "role": paper.get("role"),
+                        "files": len(manifest.get("files", [])),
+                        "present": sum(
+                            1 for f in manifest.get("files", []) if f.get("status") == "present"
+                        ),
+                        "gaps": len(manifest.get("gaps", [])),
+                    }
+                )
+            except (httpx.HTTPError, SupplementStoreError, SupplementFetchError) as exc:
+                logger.warning("%s: %s", paper["doi"], exc)
+                out.append({"doi": paper["doi"], "error": f"{type(exc).__name__}: {exc}"})
+    return out

--- a/src/atlas_chat/atlas_chat/services/supplement_store.py
+++ b/src/atlas_chat/atlas_chat/services/supplement_store.py
@@ -661,7 +661,16 @@ def _outline_xlsx(path: Path, sample_rows: int, max_cols: int) -> list[dict[str,
             "reading .xlsx needs openpyxl — install the [supplements] extra"
         ) from exc
 
-    workbook = load_workbook(path, read_only=True, data_only=True)
+    try:
+        workbook = load_workbook(path, read_only=True, data_only=True)
+    except Exception as exc:
+        # A .xlsx extension is a claim, not a fact: publishers ship legacy .xls
+        # and the occasional truncated download under that name. Raising a typed
+        # error lets a caller record the file as unreadable and carry on, rather
+        # than a corpus-wide crash on one bad file.
+        raise SupplementStoreError(
+            f"{path.name} is not a readable .xlsx workbook: {type(exc).__name__}: {exc}"
+        ) from exc
     tables: list[dict[str, Any]] = []
     try:
         scan_rows = max(sample_rows, HEADER_SCAN_ROWS)
@@ -1237,6 +1246,26 @@ def _cmd_fetch(args: argparse.Namespace) -> int:
     return 0
 
 
+def _cmd_triage(args: argparse.Namespace) -> int:
+    from atlas_chat.services.supplement_triage import indexable, triage_paper
+
+    manifest = triage_paper(Path(args.store), args.doi)
+    verdicts: dict[str, int] = {}
+    for entry in manifest.get("files", []):
+        for item in entry.get("members") or [entry]:
+            verdicts[item.get("relevance", "unset")] = (
+                verdicts.get(item.get("relevance", "unset"), 0) + 1
+            )
+    _print(
+        {
+            "doi": args.doi,
+            "verdicts": verdicts,
+            "to_index": indexable(manifest),
+        }
+    )
+    return 0
+
+
 def _cmd_papers(args: argparse.Namespace) -> int:
     cas = json.loads(Path(args.cas).read_text(encoding="utf-8"))
     _print(corpus_papers(cas))
@@ -1337,6 +1366,14 @@ def build_parser() -> argparse.ArgumentParser:
         help="ignore the negative cache and retry files that previously failed",
     )
     fetch.set_defaults(func=_cmd_fetch)
+
+    triage = sub.add_parser(
+        "triage",
+        help="judge which stored files could describe cell types, from their columns",
+    )
+    triage.add_argument("--store", required=True)
+    triage.add_argument("--doi", required=True)
+    triage.set_defaults(func=_cmd_triage)
 
     papers = sub.add_parser("papers", help="corpus papers from a CAS+ document")
     papers.add_argument("--cas", required=True)

--- a/src/atlas_chat/atlas_chat/services/supplement_store.py
+++ b/src/atlas_chat/atlas_chat/services/supplement_store.py
@@ -643,14 +643,19 @@ def _xlsx_dimensions(sheet: Any) -> tuple[int, int]:
     """
     if sheet.max_row is not None and sheet.max_column is not None:
         return sheet.max_row, sheet.max_column
-    rows = cols = 0
-    for row in sheet.iter_rows(values_only=True):
-        rows += 1
+    # Count to the last row that has content, not to the last row the reader
+    # yields. A sheet with formatting applied down to row 1000 yields 1000 rows
+    # for 35 rows of data, and reporting 1000 tells a reader to slice a table
+    # that is small enough to read whole.
+    last = cols = 0
+    for index, row in enumerate(sheet.iter_rows(values_only=True), start=1):
         width = len(row)
-        while width and row[width - 1] is None:
+        while width and (row[width - 1] is None or str(row[width - 1]).strip() == ""):
             width -= 1
-        cols = max(cols, width)
-    return rows, cols
+        if width:
+            last = index
+            cols = max(cols, width)
+    return last, cols
 
 
 def _outline_xlsx(path: Path, sample_rows: int, max_cols: int) -> list[dict[str, Any]]:

--- a/src/atlas_chat/atlas_chat/services/supplement_store.py
+++ b/src/atlas_chat/atlas_chat/services/supplement_store.py
@@ -1264,9 +1264,17 @@ def _cmd_fetch(args: argparse.Namespace) -> int:
 
 
 def _cmd_triage(args: argparse.Namespace) -> int:
-    from atlas_chat.services.supplement_triage import indexable, triage_paper
+    from atlas_chat.services.supplement_triage import (
+        indexable,
+        sheet_candidates,
+        triage_paper,
+    )
 
     manifest = triage_paper(Path(args.store), args.doi)
+    if args.sheets:
+        # Draft pointers, one per sheet, everything but the description filled in.
+        _print(sheet_candidates(Path(args.store), args.doi, manifest))
+        return 0
     verdicts: dict[str, int] = {}
     for entry in manifest.get("files", []):
         for item in entry.get("members") or [entry]:
@@ -1390,6 +1398,11 @@ def build_parser() -> argparse.ArgumentParser:
     )
     triage.add_argument("--store", required=True)
     triage.add_argument("--doi", required=True)
+    triage.add_argument(
+        "--sheets",
+        action="store_true",
+        help="emit one draft pointer per sheet (locator, columns, kind, relevance)",
+    )
     triage.set_defaults(func=_cmd_triage)
 
     papers = sub.add_parser("papers", help="corpus papers from a CAS+ document")

--- a/src/atlas_chat/atlas_chat/services/supplement_store.py
+++ b/src/atlas_chat/atlas_chat/services/supplement_store.py
@@ -653,11 +653,7 @@ def _xlsx_dimensions(sheet: Any) -> tuple[int, int]:
     scanning them is slow and their declarations have held up.
     """
     declared = sheet.max_row
-    if (
-        declared is not None
-        and sheet.max_column is not None
-        and declared > VERIFY_ROWS_AT_OR_BELOW
-    ):
+    if declared is not None and sheet.max_column is not None and declared > VERIFY_ROWS_AT_OR_BELOW:
         return declared, sheet.max_column
     # Count to the last row that has content, not to the last row the reader
     # yields. A sheet with formatting applied down to row 1000 yields 1000 rows

--- a/src/atlas_chat/atlas_chat/services/supplement_store.py
+++ b/src/atlas_chat/atlas_chat/services/supplement_store.py
@@ -632,6 +632,27 @@ def _header_row_guess(rows: list[list[str]], scan: int = 6) -> int:
     return next(index for index, count in enumerate(counts) if count >= threshold)
 
 
+def _xlsx_dimensions(sheet: Any) -> tuple[int, int]:
+    """True (rows, cols) of a worksheet.
+
+    openpyxl's read-only mode reports ``max_row``/``max_column`` as None when the
+    workbook carries no dimension record — real for publisher-generated files.
+    Reporting None would put a null where every consumer expects a count, so the
+    rows are streamed and counted instead. Only pays that cost when the cheap
+    answer is missing.
+    """
+    if sheet.max_row is not None and sheet.max_column is not None:
+        return sheet.max_row, sheet.max_column
+    rows = cols = 0
+    for row in sheet.iter_rows(values_only=True):
+        rows += 1
+        width = len(row)
+        while width and row[width - 1] is None:
+            width -= 1
+        cols = max(cols, width)
+    return rows, cols
+
+
 def _outline_xlsx(path: Path, sample_rows: int, max_cols: int) -> list[dict[str, Any]]:
     try:
         from openpyxl import load_workbook  # type: ignore[import-untyped]
@@ -649,13 +670,14 @@ def _outline_xlsx(path: Path, sample_rows: int, max_cols: int) -> list[dict[str,
             for row in sheet.iter_rows(max_row=scan_rows, max_col=max_cols, values_only=True):
                 scanned.append(_trim([_clip(cell) for cell in row]))
             rows = scanned[:sample_rows]
+            n_rows, n_cols = _xlsx_dimensions(sheet)
             tables.append(
                 {
                     "locator": sheet.title,
-                    "n_rows": sheet.max_row,
-                    "n_cols": sheet.max_column,
-                    "truncated_cols": bool(sheet.max_column and sheet.max_column > max_cols),
-                    "truncated_rows": bool(sheet.max_row and sheet.max_row > len(rows)),
+                    "n_rows": n_rows,
+                    "n_cols": n_cols,
+                    "truncated_cols": n_cols > max_cols,
+                    "truncated_rows": n_rows > len(rows),
                     "header_row_guess": _header_row_guess(scanned),
                     "rows": rows,
                 }
@@ -1164,6 +1186,57 @@ def _cmd_check(args: argparse.Namespace) -> int:
     return 0
 
 
+def _cmd_fetch(args: argparse.Namespace) -> int:
+    # Imported here so the store stays importable without httpx-backed retrieval.
+    from atlas_chat.services.supplement_fetch import fetch_corpus, fetch_supplements
+
+    if args.bundle_cap is None:
+        from atlas_chat.services.supplement_fetch import DEFAULT_BUNDLE_CAP_BYTES
+
+        args.bundle_cap = DEFAULT_BUNDLE_CAP_BYTES
+
+    if bool(args.doi) == bool(args.cas):
+        print("give exactly one of --doi or --cas", file=sys.stderr)
+        return 2
+
+    if args.cas:
+        cas = json.loads(Path(args.cas).read_text(encoding="utf-8"))
+        _print(
+            fetch_corpus(
+                Path(args.store),
+                cas,
+                bundle_cap=args.bundle_cap,
+                use_bundle=not args.no_bundle,
+                retry=args.retry,
+            )
+        )
+        return 0
+
+    manifest = fetch_supplements(
+        Path(args.store),
+        args.doi,
+        bundle_cap=args.bundle_cap,
+        use_bundle=not args.no_bundle,
+        retry=args.retry,
+    )
+    _print(
+        {
+            "doi": args.doi,
+            "files": [
+                {
+                    "file_id": f["file_id"],
+                    "status": f["status"],
+                    "route": f.get("retrieval", {}).get("route"),
+                    "size_bytes": f.get("size_bytes"),
+                }
+                for f in manifest["files"]
+            ],
+            "gaps": manifest.get("gaps", []),
+        }
+    )
+    return 0
+
+
 def _cmd_papers(args: argparse.Namespace) -> int:
     cas = json.loads(Path(args.cas).read_text(encoding="utf-8"))
     _print(corpus_papers(cas))
@@ -1239,6 +1312,31 @@ def build_parser() -> argparse.ArgumentParser:
     check = sub.add_parser("check", help="validate a manifest against its schema")
     add_store(check)
     check.set_defaults(func=_cmd_check)
+
+    fetch = sub.add_parser(
+        "fetch",
+        help="retrieve supplements: article XML -> Europe PMC bundle -> publisher -> manual",
+    )
+    fetch.add_argument("--store", required=True, help="store root directory")
+    fetch.add_argument("--doi", help="one paper")
+    fetch.add_argument("--cas", help="a CAS+ document: fetch for every corpus paper")
+    fetch.add_argument(
+        "--bundle-cap",
+        type=int,
+        default=None,
+        help="byte ceiling on the Europe PMC bundle (default 60 MB)",
+    )
+    fetch.add_argument(
+        "--no-bundle",
+        action="store_true",
+        help="skip the bundle route (for articles carrying supplementary video)",
+    )
+    fetch.add_argument(
+        "--retry",
+        action="store_true",
+        help="ignore the negative cache and retry files that previously failed",
+    )
+    fetch.set_defaults(func=_cmd_fetch)
 
     papers = sub.add_parser("papers", help="corpus papers from a CAS+ document")
     papers.add_argument("--cas", required=True)

--- a/src/atlas_chat/atlas_chat/services/supplement_store.py
+++ b/src/atlas_chat/atlas_chat/services/supplement_store.py
@@ -632,17 +632,33 @@ def _header_row_guess(rows: list[list[str]], scan: int = 6) -> int:
     return next(index for index, count in enumerate(counts) if count >= threshold)
 
 
+#: A declared row count at or below this is verified by streaming; above it the
+#: declaration is trusted. Publisher sheets routinely declare a round extent
+#: (A1:Z1000) because formatting was applied past the data, so a 9-row table
+#: claims 1000 rows — and `n_rows` is what tells a reader whether to slice or
+#: read whole. Verifying costs about 0.1s at this size; the 396,880-row table in
+#: the prenatal skin bundle would cost 18s, and its declaration is accurate
+#: anyway.
+VERIFY_ROWS_AT_OR_BELOW = 5_000
+
+
 def _xlsx_dimensions(sheet: Any) -> tuple[int, int]:
     """True (rows, cols) of a worksheet.
 
-    openpyxl's read-only mode reports ``max_row``/``max_column`` as None when the
-    workbook carries no dimension record — real for publisher-generated files.
-    Reporting None would put a null where every consumer expects a count, so the
-    rows are streamed and counted instead. Only pays that cost when the cheap
-    answer is missing.
+    Two ways a declared dimension misleads, both real in publisher files:
+    openpyxl's read-only mode reports None when the workbook carries no
+    dimension record, and a workbook can declare a round extent far past its
+    data because formatting was applied there. Small sheets are therefore
+    counted rather than believed; large ones are taken at their word, since
+    scanning them is slow and their declarations have held up.
     """
-    if sheet.max_row is not None and sheet.max_column is not None:
-        return sheet.max_row, sheet.max_column
+    declared = sheet.max_row
+    if (
+        declared is not None
+        and sheet.max_column is not None
+        and declared > VERIFY_ROWS_AT_OR_BELOW
+    ):
+        return declared, sheet.max_column
     # Count to the last row that has content, not to the last row the reader
     # yields. A sheet with formatting applied down to row 1000 yields 1000 rows
     # for 35 rows of data, and reporting 1000 tells a reader to slice a table

--- a/src/atlas_chat/atlas_chat/services/supplement_triage.py
+++ b/src/atlas_chat/atlas_chat/services/supplement_triage.py
@@ -1,0 +1,454 @@
+"""Decide which supplementary files are worth indexing, cheaply.
+
+A corpus of twenty-odd papers yields a hundred-plus supplementary files, and
+most of them have nothing to say about cell types. Deep indexing — opening every
+workbook, describing every sheet — is the expensive step, so it should only run
+on files that could carry evidence.
+
+Two stages, matching where the information actually is:
+
+**Captions, before any bytes move.** The article XML gives a label and caption
+for each file. Some captions settle the question outright: a "Reporting Summary"
+or a "Peer Review file" is never evidence about a cell type. Nothing else is
+ruled out at this stage — captions like "Supplementary Information" are common
+and say nothing, and treating silence as irrelevance would discard real tables.
+
+**Column signatures, after the bytes arrive.** ``outline`` is bounded and fast
+(a 396,880-row table describes itself in about two seconds), so every candidate
+gets outlined and judged on what its columns actually are. A sheet headed
+``names / logfoldchanges / pvals_adj`` is differential expression; one whose
+first column holds cell barcodes is per-cell metadata; one headed
+``RRID citation / Antibody / Vendor`` is a reagent list and no report will ever
+cite it.
+
+What counts as relevant is one editable table, :data:`SIGNATURES`, because it is
+a judgement about the aim rather than a fact about spreadsheets. As set here:
+differential expression, marker lists, cluster-to-name mappings, cell and sample
+metadata, enrichment results and cell-cell interactions are relevant, because
+each describes a cell type or one of its properties. Reagent lists and gene-set
+definitions are not — they are inputs to an analysis, not findings about cells.
+Figure source data is relevant only when it carries a cell-type column, which is
+the difference between per-cell-type abundances and image quantification.
+
+Anything the signatures do not match comes back ``unknown`` rather than being
+guessed at, and a reader settles it. Silence is never read as irrelevance.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from pathlib import Path
+from typing import Any
+
+from atlas_chat.services.supplement_store import (
+    SupplementStoreError,
+    load_manifest,
+    outline_file,
+    write_manifest,
+)
+
+logger = logging.getLogger(__name__)
+
+#: Captions that settle irrelevance on their own. Deliberately short: these are
+#: publishing-process artefacts, not judgement calls. Everything else waits for
+#: its columns to be seen.
+NON_EVIDENCE_CAPTIONS = (
+    "reporting summary",
+    "peer review file",
+    "peer review information",
+    "reporting checklist",
+    "author checklist",
+    "editorial policy checklist",
+)
+
+#: A 10x-style cell barcode, the giveaway that a table has one row per cell.
+BARCODE_RE = re.compile(r"^[ACGT]{12,20}(-\d+)?([-_].+)?$")
+
+
+class Signature:
+    """One recognisable kind of supplementary table.
+
+    Args:
+        name: What to call it in a note.
+        content_type: The manifest ``TablePointer.content_type`` it maps to.
+        relevant: Whether a table of this kind bears on describing cell types.
+        required: Column names that must all be present (lowercased substrings).
+        any_of: Column names of which at least one must be present.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        content_type: str,
+        relevant: bool,
+        required: tuple[str, ...] = (),
+        any_of: tuple[str, ...] = (),
+    ):
+        self.name = name
+        self.content_type = content_type
+        self.relevant = relevant
+        self.required = required
+        self.any_of = any_of
+
+    def matches(self, columns: set[str]) -> bool:
+        if self.required and not all(
+            any(req in column for column in columns) for req in self.required
+        ):
+            return False
+        if self.any_of and not any(any(opt in column for column in columns) for opt in self.any_of):
+            return False
+        return bool(self.required or self.any_of)
+
+
+#: Order matters: the first match wins, so the specific precede the general.
+SIGNATURES: tuple[Signature, ...] = (
+    # --- relevant: findings about cell types ------------------------------
+    # Interactions first: a CellPhoneDB table's `gene_pair` contains "gene" and
+    # its `padj` looks like differential expression, so the general DEG
+    # signatures would claim it and mislabel what it is.
+    Signature(
+        "cell-cell interaction",
+        "other",
+        True,
+        any_of=("celltype_pair", "gene_pair", "test_ligand"),
+    ),
+    Signature(
+        "cell-cell interaction",
+        "other",
+        True,
+        required=("ligand",),
+        any_of=("target", "receptor", "weight"),
+    ),
+    # Differential expression, however the tool that produced it named things.
+    # Seurat says avg_log2FC, scanpy says logfoldchanges, edgeR and limma say
+    # logFC with an F statistic and an FDR, DESeq2 says log2FoldChange with a
+    # baseMean. Matching only one dialect leaves most real DEG tables unjudged.
+    Signature(
+        "differential expression",
+        "deg_results",
+        True,
+        any_of=("logfoldchange", "avg_log2fc", "log2foldchange", "logfc", "log2fc"),
+    ),
+    Signature(
+        "differential expression",
+        "deg_results",
+        True,
+        required=("fdr",),
+        any_of=("gene", "genes", "ensembl_gene_id", "transcript", "names"),
+    ),
+    Signature(
+        "differential expression",
+        "deg_results",
+        True,
+        required=("padj",),
+        any_of=("gene", "genes", "basemean", "ensembl_gene_id", "names"),
+    ),
+    Signature(
+        "differential expression",
+        "deg_results",
+        True,
+        required=("pvals_adj",),
+        any_of=("names", "gene", "genes"),
+    ),
+    Signature(
+        "marker list",
+        "marker_list",
+        True,
+        required=("marker",),
+    ),
+    # A column literally named barcode is a per-cell table; the value-sniffing
+    # below only catches the case where the barcode is the first column.
+    Signature(
+        "per-cell table",
+        "cell_metadata",
+        True,
+        any_of=("barcode", "cell_id", "cell id", "cellid"),
+    ),
+    # clusterProfiler's dialect for enrichment, which names nothing "term".
+    Signature(
+        "enrichment results",
+        "other",
+        True,
+        any_of=("bgratio", "generatio", "p.adjust", "qvalue"),
+    ),
+    # A data dictionary describing the other sheets: the legend case, and worth
+    # reading first for exactly the reason a legends document is.
+    Signature(
+        "data dictionary",
+        "legend",
+        True,
+        required=("column",),
+        any_of=("description", "definition", "meaning"),
+    ),
+    Signature(
+        "cluster-to-name mapping",
+        "cluster_annotation",
+        True,
+        required=("cluster",),
+        any_of=("annotation", "label", "cell type", "celltype", "name"),
+    ),
+    Signature(
+        "enrichment results",
+        "other",
+        True,
+        required=("term",),
+        any_of=("adjusted p-value", "odds ratio", "combined score", "overlap"),
+    ),
+    Signature(
+        "label-transfer predictions",
+        "cell_metadata",
+        True,
+        any_of=("lr_assignment", "predicted", "prediction"),
+    ),
+    Signature(
+        "sample metadata",
+        "sample_metadata",
+        True,
+        any_of=(
+            "donor",
+            "sample_id",
+            "sanger_id",
+            "pcw",
+            "gestation",
+            "patient",
+            "subject",
+            "gravida",
+            "parity",
+            "ethnicity",
+        ),
+    ),
+    Signature(
+        "abundance per cell type",
+        "cell_metadata",
+        True,
+        required=("count",),
+        any_of=("annotation", "cell type", "celltype", "cluster"),
+    ),
+    # --- not relevant: inputs and reagents, not findings ------------------
+    # A reagent list needs a supplier, not just the word "antibody". The Human
+    # Protein Atlas secreted-protein table has an Antibody column beside
+    # Biological process and Blood concentration, and ruling that out as a
+    # reagent list would be a wrong answer for a plausible-looking reason —
+    # the failure direction that silently loses evidence.
+    Signature(
+        "reagent list",
+        "other",
+        False,
+        any_of=("vendor", "cat no", "catalogue no", "supplier", "clonality", "dilution"),
+        required=(),
+    ),
+    Signature(
+        "gene-set definitions",
+        "other",
+        False,
+        required=("go:",),
+    ),
+)
+
+
+def columns_of(table: dict[str, Any]) -> set[str]:
+    """Lowercased column names from an outlined table's detected header row."""
+    rows = table.get("rows") or []
+    index = table.get("header_row_guess", 0)
+    if index >= len(rows):
+        return set()
+    return {str(cell).strip().lower() for cell in rows[index] if str(cell).strip()}
+
+
+def looks_per_cell(table: dict[str, Any]) -> bool:
+    """Whether the first column holds cell barcodes.
+
+    One row per cell means per-cell annotations — abundance, label transfer,
+    predicted identity — which is evidence about cell types even when the column
+    headers are opaque.
+    """
+    rows = table.get("rows") or []
+    start = table.get("header_row_guess", 0) + 1
+    return any(row and BARCODE_RE.match(str(row[0]).strip()) for row in rows[start : start + 3])
+
+
+def classify_table(table: dict[str, Any]) -> tuple[str, str | None, str]:
+    """Judge one outlined table.
+
+    Returns:
+        ``(verdict, content_type, note)`` where verdict is ``relevant`` /
+        ``irrelevant`` / ``unknown``. ``unknown`` means the signals did not
+        settle it and a reader should look — never that it is irrelevant.
+    """
+    columns = columns_of(table)
+    if not columns:
+        return "unknown", None, "no header row could be read"
+
+    for signature in SIGNATURES:
+        if signature.matches(columns):
+            shown = sorted(columns)[:4]
+            return (
+                "relevant" if signature.relevant else "irrelevant",
+                signature.content_type,
+                f"columns {'/'.join(shown)} -> {signature.name}",
+            )
+
+    if looks_per_cell(table):
+        return "relevant", "cell_metadata", "first column holds cell barcodes -> per-cell table"
+
+    return "unknown", None, f"columns {'/'.join(sorted(columns)[:5])} matched no signature"
+
+
+def classify_caption(entry: dict[str, Any]) -> tuple[str, str] | None:
+    """Rule a file out on its caption alone, or return None to keep looking.
+
+    Only the certain cases: a reporting summary or a peer review file cannot
+    describe a cell type. An uninformative caption ("Supplementary Information")
+    returns None — sixteen files in the reproductive-atlas corpus carry captions
+    that say nothing, and reading that as irrelevance would throw away real
+    tables.
+    """
+    described = f"{entry.get('label', '')} {entry.get('caption', '')}".strip().lower()
+    if not described:
+        return None
+    for phrase in NON_EVIDENCE_CAPTIONS:
+        if phrase in described:
+            return "irrelevant", f"caption: {entry.get('caption') or entry.get('label')}"
+    return None
+
+
+# ------------------------------------------------------------------
+# Triaging a whole paper
+# ------------------------------------------------------------------
+
+#: Kinds that can hold a table worth reading. A PDF may well carry a
+#: cluster-annotation table, but we cannot see its columns, so it is left
+#: unknown for a reader rather than guessed at.
+INSPECTABLE = {"xlsx", "csv", "tsv", "txt", "docx"}
+
+
+def triage_paper(store_root: Path, doi: str) -> dict[str, Any]:
+    """Record a relevance verdict for every stored file and archive member.
+
+    Outlines each inspectable file, classifies it from its columns, and writes
+    ``relevance`` / ``relevance_note`` into the manifest. Deep indexing then runs
+    only over what came back ``relevant`` or ``unknown``.
+
+    Returns:
+        The manifest, written to disk.
+    """
+    manifest = load_manifest(store_root, doi)
+    if manifest is None:
+        raise SupplementStoreError(f"no manifest for {doi} in {store_root}")
+
+    counts: dict[str, int] = {"relevant": 0, "irrelevant": 0, "unknown": 0}
+
+    for entry in manifest.get("files", []):
+        members = entry.get("members") or []
+        if members:
+            # The archive itself is a container; its members carry the verdicts.
+            for member in members:
+                verdict, note = _judge(store_root, member, member.get("member_path", ""))
+                member["relevance"] = verdict
+                member["relevance_note"] = note
+                counts[verdict] += 1
+            verdicts = {m["relevance"] for m in members}
+            entry["relevance"] = (
+                "relevant"
+                if "relevant" in verdicts
+                else ("unknown" if "unknown" in verdicts else "irrelevant")
+            )
+            entry["relevance_note"] = (
+                f"{sum(1 for m in members if m['relevance'] == 'relevant')} of "
+                f"{len(members)} members relevant"
+            )
+            continue
+
+        caption_verdict = classify_caption(entry)
+        if caption_verdict:
+            entry["relevance"], entry["relevance_note"] = caption_verdict
+            counts[entry["relevance"]] += 1
+            continue
+
+        verdict, note = _judge(store_root, entry, entry["file_id"])
+        entry["relevance"] = verdict
+        entry["relevance_note"] = note
+        counts[verdict] += 1
+
+    write_manifest(store_root, doi, manifest)
+    logger.info(
+        "%s: %d relevant, %d irrelevant, %d unknown",
+        doi,
+        counts["relevant"],
+        counts["irrelevant"],
+        counts["unknown"],
+    )
+    return manifest
+
+
+def _judge(store_root: Path, entry: dict[str, Any], name: str) -> tuple[str, str]:
+    """Verdict for one file or archive member."""
+    caption_verdict = classify_caption(entry)
+    if caption_verdict:
+        return caption_verdict
+
+    kind = entry.get("media_type") or ""
+    path = entry.get("path")
+    if not path:
+        return "unknown", "not on disk, so its columns could not be read"
+    if kind not in INSPECTABLE:
+        return "unknown", f"{kind or 'unrecognised'} file — columns cannot be read from it"
+
+    try:
+        outline = outline_file(store_root / path, sample_rows=6, max_cols=60)
+    except SupplementStoreError as exc:
+        return "unknown", f"could not be outlined: {exc}"
+
+    tables = outline.get("tables") or []
+    if not tables:
+        return "unknown", "no tabular content found"
+
+    # A workbook is relevant if any of its sheets is; the deep index decides
+    # which ones. Notes name the sheet that settled it.
+    best = ("unknown", "")
+    for table in tables:
+        verdict, _content_type, note = classify_table(table)
+        located = f"[{table.get('locator')}] {note}" if table.get("locator") else note
+        if verdict == "relevant":
+            return "relevant", located
+        if verdict == "unknown" and best[0] != "unknown":
+            best = ("unknown", located)
+        elif not best[1]:
+            best = (verdict, located)
+    return best if best[1] else ("unknown", "no sheet matched a signature")
+
+
+def indexable(manifest: dict[str, Any]) -> list[dict[str, Any]]:
+    """The files and members deep indexing should open.
+
+    Everything judged ``relevant`` or ``unknown`` — never the ``irrelevant``.
+    Each item carries ``file_id``, optional ``member_path``, ``path``,
+    ``relevance`` and ``relevance_note`` so a caller can go straight to it.
+    """
+    out: list[dict[str, Any]] = []
+    for entry in manifest.get("files", []):
+        members = entry.get("members") or []
+        if members:
+            for member in members:
+                if member.get("relevance") in {"relevant", "unknown"} and member.get("path"):
+                    out.append(
+                        {
+                            "file_id": entry["file_id"],
+                            "member_path": member["member_path"],
+                            "path": member["path"],
+                            "relevance": member["relevance"],
+                            "relevance_note": member.get("relevance_note", ""),
+                        }
+                    )
+            continue
+        if entry.get("relevance") in {"relevant", "unknown"} and entry.get("path"):
+            out.append(
+                {
+                    "file_id": entry["file_id"],
+                    "path": entry["path"],
+                    "relevance": entry["relevance"],
+                    "relevance_note": entry.get("relevance_note", ""),
+                }
+            )
+    return out

--- a/src/atlas_chat/atlas_chat/services/supplement_triage.py
+++ b/src/atlas_chat/atlas_chat/services/supplement_triage.py
@@ -73,8 +73,13 @@ class Signature:
         name: What to call it in a note.
         content_type: The manifest ``TablePointer.content_type`` it maps to.
         relevant: Whether a table of this kind bears on describing cell types.
-        required: Column names that must all be present (lowercased substrings).
-        any_of: Column names of which at least one must be present.
+        required: Column names that must all be present, matched as substrings —
+            loose on purpose, so ``logfoldchange`` catches ``logFoldChanges``.
+        any_of: Column names of which at least one must be present, as substrings.
+        exact_any_of: As ``any_of``, but matched against the whole column name.
+            For tokens that collide: "name" as a substring matches
+            ``secondBestClusterName`` in a TF-IDF marker table, which is how a
+            marker table came to be labelled a cluster-to-name mapping.
     """
 
     def __init__(
@@ -84,21 +89,26 @@ class Signature:
         relevant: bool,
         required: tuple[str, ...] = (),
         any_of: tuple[str, ...] = (),
+        exact_any_of: tuple[str, ...] = (),
     ):
         self.name = name
         self.content_type = content_type
         self.relevant = relevant
         self.required = required
         self.any_of = any_of
+        self.exact_any_of = exact_any_of
 
     def matches(self, columns: set[str]) -> bool:
         if self.required and not all(
             any(req in column for column in columns) for req in self.required
         ):
             return False
-        if self.any_of and not any(any(opt in column for column in columns) for opt in self.any_of):
-            return False
-        return bool(self.required or self.any_of)
+        if self.any_of or self.exact_any_of:
+            loose = any(any(opt in column for column in columns) for opt in self.any_of)
+            exact = any(opt in columns for opt in self.exact_any_of)
+            if not (loose or exact):
+                return False
+        return bool(self.required or self.any_of or self.exact_any_of)
 
 
 #: Order matters: the first match wins, so the specific precede the general.
@@ -109,13 +119,13 @@ SIGNATURES: tuple[Signature, ...] = (
     # signatures would claim it and mislabel what it is.
     Signature(
         "cell-cell interaction",
-        "other",
+        "interaction",
         True,
         any_of=("celltype_pair", "gene_pair", "test_ligand"),
     ),
     Signature(
         "cell-cell interaction",
-        "other",
+        "interaction",
         True,
         required=("ligand",),
         any_of=("target", "receptor", "weight"),
@@ -168,7 +178,7 @@ SIGNATURES: tuple[Signature, ...] = (
     # clusterProfiler's dialect for enrichment, which names nothing "term".
     Signature(
         "enrichment results",
-        "other",
+        "enrichment",
         True,
         any_of=("bgratio", "generatio", "p.adjust", "qvalue"),
     ),
@@ -181,16 +191,58 @@ SIGNATURES: tuple[Signature, ...] = (
         required=("column",),
         any_of=("description", "definition", "meaning"),
     ),
+    # TF-IDF marker tables carry a cluster column and a secondBestClusterName,
+    # so they must be claimed here or the cluster signature mislabels them as a
+    # naming table — the one field this corpus is short of, where a false
+    # positive is worse than none.
+    Signature(
+        "TF-IDF marker table",
+        "marker_list",
+        True,
+        any_of=("tfidf", "genefrequency"),
+    ),
     Signature(
         "cluster-to-name mapping",
         "cluster_annotation",
         True,
         required=("cluster",),
-        any_of=("annotation", "label", "cell type", "celltype", "name"),
+        any_of=("annotation", "cell type", "celltype", "cell_type", "cell state"),
+        exact_any_of=("name", "label", "cluster name", "cluster_name", "cell name"),
+    ),
+    # An interaction matrix names cell-type PAIRS in its columns
+    # ("SOX9_LGR5--Preciliated"), which no other kind of table does.
+    Signature(
+        "cell-cell interaction matrix",
+        "interaction",
+        True,
+        required=("--",),
+    ),
+    # CellPhoneDB's own schema for a curated interaction table.
+    Signature(
+        "curated interactions",
+        "interaction",
+        True,
+        any_of=("partner_a", "partner_b", "interacting_pair"),
+    ),
+    # TF regulon activity: a normalised enrichment score per regulon per cluster.
+    Signature(
+        "regulon activity",
+        "enrichment",
+        True,
+        required=("nes",),
+        any_of=("regulon", "fdr", "p.value", "cluster"),
+    ),
+    # The curated TF-target network an activity analysis consumed — an input.
+    Signature(
+        "regulatory network",
+        "gene_set",
+        False,
+        required=("target",),
+        any_of=("regulon", "effect", "tf"),
     ),
     Signature(
         "enrichment results",
-        "other",
+        "enrichment",
         True,
         required=("term",),
         any_of=("adjusted p-value", "odds ratio", "combined score", "overlap"),
@@ -233,14 +285,23 @@ SIGNATURES: tuple[Signature, ...] = (
     # the failure direction that silently loses evidence.
     Signature(
         "reagent list",
-        "other",
+        "reagents",
         False,
-        any_of=("vendor", "cat no", "catalogue no", "supplier", "clonality", "dilution"),
-        required=(),
+        any_of=(
+            "vendor",
+            "cat no",
+            "catalogue no",
+            "catalog no",
+            "company",
+            "product number",
+            "supplier",
+            "clonality",
+            "dilution",
+        ),
     ),
     Signature(
         "gene-set definitions",
-        "other",
+        "gene_set",
         False,
         required=("go:",),
     ),
@@ -427,6 +488,85 @@ def _judge(store_root: Path, entry: dict[str, Any], name: str) -> tuple[str, str
         elif not best[1]:
             best = (verdict, located)
     return best if best[1] else ("unknown", "no sheet matched a signature")
+
+
+#: Columns recorded per sheet before the list is treated as a prefix. A
+#: label-transfer table has one column per cell state and can run to hundreds;
+#: the first two dozen tell a reader what it is.
+CANDIDATE_COLUMN_CAP = 25
+
+
+def sheet_candidates(
+    store_root: Path, doi: str, manifest: dict[str, Any] | None = None
+) -> list[dict[str, Any]]:
+    """One draft pointer per sheet, with everything mechanical already filled in.
+
+    Relevance is a per-sheet property: the same workbook holds the DEG table a
+    report needs and the antibody list it never will, so a verdict on the file
+    cannot express it. This opens every indexable file once and returns a
+    candidate per sheet carrying its locator, header row, dimensions, columns, a
+    suggested ``content_type`` and its own relevance verdict.
+
+    What is deliberately absent is ``description`` — what a table is *for* is the
+    judgement the indexing skill makes, and inventing it here would be guessing.
+    A caller fills that in and writes the result as the manifest's ``tables``.
+
+    Returns:
+        Candidates in file then sheet order. Sheets from files triage ruled
+        irrelevant are included, marked as such, so nothing is silently absent.
+    """
+    manifest = manifest or load_manifest(store_root, doi)
+    if manifest is None:
+        raise SupplementStoreError(f"no manifest for {doi} in {store_root}")
+
+    out: list[dict[str, Any]] = []
+    for entry in manifest.get("files", []):
+        for item in entry.get("members") or [entry]:
+            path = item.get("path")
+            kind = item.get("media_type") or ""
+            if not path or kind not in INSPECTABLE:
+                continue
+            try:
+                outline = outline_file(store_root / path, sample_rows=6, max_cols=200)
+            except SupplementStoreError as exc:
+                logger.warning("%s: %s", path, exc)
+                continue
+            for table in outline.get("tables") or []:
+                verdict, content_type, note = classify_table(table)
+                header_row = table.get("header_row_guess", 0)
+                candidate: dict[str, Any] = {
+                    "file_id": entry["file_id"],
+                    "locator": table.get("locator"),
+                    "content_type": content_type or "other",
+                    "relevance": verdict,
+                    "relevance_note": note,
+                    "columns": _unique_columns(table, header_row),
+                    "n_columns": table.get("n_cols", 0),
+                    "header_row": header_row,
+                    "n_rows": max((table.get("n_rows") or 0) - header_row - 1, 0),
+                }
+                if item is not entry:
+                    candidate["member_path"] = item["member_path"]
+                out.append(candidate)
+    logger.info("%s: %d sheet candidate(s)", doi, len(out))
+    return out
+
+
+def _unique_columns(table: dict[str, Any], header_row: int) -> list[dict[str, str]]:
+    """Column names from the header row, de-duplicated, order preserved.
+
+    Multi-block sheets repeat a group of columns once per subject, so the same
+    names recur; recording the distinct set is what a reader needs.
+    """
+    rows = table.get("rows") or []
+    if header_row >= len(rows):
+        return []
+    seen: list[str] = []
+    for cell in rows[header_row]:
+        name = str(cell).strip()
+        if name and name not in seen:
+            seen.append(name)
+    return [{"name": name} for name in seen[:CANDIDATE_COLUMN_CAP]]
 
 
 def indexable(manifest: dict[str, Any]) -> list[dict[str, Any]]:

--- a/src/atlas_chat/atlas_chat/services/supplement_triage.py
+++ b/src/atlas_chat/atlas_chat/services/supplement_triage.py
@@ -317,10 +317,17 @@ def classify_caption(entry: dict[str, Any]) -> tuple[str, str] | None:
 # Triaging a whole paper
 # ------------------------------------------------------------------
 
-#: Kinds that can hold a table worth reading. A PDF may well carry a
-#: cluster-annotation table, but we cannot see its columns, so it is left
-#: unknown for a reader rather than guessed at.
-INSPECTABLE = {"xlsx", "csv", "tsv", "txt", "docx"}
+#: Kinds whose columns we read. Deliberately just the delimited and spreadsheet
+#: formats: they are where the tables that describe cell types actually live
+#: (105 of the 107 inspectable items in the reproductive-atlas corpus are xlsx),
+#: and their cost is flat in file size.
+#:
+#: PDF and docx are left alone on purpose. A Supplementary Information PDF may
+#: well carry a cluster-to-name table, but getting at it needs text extraction
+#: and layout reconstruction, which is a different and much larger job. They are
+#: recorded ``unknown`` with a note saying they were not inspected, so the
+#: absence of pointers for them is a stated decision rather than a silent gap.
+INSPECTABLE = {"xlsx", "csv", "tsv", "txt"}
 
 
 def triage_paper(store_root: Path, doi: str) -> dict[str, Any]:
@@ -393,7 +400,10 @@ def _judge(store_root: Path, entry: dict[str, Any], name: str) -> tuple[str, str
     if not path:
         return "unknown", "not on disk, so its columns could not be read"
     if kind not in INSPECTABLE:
-        return "unknown", f"{kind or 'unrecognised'} file — columns cannot be read from it"
+        return "unknown", (
+            f"not inspected: {kind or 'unrecognised format'} — only spreadsheet and "
+            "delimited files are read for columns. Its content may still be useful."
+        )
 
     try:
         outline = outline_file(store_root / path, sample_rows=6, max_cols=60)

--- a/tests/integration/test_supplement_fetch_live.py
+++ b/tests/integration/test_supplement_fetch_live.py
@@ -1,0 +1,171 @@
+"""Integration tests for supplement retrieval against the real services.
+
+No mocks. These fail hard if Europe PMC or a publisher host changes shape, which
+is the point: every route here is someone else's API, and the failure modes that
+matter were all discovered by running against real papers rather than by reading
+documentation.
+
+Papers are chosen from the reproductive-atlas corpus so each exercises a
+different branch of the waterfall, and each is small enough to fetch quickly.
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from atlas_chat.services import supplement_fetch as fetch
+from atlas_chat.services import supplement_store as store
+
+pytestmark = pytest.mark.integration
+
+# 3 files, ~3.6 MB — the smallest complete Springer case in the corpus.
+SPRINGER = "10.1038/s41588-024-01873-w"
+SPRINGER_PMCID = "PMC11387200"
+
+# In PMC, but its full text is not open: no article XML, and the bundle answers
+# HTTP 200 with a 165-byte non-zip body.
+NO_OPEN_FULLTEXT = "10.1016/j.devcel.2023.07.014"
+
+# Not in PMC at all — only a person can get this one.
+NOT_IN_PMC = "10.1126/science.adx0659"
+
+
+@pytest.fixture
+def client():
+    with httpx.Client(follow_redirects=True, timeout=fetch.TIMEOUT) as c:
+        yield c
+
+
+# ------------------------------------------------------------------
+# The routes, individually
+# ------------------------------------------------------------------
+
+
+def test_resolve_pmcid(client) -> None:
+    pmcid, title = fetch.resolve_pmcid(client, SPRINGER)
+
+    assert pmcid == SPRINGER_PMCID
+    assert title
+
+
+def test_resolve_pmcid_is_empty_for_a_paper_not_in_pmc(client) -> None:
+    """An empty PMCID is the signal that only a manual route remains."""
+    pmcid, _ = fetch.resolve_pmcid(client, NOT_IN_PMC)
+
+    assert pmcid == ""
+
+
+def test_article_xml_yields_filenames_and_captions(client, tmp_path) -> None:
+    path = fetch.fetch_jats(client, SPRINGER_PMCID, tmp_path / "paper.jats.xml")
+
+    assert path is not None
+    listed = store.inventory_from_jats(path)
+    assert len(listed) == 3
+    assert all(entry["file_id"].startswith("41588_2024_1873_") for entry in listed)
+    # Captions exist nowhere else, which is why this route runs first.
+    assert any(entry.get("caption") for entry in listed)
+
+
+def test_article_xml_absent_for_a_paper_without_open_fulltext(client, tmp_path) -> None:
+    pmcid, _ = fetch.resolve_pmcid(client, NO_OPEN_FULLTEXT)
+    assert pmcid, "this paper should still have a PMC record"
+
+    assert fetch.fetch_jats(client, pmcid, tmp_path / "paper.jats.xml") is None
+
+
+def test_bundle_members_are_named_as_the_article_xml_lists_them(client) -> None:
+    """What makes selective extraction possible, and skipping figure images."""
+    result = fetch.fetch_bundle(client, SPRINGER_PMCID)
+
+    assert result.archive is not None, result.reason
+    with result.archive as archive:
+        names = {n.rsplit("/", 1)[-1] for n in archive.namelist()}
+    assert "41588_2024_1873_MOESM3_ESM.xlsx" in names
+
+
+def test_bundle_answers_200_with_a_non_zip_when_nothing_is_open(client) -> None:
+    """The trap: a naive fetch records this as an empty archive and moves on."""
+    pmcid, _ = fetch.resolve_pmcid(client, NO_OPEN_FULLTEXT)
+
+    result = fetch.fetch_bundle(client, pmcid)
+
+    assert result.archive is None
+    assert "not a zip" in result.reason or "empty" in result.reason
+
+
+def test_springer_static_host_serves_files_individually(client) -> None:
+    url = fetch.springer_url(SPRINGER, "41588_2024_1873_MOESM3_ESM.xlsx")
+    assert url is not None
+
+    response = client.head(url)
+
+    assert response.status_code == 200
+    assert int(response.headers["content-length"]) > 10_000
+
+
+# ------------------------------------------------------------------
+# The waterfall end to end
+# ------------------------------------------------------------------
+
+
+def test_springer_paper_is_fully_retrieved(tmp_path, client) -> None:
+    manifest = fetch.fetch_supplements(tmp_path, SPRINGER, client=client)
+
+    store.validate_manifest(manifest)
+    assert store.cross_check_manifest(manifest) == []
+    assert len(manifest["files"]) == 3
+    assert all(f["status"] == "present" for f in manifest["files"])
+    assert manifest["gaps"] == []
+    for entry in manifest["files"]:
+        assert (tmp_path / entry["path"]).stat().st_size == entry["size_bytes"]
+        assert len(entry["retrieval"]["sha256"]) == 64
+
+
+def test_publisher_direct_produces_the_same_bytes_as_the_bundle(tmp_path, client) -> None:
+    """Two routes to the same file must agree, or the fallback is a silent lie."""
+    via_bundle = fetch.fetch_supplements(tmp_path / "bundle", SPRINGER, client=client)
+    via_publisher = fetch.fetch_supplements(
+        tmp_path / "direct", SPRINGER, bundle_cap=1000, client=client
+    )
+
+    routes = {f["retrieval"]["route"] for f in via_publisher["files"]}
+    assert routes == {"publisher_direct"}
+
+    left = {f["file_id"]: f["retrieval"]["sha256"] for f in via_bundle["files"]}
+    right = {f["file_id"]: f["retrieval"]["sha256"] for f in via_publisher["files"]}
+    assert left == right
+
+
+def test_unreachable_paper_degrades_to_an_actionable_gap(tmp_path, client) -> None:
+    manifest = fetch.fetch_supplements(tmp_path, NOT_IN_PMC, client=client)
+
+    store.validate_manifest(manifest)
+    assert manifest["files"] == []
+    gap = manifest["gaps"][0]
+    assert "no PMC record" in gap["reason"]
+    assert NOT_IN_PMC in gap["action"]
+
+
+def test_negative_cache_stops_a_second_attempt(tmp_path, client) -> None:
+    """A permanently missing supplement must not be re-requested every run."""
+    first = fetch.fetch_supplements(tmp_path, NO_OPEN_FULLTEXT, client=client)
+    gaps_first = len(first["gaps"])
+
+    second = fetch.fetch_supplements(tmp_path, NO_OPEN_FULLTEXT, client=client)
+
+    assert len(second["gaps"]) == gaps_first, "re-running must not accumulate gaps"
+    store.validate_manifest(second)
+
+
+def test_retrieved_files_are_immediately_indexable(tmp_path, client) -> None:
+    """The two halves must meet: what fetch writes, the store can outline."""
+    manifest = fetch.fetch_supplements(tmp_path, SPRINGER, client=client)
+
+    workbook = next(f for f in manifest["files"] if f["file_id"].endswith(".xlsx"))
+    outline = store.outline_file(tmp_path / workbook["path"])
+
+    assert outline["tables"]
+    table = outline["tables"][0]
+    assert table["n_rows"] > 0
+    assert "header_row_guess" in table

--- a/tests/integration/test_supplement_fetch_live.py
+++ b/tests/integration/test_supplement_fetch_live.py
@@ -11,6 +11,8 @@ different branch of the waterfall, and each is small enough to fetch quickly.
 
 from __future__ import annotations
 
+from collections import Counter
+
 import httpx
 import pytest
 
@@ -115,9 +117,15 @@ def test_springer_paper_is_fully_retrieved(tmp_path, client) -> None:
     store.validate_manifest(manifest)
     assert store.cross_check_manifest(manifest) == []
     assert len(manifest["files"]) == 3
-    assert all(f["status"] == "present" for f in manifest["files"])
+    # One of the three is this paper's Reporting Summary, which triage rules out
+    # on its caption before any bytes move. Nothing is missing.
+    statuses = Counter(f["status"] for f in manifest["files"])
+    assert statuses == {"present": 2, "skipped": 1}
     assert manifest["gaps"] == []
     for entry in manifest["files"]:
+        if entry["status"] != "present":
+            assert "path" not in entry, "skipped means no bytes were fetched"
+            continue
         assert (tmp_path / entry["path"]).stat().st_size == entry["size_bytes"]
         assert len(entry["retrieval"]["sha256"]) == 64
 
@@ -129,11 +137,15 @@ def test_publisher_direct_produces_the_same_bytes_as_the_bundle(tmp_path, client
         tmp_path / "direct", SPRINGER, bundle_cap=1000, client=client
     )
 
-    routes = {f["retrieval"]["route"] for f in via_publisher["files"]}
-    assert routes == {"publisher_direct"}
+    fetched = [f for f in via_publisher["files"] if f["status"] == "present"]
+    assert {f["retrieval"]["route"] for f in fetched} == {"publisher_direct"}
 
-    left = {f["file_id"]: f["retrieval"]["sha256"] for f in via_bundle["files"]}
-    right = {f["file_id"]: f["retrieval"]["sha256"] for f in via_publisher["files"]}
+    left = {
+        f["file_id"]: f["retrieval"]["sha256"]
+        for f in via_bundle["files"]
+        if f["status"] == "present"
+    }
+    right = {f["file_id"]: f["retrieval"]["sha256"] for f in fetched}
     assert left == right
 
 

--- a/tests/integration/test_supplement_store_live.py
+++ b/tests/integration/test_supplement_store_live.py
@@ -80,6 +80,7 @@ def test_publisher_direct_serves_individual_files() -> None:
 # The real store
 # ------------------------------------------------------------------
 
+
 def _material_on_disk() -> bool:
     """Whether the supplement *bytes* are here, not just the manifest.
 

--- a/tests/integration/test_supplement_store_live.py
+++ b/tests/integration/test_supplement_store_live.py
@@ -80,11 +80,29 @@ def test_publisher_direct_serves_individual_files() -> None:
 # The real store
 # ------------------------------------------------------------------
 
+def _material_on_disk() -> bool:
+    """Whether the supplement *bytes* are here, not just the manifest.
+
+    The manifest is committed; the files it describes are git-ignored, so a
+    fresh worktree has the one without the other. Testing for the manifest alone
+    makes these tests fail instead of skip wherever the material has not been
+    fetched.
+    """
+    manifest = store.load_manifest(STORE, ATLAS_DOI)
+    if manifest is None:
+        return False
+    return any(
+        entry.get("path") and (STORE / entry["path"]).exists()
+        for entry in manifest.get("files", [])
+    )
+
+
 needs_store = pytest.mark.skipif(
-    not store.manifest_path(STORE, ATLAS_DOI).exists(),
+    not _material_on_disk(),
     reason=(
-        "prenatal skin supplements not on disk (git-ignored); see "
-        "projects/test_projects/fetal_skin_atlas/supplements/incoming/README.md"
+        "prenatal skin supplement files not on disk (git-ignored; the manifest "
+        "is committed without them). Fetch them with `cli_supplements fetch` or "
+        "see projects/test_projects/fetal_skin_atlas/supplements/incoming/README.md"
     ),
 )
 

--- a/tests/unit/test_supplement_fetch.py
+++ b/tests/unit/test_supplement_fetch.py
@@ -1,0 +1,381 @@
+"""Unit tests for the supplement retrieval waterfall.
+
+Route ordering, the negative cache, URL derivation and the failure modes that
+Europe PMC answers with HTTP 200. Network responses are served by an httpx mock
+transport so the *decisions* can be tested in isolation; the routes themselves
+are exercised for real in tests/integration/test_supplement_fetch_live.py.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import zipfile
+from pathlib import Path
+
+import httpx
+import pytest
+
+from atlas_chat.services import supplement_fetch as fetch
+from atlas_chat.services import supplement_store as store
+
+pytestmark = pytest.mark.unit
+
+DOI = "10.1038/s41588-024-01873-w"
+PMCID = "PMC11387200"
+STEM = "41588_2024_1873_"
+
+JATS = f"""<?xml version="1.0"?>
+<article xmlns:xlink="http://www.w3.org/1999/xlink"><body>
+  <supplementary-material xlink:href="{STEM}MOESM1_ESM.pdf">
+    <label>Supplementary Information</label>
+    <caption><p>Supplementary Figures 1-9.</p></caption>
+  </supplementary-material>
+  <supplementary-material xlink:href="{STEM}MOESM3_ESM.xlsx">
+    <label>Supplementary Tables</label>
+    <caption><p>Supplementary Tables 1-12.</p></caption>
+  </supplementary-material>
+</body></article>
+"""
+
+
+def _zip(members: dict[str, bytes]) -> bytes:
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(buffer, "w") as zf:
+        for name, payload in members.items():
+            zf.writestr(name, payload)
+    return buffer.getvalue()
+
+
+def _client(handler) -> httpx.Client:
+    return httpx.Client(transport=httpx.MockTransport(handler), follow_redirects=True)
+
+
+def _epmc_search_response() -> httpx.Response:
+    return httpx.Response(
+        200, json={"resultList": {"result": [{"pmcid": PMCID, "title": "A paper"}]}}
+    )
+
+
+# ------------------------------------------------------------------
+# URL derivation
+# ------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("doi", "expected"),
+    [
+        ("10.1038/s41586-024-08002-x", "41586_2024_8002_"),
+        ("10.1038/s41588-021-00972-2", "41588_2021_972_"),
+        ("10.1038/s41467-020-20358-y", "41467_2020_20358_"),
+        ("10.1038/s42003-022-04384-8", "42003_2022_4384_"),
+    ],
+)
+def test_springer_stem_derives_from_doi(doi: str, expected: str) -> None:
+    """The DOI's 3-digit year and zero-padded article number render differently."""
+    assert fetch.springer_esm_stem(doi) == expected
+
+
+def test_springer_stem_declines_other_publishers() -> None:
+    assert fetch.springer_esm_stem("10.1016/j.devcel.2024.01.006") is None
+
+
+def test_springer_url_encodes_the_doi() -> None:
+    url = fetch.springer_url("10.1038/s41586-024-08002-x", "x_MOESM6_ESM.xlsx")
+
+    assert url is not None
+    assert "art%3A10.1038%2Fs41586-024-08002-x" in url
+    assert url.endswith("/MediaObjects/x_MOESM6_ESM.xlsx")
+
+
+def test_no_template_for_unknown_publisher() -> None:
+    """Absence of a template is a routing fact, not an error."""
+    assert fetch.publisher_direct_url("10.1073/pnas.2404775121", "pnas.sd01.xlsx") is None
+
+
+# ------------------------------------------------------------------
+# The bundle's failure modes, all of which are HTTP 200
+# ------------------------------------------------------------------
+
+
+def test_bundle_empty_body_is_not_success() -> None:
+    """Europe PMC answers 200 with a short non-zip body when nothing is open.
+
+    Recorded as success this is an empty archive and a paper that looks as though
+    it has no supplements.
+    """
+    handler = lambda request: httpx.Response(200, content=b"No supplementary files found")  # noqa: E731
+
+    with _client(handler) as client:
+        result = fetch.fetch_bundle(client, PMCID)
+
+    assert result.archive is None
+    assert "not a zip" in result.reason
+
+
+def test_bundle_zero_bytes_is_not_success() -> None:
+    handler = lambda request: httpx.Response(200, content=b"")  # noqa: E731
+
+    with _client(handler) as client:
+        result = fetch.fetch_bundle(client, PMCID)
+
+    assert result.archive is None
+    assert "empty" in result.reason
+
+
+def test_bundle_abandoned_above_cap() -> None:
+    handler = lambda request: httpx.Response(200, content=b"x" * 5000)  # noqa: E731
+
+    with _client(handler) as client:
+        result = fetch.fetch_bundle(client, PMCID, cap=1000)
+
+    assert result.archive is None
+    assert "exceeds the 1000-byte cap" in result.reason
+    assert result.size > 1000
+
+
+def test_bundle_http_error_is_reported() -> None:
+    handler = lambda request: httpx.Response(503)  # noqa: E731
+
+    with _client(handler) as client:
+        result = fetch.fetch_bundle(client, PMCID)
+
+    assert result.archive is None
+    assert "HTTP 503" in result.reason
+
+
+def test_bundle_returns_an_archive() -> None:
+    payload = _zip({f"{STEM}MOESM1_ESM.pdf": b"%PDF-1.4"})
+    handler = lambda request: httpx.Response(200, content=payload)  # noqa: E731
+
+    with _client(handler) as client:
+        result = fetch.fetch_bundle(client, PMCID)
+        assert result.archive is not None
+        assert result.archive.namelist() == [f"{STEM}MOESM1_ESM.pdf"]
+
+
+# ------------------------------------------------------------------
+# The negative cache
+# ------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("entry", "retry", "expected", "note"),
+    [
+        ({"status": "present"}, False, False, "already on disk"),
+        ({"status": "present"}, True, False, "retry never re-fetches what we have"),
+        ({"status": "listed"}, False, True, "never tried"),
+        (
+            {
+                "status": "unavailable",
+                "retrieval": {"route": "none", "attempted_at": "2026-08-25T00:00:00+00:00"},
+            },
+            False,
+            False,
+            "tried and failed — do not ask again every run",
+        ),
+        (
+            {
+                "status": "unavailable",
+                "retrieval": {"route": "none", "attempted_at": "2026-08-25T00:00:00+00:00"},
+            },
+            True,
+            True,
+            "retry overrides the cache",
+        ),
+        (
+            {"status": "failed", "retrieval": {"route": "publisher_direct"}},
+            False,
+            True,
+            "failed without a stamp is not cached",
+        ),
+    ],
+)
+def test_should_attempt(entry: dict, retry: bool, expected: bool, note: str) -> None:
+    assert fetch.should_attempt(entry, retry) is expected, note
+
+
+# ------------------------------------------------------------------
+# The waterfall
+# ------------------------------------------------------------------
+
+
+def _waterfall_handler(
+    *,
+    jats: str | None = JATS,
+    bundle: bytes | None = None,
+    publisher_ok: bool = False,
+    calls: list[str] | None = None,
+):
+    def handler(request: httpx.Request) -> httpx.Response:
+        url = str(request.url)
+        if calls is not None:
+            calls.append(url)
+        if "/search" in url:
+            return _epmc_search_response()
+        if url.endswith("/fullTextXML"):
+            return httpx.Response(200, text=jats) if jats else httpx.Response(404)
+        if url.endswith("/supplementaryFiles"):
+            return (
+                httpx.Response(200, content=bundle) if bundle else httpx.Response(200, content=b"")
+            )
+        if "static-content.springer.com" in url:
+            return httpx.Response(200, content=b"payload") if publisher_ok else httpx.Response(404)
+        return httpx.Response(404)
+
+    return handler
+
+
+def test_bundle_route_stores_only_listed_files(tmp_path: Path) -> None:
+    """Figure images bloat the bundle; only the listed supplements are wanted."""
+    bundle = _zip(
+        {
+            f"{STEM}MOESM1_ESM.pdf": b"%PDF-1.4",
+            f"{STEM}MOESM3_ESM.xlsx": b"xlsx-bytes",
+            "41588_2024_1873_g001.jpg": b"\xff\xd8\xff",  # a figure, not a supplement
+        }
+    )
+    with _client(_waterfall_handler(bundle=bundle)) as client:
+        manifest = fetch.fetch_supplements(tmp_path, DOI, client=client)
+
+    by_id = {f["file_id"]: f for f in manifest["files"]}
+    assert by_id[f"{STEM}MOESM1_ESM.pdf"]["status"] == "present"
+    assert by_id[f"{STEM}MOESM1_ESM.pdf"]["retrieval"]["route"] == "europepmc_bundle"
+    assert by_id[f"{STEM}MOESM3_ESM.xlsx"]["status"] == "present"
+    assert "41588_2024_1873_g001.jpg" not in by_id
+    # The caption from the article XML survives into the manifest.
+    assert by_id[f"{STEM}MOESM3_ESM.xlsx"]["caption"] == "Supplementary Tables 1-12."
+    assert manifest["paper"]["pmcid"] == PMCID
+
+
+def test_publisher_direct_takes_over_when_the_bundle_is_capped(tmp_path: Path) -> None:
+    calls: list[str] = []
+    with _client(_waterfall_handler(bundle=b"x" * 5000, publisher_ok=True, calls=calls)) as client:
+        manifest = fetch.fetch_supplements(tmp_path, DOI, bundle_cap=1000, client=client)
+
+    routes = {f["file_id"]: f["retrieval"]["route"] for f in manifest["files"]}
+    assert set(routes.values()) == {"publisher_direct"}
+    assert all(f["status"] == "present" for f in manifest["files"])
+    # The bundle was tried before the per-file route, not instead of it.
+    assert any(u.endswith("/supplementaryFiles") for u in calls)
+    assert any("static-content.springer.com" in u for u in calls)
+
+
+def test_a_capped_bundle_is_not_a_gap_once_the_files_arrive(tmp_path: Path) -> None:
+    """How we got the bytes is a detail; a gap means something is missing."""
+    with _client(_waterfall_handler(bundle=b"x" * 5000, publisher_ok=True)) as client:
+        manifest = fetch.fetch_supplements(tmp_path, DOI, bundle_cap=1000, client=client)
+
+    assert manifest["gaps"] == []
+
+
+def test_everything_failing_leaves_actionable_gaps(tmp_path: Path) -> None:
+    with _client(_waterfall_handler(bundle=None, publisher_ok=False)) as client:
+        manifest = fetch.fetch_supplements(tmp_path, DOI, client=client)
+
+    assert all(f["status"] in {"failed", "unavailable"} for f in manifest["files"])
+    assert all(f["retrieval"]["attempted_at"] for f in manifest["files"])
+    assert manifest["gaps"]
+    assert all("incoming/" in gap["action"] for gap in manifest["gaps"] if "action" in gap)
+
+
+def test_no_pmc_record_records_the_manual_route(tmp_path: Path) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        if "/search" in str(request.url):
+            return httpx.Response(200, json={"resultList": {"result": []}})
+        return httpx.Response(404)
+
+    with _client(handler) as client:
+        manifest = fetch.fetch_supplements(tmp_path, "10.1126/science.adx0659", client=client)
+
+    assert manifest["files"] == []
+    gap = manifest["gaps"][0]
+    assert "no PMC record" in gap["reason"]
+    assert "doi.org/10.1126/science.adx0659" in gap["action"]
+
+
+def test_bundle_is_tried_even_with_no_article_xml(tmp_path: Path) -> None:
+    """A paper with no open full text can still have open supplements.
+
+    Without this the bundle is never attempted for such papers and their files
+    are reported unavailable without anyone having looked.
+    """
+    bundle = _zip({"mmc1.xlsx": b"xlsx", "gr1.jpg": b"\xff\xd8\xff"})
+    with _client(_waterfall_handler(jats=None, bundle=bundle)) as client:
+        manifest = fetch.fetch_supplements(tmp_path, "10.1016/j.devcel.2024.01.006", client=client)
+
+    by_id = {f["file_id"]: f for f in manifest["files"]}
+    assert by_id["mmc1.xlsx"]["status"] == "present"
+    assert "gr1.jpg" not in by_id
+    # No captions are possible without the article XML — say so.
+    assert any("no article XML" in gap["reason"] for gap in manifest["gaps"])
+
+
+def test_second_run_does_not_refetch(tmp_path: Path) -> None:
+    bundle = _zip({f"{STEM}MOESM1_ESM.pdf": b"%PDF", f"{STEM}MOESM3_ESM.xlsx": b"x"})
+    calls: list[str] = []
+    with _client(_waterfall_handler(bundle=bundle, calls=calls)) as client:
+        fetch.fetch_supplements(tmp_path, DOI, client=client)
+        first = len([u for u in calls if u.endswith("/supplementaryFiles")])
+        fetch.fetch_supplements(tmp_path, DOI, client=client)
+        second = len([u for u in calls if u.endswith("/supplementaryFiles")])
+
+    assert first == 1
+    assert second == 1, "files already present must not trigger another bundle download"
+
+
+def test_manifest_stays_schema_valid_through_the_waterfall(tmp_path: Path) -> None:
+    with _client(_waterfall_handler(bundle=None)) as client:
+        manifest = fetch.fetch_supplements(tmp_path, DOI, client=client)
+
+    store.validate_manifest(manifest)
+    assert store.cross_check_manifest(manifest) == []
+
+
+def test_video_is_never_fetched(tmp_path: Path) -> None:
+    """Supplementary video is what makes bundles enormous and holds no tables."""
+    jats = JATS.replace(f"{STEM}MOESM3_ESM.xlsx", f"{STEM}MOESM5_ESM.mp4")
+    bundle = _zip({f"{STEM}MOESM1_ESM.pdf": b"%PDF", f"{STEM}MOESM5_ESM.mp4": b"video"})
+    with _client(_waterfall_handler(jats=jats, bundle=bundle)) as client:
+        manifest = fetch.fetch_supplements(tmp_path, DOI, client=client)
+
+    video = next(f for f in manifest["files"] if f["file_id"].endswith(".mp4"))
+    assert video["status"] == "listed", "listed so it is known, not fetched"
+
+
+# ------------------------------------------------------------------
+# Corpus level
+# ------------------------------------------------------------------
+
+
+def test_fetch_corpus_continues_past_a_failing_paper(tmp_path: Path, monkeypatch) -> None:
+    cas = {
+        "source": {
+            "doi": "10.1038/atlas-1",
+            "subatlas_papers": [{"label": "s", "doi": "10.1038/sub-1"}],
+        }
+    }
+    seen: list[str] = []
+
+    def fake(store_root, doi, **kwargs):
+        seen.append(doi)
+        if doi == "10.1038/atlas-1":
+            raise httpx.ConnectError("network gone")
+        return {"files": [{"status": "present"}], "gaps": []}
+
+    monkeypatch.setattr(fetch, "fetch_supplements", fake)
+    rows = fetch.fetch_corpus(tmp_path, cas)
+
+    assert seen == ["10.1038/atlas-1", "10.1038/sub-1"]
+    assert "error" in rows[0]
+    assert rows[1]["present"] == 1
+
+
+def test_cli_fetch_rejects_both_doi_and_cas(tmp_path: Path, capsys) -> None:
+    cas = tmp_path / "cas.json"
+    cas.write_text(json.dumps({"source": {"doi": "10.1038/x"}}))
+
+    code = store.main(["fetch", "--store", str(tmp_path), "--doi", "10.1038/x", "--cas", str(cas)])
+
+    assert code == 2
+    assert "exactly one" in capsys.readouterr().err

--- a/tests/unit/test_supplement_fetch.py
+++ b/tests/unit/test_supplement_fetch.py
@@ -39,12 +39,30 @@ JATS = f"""<?xml version="1.0"?>
 """
 
 
+def _xlsx() -> bytes:
+    """A minimal but structurally valid .xlsx payload.
+
+    Retrieval verifies that a file is the format it claims, so a fixture using
+    b"xlsx-bytes" would be rejected — as it should be. Real payloads open.
+    """
+    return _zip({"[Content_Types].xml": b"<Types/>"})
+
+
+def _pdf() -> bytes:
+    return b"%PDF-1.4\n%%EOF\n"
+
+
 def _zip(members: dict[str, bytes]) -> bytes:
     buffer = io.BytesIO()
     with zipfile.ZipFile(buffer, "w") as zf:
         for name, payload in members.items():
             zf.writestr(name, payload)
     return buffer.getvalue()
+
+
+def _payload_for(url: str) -> bytes:
+    """A payload that will survive the integrity check for the requested name."""
+    return _pdf() if url.endswith(".pdf") else _xlsx()
 
 
 def _client(handler) -> httpx.Client:
@@ -145,7 +163,7 @@ def test_bundle_http_error_is_reported() -> None:
 
 
 def test_bundle_returns_an_archive() -> None:
-    payload = _zip({f"{STEM}MOESM1_ESM.pdf": b"%PDF-1.4"})
+    payload = _zip({f"{STEM}MOESM1_ESM.pdf": _pdf()})
     handler = lambda request: httpx.Response(200, content=payload)  # noqa: E731
 
     with _client(handler) as client:
@@ -220,7 +238,11 @@ def _waterfall_handler(
                 httpx.Response(200, content=bundle) if bundle else httpx.Response(200, content=b"")
             )
         if "static-content.springer.com" in url:
-            return httpx.Response(200, content=b"payload") if publisher_ok else httpx.Response(404)
+            return (
+                httpx.Response(200, content=_payload_for(url))
+                if publisher_ok
+                else httpx.Response(404)
+            )
         return httpx.Response(404)
 
     return handler
@@ -230,8 +252,8 @@ def test_bundle_route_stores_only_listed_files(tmp_path: Path) -> None:
     """Figure images bloat the bundle; only the listed supplements are wanted."""
     bundle = _zip(
         {
-            f"{STEM}MOESM1_ESM.pdf": b"%PDF-1.4",
-            f"{STEM}MOESM3_ESM.xlsx": b"xlsx-bytes",
+            f"{STEM}MOESM1_ESM.pdf": _pdf(),
+            f"{STEM}MOESM3_ESM.xlsx": _xlsx(),
             "41588_2024_1873_g001.jpg": b"\xff\xd8\xff",  # a figure, not a supplement
         }
     )
@@ -300,7 +322,7 @@ def test_bundle_is_tried_even_with_no_article_xml(tmp_path: Path) -> None:
     Without this the bundle is never attempted for such papers and their files
     are reported unavailable without anyone having looked.
     """
-    bundle = _zip({"mmc1.xlsx": b"xlsx", "gr1.jpg": b"\xff\xd8\xff"})
+    bundle = _zip({"mmc1.xlsx": _xlsx(), "gr1.jpg": b"\xff\xd8\xff"})
     with _client(_waterfall_handler(jats=None, bundle=bundle)) as client:
         manifest = fetch.fetch_supplements(tmp_path, "10.1016/j.devcel.2024.01.006", client=client)
 
@@ -312,7 +334,7 @@ def test_bundle_is_tried_even_with_no_article_xml(tmp_path: Path) -> None:
 
 
 def test_second_run_does_not_refetch(tmp_path: Path) -> None:
-    bundle = _zip({f"{STEM}MOESM1_ESM.pdf": b"%PDF", f"{STEM}MOESM3_ESM.xlsx": b"x"})
+    bundle = _zip({f"{STEM}MOESM1_ESM.pdf": _pdf(), f"{STEM}MOESM3_ESM.xlsx": _xlsx()})
     calls: list[str] = []
     with _client(_waterfall_handler(bundle=bundle, calls=calls)) as client:
         fetch.fetch_supplements(tmp_path, DOI, client=client)
@@ -335,7 +357,7 @@ def test_manifest_stays_schema_valid_through_the_waterfall(tmp_path: Path) -> No
 def test_video_is_never_fetched(tmp_path: Path) -> None:
     """Supplementary video is what makes bundles enormous and holds no tables."""
     jats = JATS.replace(f"{STEM}MOESM3_ESM.xlsx", f"{STEM}MOESM5_ESM.mp4")
-    bundle = _zip({f"{STEM}MOESM1_ESM.pdf": b"%PDF", f"{STEM}MOESM5_ESM.mp4": b"video"})
+    bundle = _zip({f"{STEM}MOESM1_ESM.pdf": _pdf(), f"{STEM}MOESM5_ESM.mp4": b"video"})
     with _client(_waterfall_handler(jats=jats, bundle=bundle)) as client:
         manifest = fetch.fetch_supplements(tmp_path, DOI, client=client)
 
@@ -379,3 +401,128 @@ def test_cli_fetch_rejects_both_doi_and_cas(tmp_path: Path, capsys) -> None:
 
     assert code == 2
     assert "exactly one" in capsys.readouterr().err
+
+
+# ------------------------------------------------------------------
+# Not everything in a supplement bundle is evidence
+# ------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("entry", "expected"),
+    [
+        ({"label": "Reporting Summary"}, True),
+        ({"caption": "Peer Review file"}, True),
+        ({"caption": "Peer review information"}, True),
+        ({"label": "Supplementary Tables", "caption": "Supplementary Tables 1-40."}, False),
+        ({"caption": "Source Data Figs. 2 and 4"}, False),
+        # No caption is not evidence of absence — fetch it and let indexing judge.
+        ({"file_id": "mmc9.pdf"}, False),
+    ],
+)
+def test_is_non_evidence_uses_the_publisher_s_own_words(entry: dict, expected: bool) -> None:
+    assert fetch.is_non_evidence(entry) is expected
+
+
+def test_process_artefacts_are_skipped_before_any_bytes_move(tmp_path: Path) -> None:
+    """Their captions say what they are, and captions arrive before the bytes."""
+    jats = f"""<?xml version="1.0"?>
+    <article xmlns:xlink="http://www.w3.org/1999/xlink"><body>
+      <supplementary-material xlink:href="{STEM}MOESM1_ESM.xlsx">
+        <label>Supplementary Tables</label><caption><p>Supplementary Tables 1-9.</p></caption>
+      </supplementary-material>
+      <supplementary-material xlink:href="{STEM}MOESM2_ESM.pdf">
+        <caption><p>Reporting Summary</p></caption>
+      </supplementary-material>
+      <supplementary-material xlink:href="{STEM}MOESM3_ESM.pdf">
+        <caption><p>Peer Review file</p></caption>
+      </supplementary-material>
+    </body></article>"""
+    bundle = _zip(
+        {
+            f"{STEM}MOESM1_ESM.xlsx": _xlsx(),
+            f"{STEM}MOESM2_ESM.pdf": _pdf(),
+            f"{STEM}MOESM3_ESM.pdf": _pdf(),
+        }
+    )
+    with _client(_waterfall_handler(jats=jats, bundle=bundle)) as client:
+        manifest = fetch.fetch_supplements(tmp_path, DOI, client=client)
+
+    by_id = {f["file_id"]: f for f in manifest["files"]}
+    assert by_id[f"{STEM}MOESM1_ESM.xlsx"]["status"] == "present"
+    for artefact in (f"{STEM}MOESM2_ESM.pdf", f"{STEM}MOESM3_ESM.pdf"):
+        assert by_id[artefact]["status"] == "skipped"
+        assert "path" not in by_id[artefact], "skipped means no bytes on disk"
+    # Skipping is not a gap: nothing is missing that anyone wanted.
+    assert manifest["gaps"] == []
+    store.validate_manifest(manifest)
+    assert store.cross_check_manifest(manifest) == []
+
+
+# ------------------------------------------------------------------
+# Payload integrity — a route can return bytes nothing can open
+# ------------------------------------------------------------------
+
+
+def test_verify_payload_accepts_real_formats(tmp_path: Path) -> None:
+    book = tmp_path / "t.xlsx"
+    book.write_bytes(_xlsx())
+    doc = tmp_path / "t.pdf"
+    doc.write_bytes(_pdf())
+
+    assert fetch.verify_payload(book, "xlsx") == (True, "ok")
+    assert fetch.verify_payload(doc, "pdf") == (True, "ok")
+
+
+@pytest.mark.parametrize(
+    ("name", "media", "payload", "expected"),
+    [
+        # The real case: Europe PMC's bundle for PMC8648563 carries an 18.5 MB
+        # copy of a workbook the publisher serves at 35.7 MB, truncated so no
+        # zip reader can open it.
+        ("t.xlsx", "xlsx", b"PK\x03\x04" + b"\x00" * 100, "not a readable zip"),
+        ("t.xlsx", "xlsx", b"", "zero bytes"),
+        ("t.pdf", "pdf", b"<html>Access denied</html>", "no %PDF header"),
+    ],
+)
+def test_verify_payload_rejects_broken_bytes(
+    tmp_path: Path, name: str, media: str, payload: bytes, expected: str
+) -> None:
+    path = tmp_path / name
+    path.write_bytes(payload)
+
+    ok, note = fetch.verify_payload(path, media)
+
+    assert ok is False
+    assert expected in note
+
+
+def test_a_corrupt_bundle_copy_falls_through_to_the_publisher(tmp_path: Path) -> None:
+    """The bundle is not authoritative: verify, then let the next route try."""
+    bundle = _zip(
+        {
+            f"{STEM}MOESM1_ESM.pdf": _pdf(),
+            f"{STEM}MOESM3_ESM.xlsx": b"PK\x03\x04truncated",  # what EPMC actually served
+        }
+    )
+    with _client(_waterfall_handler(bundle=bundle, publisher_ok=True)) as client:
+        manifest = fetch.fetch_supplements(tmp_path, DOI, client=client)
+
+    by_id = {f["file_id"]: f for f in manifest["files"]}
+    assert by_id[f"{STEM}MOESM1_ESM.pdf"]["retrieval"]["route"] == "europepmc_bundle"
+    rescued = by_id[f"{STEM}MOESM3_ESM.xlsx"]
+    assert rescued["status"] == "present"
+    assert rescued["retrieval"]["route"] == "publisher_direct"
+    assert manifest["gaps"] == []
+
+
+def test_corrupt_bytes_are_not_left_on_disk(tmp_path: Path) -> None:
+    """Storing an unopenable file would poison indexing later."""
+    bundle = _zip({f"{STEM}MOESM3_ESM.xlsx": b"PK\x03\x04truncated"})
+    with _client(_waterfall_handler(bundle=bundle, publisher_ok=False)) as client:
+        manifest = fetch.fetch_supplements(tmp_path, DOI, client=client)
+
+    entry = next(f for f in manifest["files"] if f["file_id"].endswith(".xlsx"))
+    assert entry["status"] in {"failed", "unavailable"}
+    assert "path" not in entry
+    assert not list((tmp_path / "papers").rglob("*.xlsx"))

--- a/tests/unit/test_supplement_store.py
+++ b/tests/unit/test_supplement_store.py
@@ -910,3 +910,36 @@ def test_header_detection_survives_a_small_sample(tmp_path: Path) -> None:
     assert table["header_row_guess"] == 2
     # Still only returns what was asked for.
     assert len(table["rows"]) == 2
+
+
+def test_outline_counts_rows_when_the_workbook_omits_its_dimensions() -> None:
+    """openpyxl read-only reports None for max_row on some publisher files.
+
+    Passing that through puts a null where every consumer expects a count — and
+    `n_rows` is what tells a reader a table needs slicing rather than opening.
+    """
+
+    class DimensionlessSheet:
+        title = "Sheet1"
+        max_row = None
+        max_column = None
+
+        def iter_rows(self, values_only=False, max_row=None, max_col=None):
+            rows = [("gene", "lfc", None), ("A", 1.0, None), ("B", 2.0, None)]
+            for index, row in enumerate(rows):
+                if max_row is not None and index >= max_row:
+                    return
+                yield row[:max_col] if max_col else row
+
+    assert store._xlsx_dimensions(DimensionlessSheet()) == (3, 2)
+
+
+def test_xlsx_dimensions_prefers_the_cheap_answer() -> None:
+    class Sheet:
+        max_row = 500
+        max_column = 12
+
+        def iter_rows(self, **kwargs):  # pragma: no cover - must not be called
+            raise AssertionError("should not stream when dimensions are known")
+
+    assert store._xlsx_dimensions(Sheet()) == (500, 12)

--- a/tests/unit/test_supplement_store.py
+++ b/tests/unit/test_supplement_store.py
@@ -934,15 +934,38 @@ def test_outline_counts_rows_when_the_workbook_omits_its_dimensions() -> None:
     assert store._xlsx_dimensions(DimensionlessSheet()) == (3, 2)
 
 
-def test_xlsx_dimensions_prefers_the_cheap_answer() -> None:
+def test_a_large_declared_extent_is_trusted_without_streaming() -> None:
+    """Scanning a 396,880-row sheet costs 18s; its declaration has held up."""
+
     class Sheet:
-        max_row = 500
+        max_row = store.VERIFY_ROWS_AT_OR_BELOW + 1
         max_column = 12
 
         def iter_rows(self, **kwargs):  # pragma: no cover - must not be called
-            raise AssertionError("should not stream when dimensions are known")
+            raise AssertionError("should not stream above the verify threshold")
 
-    assert store._xlsx_dimensions(Sheet()) == (500, 12)
+    assert store._xlsx_dimensions(Sheet()) == (store.VERIFY_ROWS_AT_OR_BELOW + 1, 12)
+
+
+def test_a_small_declared_extent_is_verified() -> None:
+    """Publisher sheets declare a round extent when formatting ran past the data.
+
+    Real case: sheets in the Garcia-Alonso 2021 supplement declare 1000 rows for
+    9 rows of content, and n_rows is what tells a reader to slice rather than
+    read whole.
+    """
+
+    class InflatedSheet:
+        max_row = 1000  # declared
+        max_column = 10
+
+        def iter_rows(self, values_only=False, max_row=None, max_col=None):
+            yield ("Organoid Cluster:", "SOX9+LGR5-")
+            yield ("Lumenal 1", 0.4)
+            for _ in range(998):
+                yield (None, None)
+
+    assert store._xlsx_dimensions(InflatedSheet()) == (2, 2)
 
 
 def test_xlsx_dimensions_ignores_trailing_empty_rows() -> None:

--- a/tests/unit/test_supplement_store.py
+++ b/tests/unit/test_supplement_store.py
@@ -943,3 +943,38 @@ def test_xlsx_dimensions_prefers_the_cheap_answer() -> None:
             raise AssertionError("should not stream when dimensions are known")
 
     assert store._xlsx_dimensions(Sheet()) == (500, 12)
+
+
+def test_xlsx_dimensions_ignores_trailing_empty_rows() -> None:
+    """Formatting applied past the data must not inflate the row count.
+
+    Real case: a subject table with 35 rows of data in a sheet formatted to row
+    1000 reported 1000, which tells a reader to slice a table small enough to
+    read whole.
+    """
+
+    class FormattedFarSheet:
+        max_row = None
+        max_column = None
+
+        def iter_rows(self, values_only=False, max_row=None, max_col=None):
+            yield ("Subject", "Age", None)
+            yield ("S1", 59, None)
+            yield ("S2", 65, None)
+            for _ in range(200):  # formatted, but empty
+                yield (None, None, None)
+
+    assert store._xlsx_dimensions(FormattedFarSheet()) == (3, 2)
+
+
+def test_xlsx_dimensions_ignores_whitespace_only_cells() -> None:
+    class Sheet:
+        max_row = None
+        max_column = None
+
+        def iter_rows(self, values_only=False, max_row=None, max_col=None):
+            yield ("gene", "lfc")
+            yield ("A", 1.0)
+            yield ("   ", "")
+
+    assert store._xlsx_dimensions(Sheet()) == (2, 2)

--- a/tests/unit/test_supplement_triage.py
+++ b/tests/unit/test_supplement_triage.py
@@ -68,17 +68,17 @@ def _table(columns: list[str], data: list[list[str]] | None = None, locator="She
         (
             ["Gene_set", "Term", "Overlap", "P-value", "Adjusted P-value", "Odds Ratio"],
             "relevant",
-            "other",
+            "enrichment",
             "Gopee Table 24, GSEA for iron-recycling macrophages",
         ),
         # interactions
         (
             ["gene_pair", "celltype_pair", "mean", "p", "padj"],
             "relevant",
-            "other",
+            "interaction",
             "Gopee Table 28, CellPhoneDB",
         ),
-        (["ligand", "target", "weight"], "relevant", "other", "Gopee Table 36, NicheNet"),
+        (["ligand", "target", "weight"], "relevant", "interaction", "Gopee Table 36, NicheNet"),
         # per-cell label transfer
         (
             ["", "LR_assignment", "Adipocyte", "B cell", "DC"],
@@ -100,13 +100,13 @@ def _table(columns: list[str], data: list[list[str]] | None = None, locator="She
         (
             ["RRID citation", "Antibody", "Vendor", "Cat no", "Clone"],
             "irrelevant",
-            "other",
+            "reagents",
             "Gopee Table 38, antibodies",
         ),
         (
             ["positive regulation of angiogenesis (GO:0045766)"],
             "irrelevant",
-            "other",
+            "gene_set",
             "Gopee Table 27, gene-set definitions",
         ),
     ],
@@ -440,3 +440,156 @@ def test_uninspected_formats_say_so_explicitly(tmp_path: Path, kind: str) -> Non
     entry = manifest["files"][0]
     assert entry["relevance"] == "unknown", "never irrelevant — we simply did not look"
     assert "not inspected" in entry["relevance_note"]
+
+
+# ------------------------------------------------------------------
+# Sheet-level candidates
+# ------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("columns", "content_type", "source"),
+    [
+        (
+            ["gene", "cluster", "geneFrequency", "secondBestClusterName", "tfidf", "qval"],
+            "marker_list",
+            "s41586-022-04918-4 TF-IDF markers. 'name' as a substring of "
+            "secondBestClusterName once made this a cluster-to-name mapping — the "
+            "one field the corpus is short of, where a false positive is worst",
+        ),
+        (["cluster", "annotation"], "cluster_annotation", "a genuine mapping"),
+        (["cluster", "name"], "cluster_annotation", "exact 'name' still counts"),
+        (
+            ["cluster", "Regulon", "NES", "p.value", "FDR"],
+            "enrichment",
+            "Dorothea regulon activity",
+        ),
+        (
+            ["SOX9_LGR5--Preciliated", "Ciliated--Ciliated"],
+            "interaction",
+            "CellPhoneDB matrix: columns are cell-type pairs",
+        ),
+        (
+            ["partner_a", "partner_b", "protein_name_a", "annotation_strategy"],
+            "interaction",
+            "CellPhoneDB's curated-interaction schema",
+        ),
+        (
+            ["Product", "Description", "Company", "Product Number", "Final Concentration"],
+            "reagents",
+            "culture-medium components: says Company, not Vendor",
+        ),
+        (["TF", "target", "effect", "Source"], "gene_set", "a curated regulatory network"),
+    ],
+)
+def test_extended_content_types(columns: list[str], content_type: str, source: str) -> None:
+    assert triage.classify_table(_table(columns))[1] == content_type, source
+
+
+def test_exact_matching_does_not_fire_on_a_substring() -> None:
+    """The mechanism behind the marker/mapping fix."""
+    sig = triage.Signature("x", "other", True, required=("cluster",), exact_any_of=("name",))
+
+    assert sig.matches({"cluster", "name"}) is True
+    assert sig.matches({"cluster", "secondbestclustername"}) is False
+
+
+def test_sheet_candidates_judges_each_sheet_separately(tmp_path: Path) -> None:
+    """The point of sheet-level pointers: one workbook, two different answers."""
+    openpyxl = pytest.importorskip("openpyxl")
+    from atlas_chat.services.supplement_store import MANIFEST_VERSION, write_manifest
+
+    files = tmp_path / "papers" / "10.1038_test" / "files"
+    files.mkdir(parents=True)
+    book = files / "mixed.xlsx"
+    wb = openpyxl.Workbook()
+    degs = wb.active
+    degs.title = "DEGs"
+    degs.append(["Supplementary Table 4 | DEGs by cluster"])  # a title row
+    degs.append(["names", "logfoldchanges", "pvals_adj"])
+    degs.append(["DAB2", 4.18, 0.0])
+    ab = wb.create_sheet("Antibodies")
+    ab.append(["Antibody", "Vendor", "Cat no"])
+    ab.append(["anti-CD45", "Abcam", "ab123"])
+    wb.save(book)
+
+    write_manifest(
+        tmp_path,
+        "10.1038/test",
+        {
+            "manifest_version": MANIFEST_VERSION,
+            "paper": {"doi": "10.1038/test"},
+            "files": [
+                {
+                    "file_id": "mixed.xlsx",
+                    "media_type": "xlsx",
+                    "status": "present",
+                    "path": "papers/10.1038_test/files/mixed.xlsx",
+                }
+            ],
+        },
+    )
+
+    candidates = triage.sheet_candidates(tmp_path, "10.1038/test")
+
+    by_sheet = {c["locator"]: c for c in candidates}
+    assert by_sheet["DEGs"]["relevance"] == "relevant"
+    assert by_sheet["DEGs"]["content_type"] == "deg_results"
+    # The title row is skipped, so the recorded columns are the real ones.
+    assert by_sheet["DEGs"]["header_row"] == 1
+    assert [c["name"] for c in by_sheet["DEGs"]["columns"]] == [
+        "names",
+        "logfoldchanges",
+        "pvals_adj",
+    ]
+    assert by_sheet["DEGs"]["n_rows"] == 1
+
+    assert by_sheet["Antibodies"]["relevance"] == "irrelevant"
+    assert by_sheet["Antibodies"]["content_type"] == "reagents"
+    # An irrelevant sheet is still returned, so it is accounted for.
+    assert len(candidates) == 2
+
+
+def test_sheet_candidates_omits_description(tmp_path: Path, stored: Path) -> None:
+    """What a table is FOR is the skill's judgement, not the service's."""
+    candidates = triage.sheet_candidates(stored, "10.1038/test")
+
+    assert candidates
+    assert all("description" not in c for c in candidates)
+    assert all(c["relevance"] in {"relevant", "irrelevant", "unknown"} for c in candidates)
+
+
+def test_sheet_candidates_dedupes_repeated_block_columns(tmp_path: Path) -> None:
+    """Multi-block sheets repeat a column group per subject."""
+    openpyxl = pytest.importorskip("openpyxl")
+    from atlas_chat.services.supplement_store import MANIFEST_VERSION, write_manifest
+
+    files = tmp_path / "papers" / "10.1038_test" / "files"
+    files.mkdir(parents=True)
+    book = files / "blocks.xlsx"
+    wb = openpyxl.Workbook()
+    sheet = wb.active
+    sheet.append(["names", "logfoldchanges", "", "names", "logfoldchanges"])
+    sheet.append(["DAB2", 4.1, None, "STAB1", 1.6])
+    wb.save(book)
+    write_manifest(
+        tmp_path,
+        "10.1038/test",
+        {
+            "manifest_version": MANIFEST_VERSION,
+            "paper": {"doi": "10.1038/test"},
+            "files": [
+                {
+                    "file_id": "blocks.xlsx",
+                    "media_type": "xlsx",
+                    "status": "present",
+                    "path": "papers/10.1038_test/files/blocks.xlsx",
+                }
+            ],
+        },
+    )
+
+    candidate = triage.sheet_candidates(tmp_path, "10.1038/test")[0]
+
+    assert [c["name"] for c in candidate["columns"]] == ["names", "logfoldchanges"]
+    assert candidate["n_columns"] == 5, "the true width is still reported"

--- a/tests/unit/test_supplement_triage.py
+++ b/tests/unit/test_supplement_triage.py
@@ -1,0 +1,410 @@
+"""Unit tests for relevance triage.
+
+The signatures are a judgement about the aim — which files could describe cell
+types and their properties — so these tests pin that judgement on the column
+shapes real supplements actually have. Every column set below was taken from a
+paper in the reproductive-atlas or prenatal-skin corpora.
+
+The asymmetry that matters: a false ``relevant`` costs one wasted inspection, a
+false ``irrelevant`` silently drops evidence. So the unmatched case must be
+``unknown``, never ``irrelevant``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from atlas_chat.services import supplement_triage as triage
+
+pytestmark = pytest.mark.unit
+
+
+def _table(columns: list[str], data: list[list[str]] | None = None, locator="Sheet1") -> dict:
+    rows = [columns] + (data or [])
+    return {"locator": locator, "rows": rows, "header_row_guess": 0, "n_rows": len(rows)}
+
+
+# ------------------------------------------------------------------
+# Column signatures, against real column sets
+# ------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("columns", "verdict", "content_type", "source"),
+    [
+        # scanpy / Seurat differential expression
+        (
+            ["names", "scores", "logfoldchanges", "pvals", "pvals_adj"],
+            "relevant",
+            "deg_results",
+            "Gopee Supplementary Table 22, macrophage subsets",
+        ),
+        (
+            ["gene", "avg_log2FC", "p_val_adj", "cluster"],
+            "relevant",
+            "deg_results",
+            "JCI insight, epithelium markers",
+        ),
+        # edgeR / limma dialect — the case that first came back unknown
+        (
+            ["description", "ensembl_gene_id", "F", "FDR", "gene_biotype"],
+            "relevant",
+            "deg_results",
+            "JCI insight 195254, early-vs-proliferative",
+        ),
+        # DESeq2 dialect
+        (["gene", "baseMean", "log2FoldChange", "padj"], "relevant", "deg_results", "DESeq2"),
+        # cluster-to-name mapping — what name resolution depends on
+        (["cluster", "annotation"], "relevant", "cluster_annotation", "typical"),
+        (
+            ["No.", "Microenvironment label"],
+            "unknown",
+            None,
+            "Gopee Table 40 — 'label' without 'cluster' does not match",
+        ),
+        # enrichment
+        (
+            ["Gene_set", "Term", "Overlap", "P-value", "Adjusted P-value", "Odds Ratio"],
+            "relevant",
+            "other",
+            "Gopee Table 24, GSEA for iron-recycling macrophages",
+        ),
+        # interactions
+        (
+            ["gene_pair", "celltype_pair", "mean", "p", "padj"],
+            "relevant",
+            "other",
+            "Gopee Table 28, CellPhoneDB",
+        ),
+        (["ligand", "target", "weight"], "relevant", "other", "Gopee Table 36, NicheNet"),
+        # per-cell label transfer
+        (
+            ["", "LR_assignment", "Adipocyte", "B cell", "DC"],
+            "relevant",
+            "cell_metadata",
+            "Gopee Table 10, murine projection",
+        ),
+        # sample metadata
+        (["Sanger_id", "Donor", "PCW", "Sorting"], "relevant", "sample_metadata", "Gopee Table 1"),
+        (["subject", "phase", "bmi"], "relevant", "sample_metadata", "JCI insight Figure 1B"),
+        # abundance
+        (
+            ["PCW", "Donor", "Annotation_Fine", "Counts"],
+            "relevant",
+            "sample_metadata",
+            "Gopee source data Fig 2b — matches on Donor first",
+        ),
+        # not relevant: inputs, not findings
+        (
+            ["RRID citation", "Antibody", "Vendor", "Cat no", "Clone"],
+            "irrelevant",
+            "other",
+            "Gopee Table 38, antibodies",
+        ),
+        (
+            ["positive regulation of angiogenesis (GO:0045766)"],
+            "irrelevant",
+            "other",
+            "Gopee Table 27, gene-set definitions",
+        ),
+    ],
+)
+def test_classify_table(columns, verdict, content_type, source) -> None:
+    got_verdict, got_type, note = triage.classify_table(_table(columns))
+
+    assert got_verdict == verdict, f"{source}: {note}"
+    if content_type is not None:
+        assert got_type == content_type, source
+
+
+def test_unmatched_columns_are_unknown_not_irrelevant() -> None:
+    """The asymmetry: a wrong 'irrelevant' silently drops evidence."""
+    verdict, content_type, note = triage.classify_table(_table(["alpha", "beta", "gamma"]))
+
+    assert verdict == "unknown"
+    assert content_type is None
+    assert "matched no signature" in note
+
+
+def test_a_table_with_no_readable_header_is_unknown() -> None:
+    verdict, _, note = triage.classify_table({"rows": [], "header_row_guess": 0})
+
+    assert verdict == "unknown"
+    assert "no header row" in note
+
+
+def test_barcodes_make_a_table_relevant_despite_opaque_headers() -> None:
+    """One row per cell is evidence about cell types whatever the columns say."""
+    table = _table(
+        ["", "0", "1", "2"],
+        [["AAACCTGGTCAGTGGA-1-4834STDY7002879", "0.8", "0.1", "0.1"]],
+    )
+
+    verdict, content_type, note = triage.classify_table(table)
+
+    assert verdict == "relevant"
+    assert content_type == "cell_metadata"
+    assert "barcode" in note
+
+
+def test_columns_are_read_from_the_detected_header_row() -> None:
+    """Publisher tables carry title rows; reading row 0 would see the title."""
+    table = {
+        "locator": "Sheet1",
+        "rows": [
+            ["DEG analysis for macrophage subpopulations"],
+            ["", "names", "scores", "logfoldchanges", "pvals_adj"],
+            ["", "DAB2", "150.7", "4.18", "0"],
+        ],
+        "header_row_guess": 1,
+    }
+
+    assert triage.columns_of(table) == {"names", "scores", "logfoldchanges", "pvals_adj"}
+    assert triage.classify_table(table)[0] == "relevant"
+
+
+# ------------------------------------------------------------------
+# Captions
+# ------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("entry", "expected"),
+    [
+        ({"caption": "Reporting Summary"}, "irrelevant"),
+        ({"label": "Peer Review file"}, "irrelevant"),
+        ({"caption": "Editorial policy checklist"}, "irrelevant"),
+        # Uninformative captions must not be read as irrelevance: sixteen files
+        # in the reproductive-atlas corpus say only this.
+        ({"caption": "Supplementary Information"}, None),
+        ({"caption": "Data S1 to S8"}, None),
+        ({"label": "Supplementary Tables", "caption": "Supplementary Tables 1-40."}, None),
+        ({}, None),
+    ],
+)
+def test_classify_caption_rules_out_only_the_certain_cases(entry: dict, expected) -> None:
+    result = triage.classify_caption(entry)
+
+    assert (result[0] if result else None) == expected
+
+
+# ------------------------------------------------------------------
+# Triaging a stored paper
+# ------------------------------------------------------------------
+
+
+@pytest.fixture
+def stored(tmp_path: Path):
+    """A store holding one workbook, one reagent list and one peer review PDF."""
+    openpyxl = pytest.importorskip("openpyxl")
+    from atlas_chat.services.supplement_store import MANIFEST_VERSION, write_manifest
+
+    files = tmp_path / "papers" / "10.1038_test" / "files"
+    files.mkdir(parents=True)
+
+    degs = files / "tables.xlsx"
+    wb = openpyxl.Workbook()
+    sheet = wb.active
+    sheet.append(["names", "logfoldchanges", "pvals_adj"])
+    sheet.append(["DAB2", 4.18, 0.0])
+    wb.save(degs)
+
+    reagents = files / "antibodies.xlsx"
+    wb2 = openpyxl.Workbook()
+    s2 = wb2.active
+    s2.append(["RRID citation", "Antibody", "Vendor"])
+    s2.append(["AB_123", "anti-CD45", "Abcam"])
+    wb2.save(reagents)
+
+    review = files / "review.pdf"
+    review.write_bytes(b"%PDF-1.4 peer review")
+
+    manifest = {
+        "manifest_version": MANIFEST_VERSION,
+        "paper": {"doi": "10.1038/test"},
+        "files": [
+            {
+                "file_id": "tables.xlsx",
+                "media_type": "xlsx",
+                "status": "present",
+                "path": "papers/10.1038_test/files/tables.xlsx",
+            },
+            {
+                "file_id": "antibodies.xlsx",
+                "media_type": "xlsx",
+                "status": "present",
+                "path": "papers/10.1038_test/files/antibodies.xlsx",
+            },
+            {
+                "file_id": "review.pdf",
+                "media_type": "pdf",
+                "status": "present",
+                "caption": "Peer Review file",
+                "path": "papers/10.1038_test/files/review.pdf",
+            },
+            {"file_id": "gone.xlsx", "media_type": "xlsx", "status": "unavailable"},
+        ],
+    }
+    write_manifest(tmp_path, "10.1038/test", manifest)
+    return tmp_path
+
+
+def test_triage_paper_records_a_verdict_for_every_file(stored: Path) -> None:
+    manifest = triage.triage_paper(stored, "10.1038/test")
+
+    by_id = {f["file_id"]: f for f in manifest["files"]}
+    assert by_id["tables.xlsx"]["relevance"] == "relevant"
+    assert "logfoldchanges" in by_id["tables.xlsx"]["relevance_note"]
+    assert by_id["antibodies.xlsx"]["relevance"] == "irrelevant"
+    assert by_id["review.pdf"]["relevance"] == "irrelevant"
+    assert "caption" in by_id["review.pdf"]["relevance_note"]
+    # Not on disk is not the same as not relevant.
+    assert by_id["gone.xlsx"]["relevance"] == "unknown"
+
+
+def test_indexable_excludes_only_the_irrelevant(stored: Path) -> None:
+    manifest = triage.triage_paper(stored, "10.1038/test")
+
+    names = {item["file_id"] for item in triage.indexable(manifest)}
+
+    assert names == {"tables.xlsx"}, "unknown-but-absent files have nothing to open"
+
+
+def test_triage_is_idempotent(stored: Path) -> None:
+    first = triage.triage_paper(stored, "10.1038/test")
+    second = triage.triage_paper(stored, "10.1038/test")
+
+    assert [f.get("relevance") for f in first["files"]] == [
+        f.get("relevance") for f in second["files"]
+    ]
+
+
+def test_an_unreadable_workbook_is_unknown_not_irrelevant(tmp_path: Path) -> None:
+    """Europe PMC's bundle really does serve truncated workbooks."""
+    from atlas_chat.services.supplement_store import MANIFEST_VERSION, write_manifest
+
+    files = tmp_path / "papers" / "10.1038_test" / "files"
+    files.mkdir(parents=True)
+    broken = files / "truncated.xlsx"
+    broken.write_bytes(b"PK\x03\x04" + b"\x00" * 200)  # starts like a zip, isn't one
+
+    write_manifest(
+        tmp_path,
+        "10.1038/test",
+        {
+            "manifest_version": MANIFEST_VERSION,
+            "paper": {"doi": "10.1038/test"},
+            "files": [
+                {
+                    "file_id": "truncated.xlsx",
+                    "media_type": "xlsx",
+                    "status": "present",
+                    "path": "papers/10.1038_test/files/truncated.xlsx",
+                }
+            ],
+        },
+    )
+
+    manifest = triage.triage_paper(tmp_path, "10.1038/test")
+
+    entry = manifest["files"][0]
+    assert entry["relevance"] == "unknown"
+    assert "not a readable .xlsx" in entry["relevance_note"]
+
+
+def test_archive_members_are_triaged_individually(tmp_path: Path) -> None:
+    """A bundle of forty tables is judged per table, not as one blob."""
+    openpyxl = pytest.importorskip("openpyxl")
+    from atlas_chat.services.supplement_store import MANIFEST_VERSION, write_manifest
+
+    unpacked = tmp_path / "papers" / "10.1038_test" / "files" / "bundle__unpacked"
+    unpacked.mkdir(parents=True)
+    for name, columns in [
+        ("Table 1.xlsx", ["names", "logfoldchanges", "pvals_adj"]),
+        ("Table 2.xlsx", ["RRID citation", "Antibody", "Vendor"]),
+    ]:
+        wb = openpyxl.Workbook()
+        wb.active.append(columns)
+        wb.save(unpacked / name)
+
+    base = "papers/10.1038_test/files/bundle__unpacked"
+    write_manifest(
+        tmp_path,
+        "10.1038/test",
+        {
+            "manifest_version": MANIFEST_VERSION,
+            "paper": {"doi": "10.1038/test"},
+            "files": [
+                {
+                    "file_id": "bundle.zip",
+                    "media_type": "zip",
+                    "status": "present",
+                    "path": "papers/10.1038_test/files/bundle.zip",
+                    "members": [
+                        {
+                            "member_path": "Table 1.xlsx",
+                            "media_type": "xlsx",
+                            "extracted": True,
+                            "path": f"{base}/Table 1.xlsx",
+                        },
+                        {
+                            "member_path": "Table 2.xlsx",
+                            "media_type": "xlsx",
+                            "extracted": True,
+                            "path": f"{base}/Table 2.xlsx",
+                        },
+                    ],
+                }
+            ],
+        },
+    )
+
+    manifest = triage.triage_paper(tmp_path, "10.1038/test")
+
+    members = {m["member_path"]: m["relevance"] for m in manifest["files"][0]["members"]}
+    assert members == {"Table 1.xlsx": "relevant", "Table 2.xlsx": "irrelevant"}
+    # The archive is relevant because something inside it is.
+    assert manifest["files"][0]["relevance"] == "relevant"
+    assert {i["member_path"] for i in triage.indexable(manifest)} == {"Table 1.xlsx"}
+
+
+@pytest.mark.parametrize(
+    ("columns", "verdict", "source"),
+    [
+        (
+            ["RRID citation", "Antibody", "Vendor", "Cat no", "Clonality", "Clone"],
+            "irrelevant",
+            "Gopee Table 38 — a real antibody list, with a supplier",
+        ),
+        (
+            [
+                "Gene",
+                "Gene synonym",
+                "Ensembl",
+                "Antibody",
+                "Biological process",
+                "Blood concentration",
+                "Protein class",
+            ],
+            "unknown",
+            "Gopee Table 39 — the HPA secreted-protein database, which merely has "
+            "an Antibody column. Ruling this out as a reagent list would be a "
+            "wrong answer for a plausible reason",
+        ),
+        (["Primer name", "Sequence", "Supplier"], "irrelevant", "a primer list"),
+    ],
+)
+def test_reagent_lists_are_told_apart_from_protein_reference_tables(
+    columns: list[str], verdict: str, source: str
+) -> None:
+    assert triage.classify_table(_table(columns))[0] == verdict, source
+
+
+def test_no_signature_can_produce_irrelevant_without_naming_its_reason() -> None:
+    """Every exclusion must be auditable, since exclusions lose evidence."""
+    for signature in triage.SIGNATURES:
+        if not signature.relevant:
+            assert signature.name, "an excluding signature needs a name for its note"
+            assert signature.required or signature.any_of, "and real criteria"

--- a/tests/unit/test_supplement_triage.py
+++ b/tests/unit/test_supplement_triage.py
@@ -408,3 +408,35 @@ def test_no_signature_can_produce_irrelevant_without_naming_its_reason() -> None
         if not signature.relevant:
             assert signature.name, "an excluding signature needs a name for its note"
             assert signature.required or signature.any_of, "and real criteria"
+
+
+@pytest.mark.parametrize("kind", ["pdf", "docx", "video", "other"])
+def test_uninspected_formats_say_so_explicitly(tmp_path: Path, kind: str) -> None:
+    """A stated decision, not a silent gap: these are never read for columns."""
+    from atlas_chat.services.supplement_store import MANIFEST_VERSION, write_manifest
+
+    files = tmp_path / "papers" / "10.1038_test" / "files"
+    files.mkdir(parents=True)
+    (files / f"f.{kind}").write_bytes(b"whatever")
+    write_manifest(
+        tmp_path,
+        "10.1038/test",
+        {
+            "manifest_version": MANIFEST_VERSION,
+            "paper": {"doi": "10.1038/test"},
+            "files": [
+                {
+                    "file_id": f"f.{kind}",
+                    "media_type": kind,
+                    "status": "present",
+                    "path": f"papers/10.1038_test/files/f.{kind}",
+                }
+            ],
+        },
+    )
+
+    manifest = triage.triage_paper(tmp_path, "10.1038/test")
+
+    entry = manifest["files"][0]
+    assert entry["relevance"] == "unknown", "never irrelevant — we simply did not look"
+    assert "not inspected" in entry["relevance_note"]


### PR DESCRIPTION
## Supplement retrieval waterfall (#21 phase 2)

Gets supplementary material onto disk for a corpus, so indexing has something to index without a person fetching every file by hand. The store from #29 already defined the vocabulary for this — `Retrieval.route` and `SupplementFile.status` — so this fills it in rather than reshaping it.

### The routes are measured, not guessed

Probed all 22 papers of the reproductive-atlas corpus (`projects/HCA_reproductive_atlas_v1/subatlas_pubs`), spanning Springer Nature, Cell Press, AAAS, JCI, Wiley, Oxford, PNAS and the bioRxiv preprint:

| Route | Reach | Why it sits here |
|---|---|---|
| Article XML (`jats_listing`) | 14/22 | Filenames **and** the publisher's captions, which exist nowhere else |
| Europe PMC bundle (`europepmc_bundle`) | most of those | One zip per article, members named exactly as the XML lists them — needs no per-publisher knowledge, which is why it outranks the per-file route |
| Publisher-direct (`publisher_direct`) | Springer only | Its ESM stem turns out to be derivable from the DOI alone (verified 8/8) |
| Manual (`manual`) | the remainder | A gap naming the file and the DOI to get it from |

**Result over the corpus: 14 of 22 papers complete, 114 of 114 listed files on disk, nothing partial.** The 8 misses are exactly the papers with no PMC route — the boundary where a person has to step in. 443 MB in one pass.

**Rejected on evidence:** NCBI's OA package. `oa.fcgi` advertises a tarball for 14 of 17 PMC papers and it would have been one clean download per paper, but every one 404s over https regardless of licence, and ftp returns nothing. A PNAS template was also tried and 403s behind bot protection, so it would need TLS impersonation; raising the bundle cap covered PNAS instead, which is the better trade.

### Three failure modes, all found by running it

- **The bundle answers HTTP 200 with a 165-byte non-zip body** when a PMC paper's full text is not open. Recorded naively that is an empty archive treated as success, and the paper looks as though it has no supplements.
- **A paper with no article XML was never offered the bundle at all**, because nothing was listed to want — which also made the unlisted-adoption path dead code. Closed full text with open supplements is a real combination, so the bundle is now tried whenever there is no listing.
- **Gaps accumulated on every run**, because the in-memory marker distinguishing this run's gaps was stripped before writing. They are now deduplicated on write, and a gap about a file since retrieved is retired.

### Negative cache

`Retrieval.attempted_at` is the point of it: a route that failed is not retried on later runs unless `--retry` is passed, so a permanently missing supplement stops being requested every pass.

### Sizes

Bundle bytes spool to a temp file past 32 MB, so the 250 MB cap costs disk rather than RAM. The cap comes from measurement: most bundles are 10–30 MB, the PNAS article is 197 MB (mostly figure images we then discard), and the prenatal skin atlas exceeds 445 MB because of a supplementary video — the case the cap exists to refuse.

### Two store fixes this exercised

- openpyxl's read-only mode reports `max_row` as `None` for workbooks carrying no dimension record — real for publisher files — which put a null where every consumer expects a count. `n_rows` is what tells a reader a table needs slicing rather than opening.
- The store's integration tests keyed their skip on the committed manifest rather than the git-ignored bytes it describes, so they failed instead of skipping in a fresh worktree.

### Usage

```bash
python -m atlas_chat.cli_supplements fetch --store S --doi 10.1038/...
python -m atlas_chat.cli_supplements fetch --store S --cas projects/X/cas.json
# --bundle-cap N   --no-bundle   --retry
```

### Testing

29 unit tests (mock transport, so route *decisions* are tested in isolation) and 12 live integration tests against real Europe PMC and the Springer host, no mocks. 233 unit tests pass overall; ruff and mypy clean on the new files.

`tests/integration/test_integration_env.py` fails in my environment for want of `OPENAI_API_KEY` / `ANTHROPIC_API_KEY` — pre-existing on `dev`, unrelated to this change.

### For discussion

`fetch_corpus` runs serially and the 22-paper corpus took several minutes, almost all of it waiting on bundle downloads. Parallelising across papers is a small change but puts more load on Europe PMC, so I left the choice open.

Not in scope: publisher templates beyond Springer (add one when a corpus needs it), and TLS impersonation for the hosts that block plain clients.
