### PR TITLE
Fix three JATS extraction bugs: figure-legend splicing, body-paragraph order, AAAS references

### DIFF
--- a/src/atlas_chat/atlas_chat/services/_jats_parser.py
+++ b/src/atlas_chat/atlas_chat/services/_jats_parser.py
@@ -80,6 +80,71 @@ def _strip_namespace_from_tree(root: ET.Element) -> None:
 # ---------------------------------------------------------------------------
 
 
+# AAAS (Science) JATS puts no structured children inside <mixed-citation>: the
+# whole reference is one <named-content content-type="citation-string"> blob and
+# the identifiers are <ext-link ext-link-type="doi|pmid|pmcid">. Without the two
+# helpers below the parser returns a ResolvedRef with every field None for an
+# entire publisher class, silently (#35).
+
+_ID_LINK_TYPES = {"doi": "doi", "pmid": "pmid", "pmcid": "pmcid"}
+
+# "Park J-E, Jardine L, Haniffa M. Prenatal development of human immunity.
+#  Science. 2020;368:600-603. doi: 10.1126/science.aaz9330."
+_CITE_YEAR_RE = re.compile(r"\b((?:19|20)\d{2})\b(?=[;:]|\s*doi)")
+_CITE_SURNAME_RE = re.compile(r"^([A-Z][\w'\u2019]+(?:-[\w'\u2019]+)*)[\s,]")
+_CITE_DOI_RE = re.compile(r"\bdoi:\s*(10\.\S+?)\.?\s*$", re.IGNORECASE)
+
+
+def _ids_from_ext_links(ref_elem: ET.Element) -> dict[str, str]:
+    """Collect doi/pmid/pmcid from ``<ext-link ext-link-type=...>`` children.
+
+    Namespaces are stripped upstream, so ``xlink:href`` reads as ``href``.
+    """
+    found: dict[str, str] = {}
+    for link in ref_elem.iter("ext-link"):
+        key = _ID_LINK_TYPES.get((link.get("ext-link-type") or "").lower())
+        if not key or key in found:
+            continue
+        val = (link.get("href") or "").strip() or "".join(link.itertext()).strip()
+        if val:
+            found[key] = val
+    return found
+
+
+def _parse_citation_string(text: str) -> dict[str, object]:
+    """Pull first author, title, year and DOI out of an unstructured citation.
+
+    Best-effort on the ``AUTHORS. TITLE. JOURNAL. YEAR;VOL:PAGES. doi: DOI.``
+    convention. Anything it cannot place is simply left out.
+    """
+    text = re.sub(r"\s+", " ", text).strip()
+    out: dict[str, object] = {}
+
+    m = _CITE_DOI_RE.search(text)
+    if m:
+        out["doi"] = m.group(1)
+
+    m_surname = _CITE_SURNAME_RE.match(text)
+    if m_surname:
+        out["first_author"] = m_surname.group(1)
+
+    m_year = _CITE_YEAR_RE.search(text)
+    if not m_year:
+        return out
+    out["year"] = int(m_year.group(1))
+
+    # Everything before the year is "authors. title. journal." — the title is
+    # the field before the journal. Fewer than three fields means the layout is
+    # not the one assumed, so no title is claimed.
+    fields = [f.strip(" .") for f in text[: m_year.start()].split(". ")]
+    fields = [f for f in fields if f]
+    if len(fields) >= 3:
+        title = fields[-2]
+        if len(title) > 10:
+            out["title"] = title
+    return out
+
+
 def _parse_single_ref(ref_elem: ET.Element) -> ResolvedRef:
     """Extract identifiers and metadata from one <ref> element."""
     ref_id = ref_elem.get("id", "")
@@ -125,6 +190,25 @@ def _parse_single_ref(ref_elem: ET.Element) -> ResolvedRef:
             surname = name_elem.find("surname")
             if surname is not None:
                 first_author = (surname.text or "").strip()
+
+    # Fallbacks for dialects with no structured citation children (AAAS).
+    if not (doi and pmid and pmcid):
+        links = _ids_from_ext_links(ref_elem)
+        doi = doi or links.get("doi")
+        pmid = pmid or links.get("pmid")
+        pmcid = pmcid or links.get("pmcid")
+
+    if not (title and year and first_author and doi):
+        blob = ref_elem.find(".//named-content[@content-type='citation-string']")
+        raw = "".join(blob.itertext()) if blob is not None else ""
+        if not raw and citation is not None and not len(citation):
+            raw = "".join(citation.itertext())
+        if raw.strip():
+            parsed = _parse_citation_string(raw)
+            title = title or parsed.get("title")  # type: ignore[assignment]
+            year = year or parsed.get("year")  # type: ignore[assignment]
+            first_author = first_author or parsed.get("first_author")  # type: ignore[assignment]
+            doi = doi or parsed.get("doi")  # type: ignore[assignment]
 
     return ResolvedRef(
         ref_id=ref_id,

--- a/src/atlas_chat/atlas_chat/services/local_snippet_index.py
+++ b/src/atlas_chat/atlas_chat/services/local_snippet_index.py
@@ -181,8 +181,25 @@ def _contains_bibr(el: ET.Element) -> bool:
     return any(_is_bibr_xref(g) for g in el.iter())
 
 
+# Elements whose text is not part of the running prose. In Nature-style JATS
+# these sit *inside* body <p>, so serialising a paragraph's descendants without
+# skipping them splices figure legends onto the end of the prose (#35). Their
+# tails are still kept — the prose resumes after the element.
+_NON_PROSE_TAGS = frozenset(
+    {
+        "ref-list",
+        "table-wrap",
+        "fig",
+        "fig-group",
+        "supplementary-material",
+        "boxed-text",
+        "disp-formula",
+    }
+)
+
+
 def _text_of(el: ET.Element, in_citation: bool = False) -> str:
-    """Concatenate all descendant text, skipping ref-list and tables.
+    """Concatenate all descendant text, skipping non-prose blocks.
 
     Wraps citation markers in brackets so the rendered text shows e.g.
     ``[12-15]`` rather than a bare ``12-15`` run.
@@ -191,7 +208,9 @@ def _text_of(el: ET.Element, in_citation: bool = False) -> str:
     if el.text:
         parts.append(el.text)
     for child in el:
-        if child.tag in {"ref-list", "table-wrap"}:
+        if child.tag in _NON_PROSE_TAGS:
+            if child.tail:
+                parts.append(child.tail)
             continue
         is_citation_block = (child.tag == "sup" and _contains_bibr(child)) or _is_bibr_xref(child)
         if is_citation_block and not in_citation:
@@ -220,27 +239,29 @@ def extract_body_segments(xml: str) -> list[_BodySegment]:
     if body is None:
         return segments
 
-    def walk(sec_el: ET.Element, parent_title: str) -> None:
-        title_el = sec_el.find("title")
-        title = (
-            re.sub(r"\s+", " ", _text_of(title_el)).strip()
-            if title_el is not None
-            else parent_title
-        )
-        for child in sec_el:
+    # One recursive walk in document order. Some publishers (AAAS) put main-text
+    # paragraphs directly under <body> or inside non-<sec> wrappers; walking
+    # <sec> subtrees first and appending stray <p> afterwards returned them out
+    # of order and missed anything nested (#35).
+    def walk(el: ET.Element, title: str) -> None:
+        for child in el:
+            if child.tag in _NON_PROSE_TAGS:
+                continue
             if child.tag == "sec":
-                walk(child, title)
+                # `is not None` matters: an Element with no children is falsy.
+                title_el = child.find("title")
+                sec_title = (
+                    re.sub(r"\s+", " ", _text_of(title_el)).strip() if title_el is not None else ""
+                )
+                walk(child, sec_title or title)
             elif child.tag == "p":
                 txt = re.sub(r"\s+", " ", _text_of(child)).strip()
                 if txt:
                     segments.append(_BodySegment(title, txt))
+            elif child.tag != "title":
+                walk(child, title)
 
-    for sec in body.findall("sec"):
-        walk(sec, "BODY")
-    for p in body.findall("p"):
-        txt = re.sub(r"\s+", " ", _text_of(p)).strip()
-        if txt:
-            segments.append(_BodySegment("BODY", txt))
+    walk(body, "BODY")
 
     return segments
 

--- a/tests/unit/test_jats_parser_dialects.py
+++ b/tests/unit/test_jats_parser_dialects.py
@@ -1,0 +1,139 @@
+"""Reference-list parsing across JATS dialects (#35).
+
+Springer/Nature supplies structured ``<element-citation>`` children. AAAS
+(Science) supplies one unstructured citation string plus ``<ext-link>``
+identifiers — that dialect used to yield a ``ResolvedRef`` with every field
+``None``, for every reference, silently.
+"""
+
+from __future__ import annotations
+
+import xml.etree.ElementTree as ET
+from textwrap import dedent
+
+import pytest
+from atlas_chat.services._jats_parser import (
+    _clean_xml,
+    _parse_citation_string,
+    _parse_ref_list,
+    _strip_namespace_from_tree,
+)
+
+AAAS_REFS = dedent("""\
+    <?xml version="1.0"?>
+    <article xmlns:xlink="http://www.w3.org/1999/xlink">
+      <back>
+        <ref-list>
+          <ref id="R1"><label>1.</label><mixed-citation>
+            <named-content content-type="citation-string">Park J-E, Jardine L,
+              Gottgens B, Haniffa M. Prenatal development of human immunity.
+              Science. 2020;368:600-603. doi: 10.1126/science.aaz9330.</named-content>
+            <ext-link ext-link-type="doi" xlink:href="10.1126/science.aaz9330"/>
+            <ext-link ext-link-type="pmcid" xlink:href="PMC7612900"/>
+            <ext-link ext-link-type="pmid" xlink:href="32381715"/>
+            <ext-link ext-link-type="google-scholar" xlink:href="journal=Science"/>
+          </mixed-citation></ref>
+          <ref id="R2"><label>2.</label><mixed-citation>
+            <named-content content-type="citation-string">Popescu D-M, et al.
+              Decoding human fetal liver haematopoiesis. Nature.
+              2019;574:365-371. doi: 10.1038/s41586-019-1652-y.</named-content>
+            <ext-link ext-link-type="doi" xlink:href="10.1038/s41586-019-1652-y"/>
+          </mixed-citation></ref>
+        </ref-list>
+      </back>
+    </article>
+""")
+
+NATURE_REFS = dedent("""\
+    <?xml version="1.0"?>
+    <article>
+      <back>
+        <ref-list>
+          <ref id="CR1"><element-citation publication-type="journal">
+            <person-group><name><surname>Lee</surname><given-names>J</given-names></name></person-group>
+            <article-title>Hair-bearing human skin from pluripotent stem cells</article-title>
+            <year>2020</year>
+            <pub-id pub-id-type="doi">10.1038/s41586-020-2352-3</pub-id>
+            <pub-id pub-id-type="pmid">32494013</pub-id>
+          </element-citation></ref>
+        </ref-list>
+      </back>
+    </article>
+""")
+
+
+def _refs(xml: str) -> dict:
+    root = ET.fromstring(_clean_xml(xml))
+    _strip_namespace_from_tree(root)
+    return _parse_ref_list(root)
+
+
+@pytest.mark.unit
+def test_aaas_mixed_citation_yields_identifiers_and_metadata() -> None:
+    refs = _refs(AAAS_REFS)
+    assert set(refs) == {"R1", "R2"}
+    r1 = refs["R1"]
+    assert r1.doi == "10.1126/science.aaz9330"
+    assert r1.pmid == "32381715"
+    assert r1.pmcid == "PMC7612900"
+    assert r1.year == 2020
+    assert r1.first_author == "Park"
+    assert r1.title == "Prenatal development of human immunity"
+    # "et al." author lists still resolve a surname and a title.
+    r2 = refs["R2"]
+    assert r2.first_author == "Popescu"
+    assert r2.title == "Decoding human fetal liver haematopoiesis"
+    assert r2.doi == "10.1038/s41586-019-1652-y"
+
+
+@pytest.mark.unit
+def test_google_scholar_ext_links_are_not_mistaken_for_identifiers() -> None:
+    r1 = _refs(AAAS_REFS)["R1"]
+    assert "journal=Science" not in (r1.doi, r1.pmid, r1.pmcid)
+
+
+@pytest.mark.unit
+def test_structured_element_citation_still_preferred() -> None:
+    r1 = _refs(NATURE_REFS)["CR1"]
+    assert r1.doi == "10.1038/s41586-020-2352-3"
+    assert r1.pmid == "32494013"
+    assert r1.first_author == "Lee"
+    assert r1.title == "Hair-bearing human skin from pluripotent stem cells"
+    assert r1.year == 2020
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        # Volume-only, no page range.
+        (
+            "Cao J, et al. A human cell atlas of fetal gene expression. "
+            "Science. 2020;370 doi: 10.1126/science.aba7721.",
+            {"first_author": "Cao", "year": 2020, "doi": "10.1126/science.aba7721"},
+        ),
+        # Hyphenated surname, full author list.
+        (
+            "Jagannathan-Bogdan M, Zon LI. Hematopoiesis. Dev Camb Engl. "
+            "2013;140:2463-2467. doi: 10.1242/dev.083147.",
+            {"first_author": "Jagannathan-Bogdan", "year": 2013},
+        ),
+        # Year immediately followed by a colon rather than a semicolon.
+        (
+            "Jardine L, et al. Blood and immune development in fetal bone marrow. "
+            "Nature. 2021:1-5. doi: 10.1038/s41586-021-03929-x.",
+            {"year": 2021, "title": "Blood and immune development in fetal bone marrow"},
+        ),
+    ],
+)
+def test_citation_string_variants(raw: str, expected: dict) -> None:
+    parsed = _parse_citation_string(raw)
+    for key, val in expected.items():
+        assert parsed[key] == val
+
+
+@pytest.mark.unit
+def test_citation_string_claims_nothing_it_cannot_place() -> None:
+    # No year, no recognisable field layout — must not invent a title.
+    assert "title" not in _parse_citation_string("Some unstructured note.")
+    assert _parse_citation_string("") == {}

--- a/tests/unit/test_local_snippet_index.py
+++ b/tests/unit/test_local_snippet_index.py
@@ -326,3 +326,58 @@ def test_no_cached_refs_when_file_missing_or_empty(tmp_path) -> None:
     assert _cached_ref_resolution(d, {"source_sha": "abc"}, "abc") is None
     (d / "ref_resolution.json").write_text("not json")
     assert _cached_ref_resolution(d, {"source_sha": "abc"}, "abc") is None
+
+
+# ---------------------------------------------------------------------------
+# Non-prose exclusion + document order (#35)
+# ---------------------------------------------------------------------------
+
+# Nature-style layout: <fig> and <supplementary-material> sit *inside* body <p>,
+# and one main-text paragraph sits directly under <body> between two sections.
+JATS_NON_PROSE_FIXTURE = dedent("""\
+    <?xml version="1.0"?>
+    <article>
+      <body>
+        <sec>
+          <title>Results</title>
+          <p>Hair pegs were evident beneath a stratified epidermal layer (Fig. 2a).<fig
+              id="Fig2"><label>Fig. 2</label><caption><title>Human prenatal HF
+              development.</title><p>a, Representative images stained with
+              haematoxylin and eosin. Scale bars, 200 um.</p></caption></fig> The
+              dermis remained sparsely populated at this stage.</p>
+          <p>Marker expression was confirmed by immunofluorescence.<supplementary-material
+              id="MOESM1"><caption><p>Supplementary Table 22. Macrophage subset
+              DEGs.</p></caption></supplementary-material></p>
+        </sec>
+        <p>This standalone paragraph sits directly under body, between sections.</p>
+        <sec>
+          <title>Discussion</title>
+          <div><p>Nested inside a wrapper element that is not a sec.</p></div>
+        </sec>
+      </body>
+    </article>
+""")
+
+
+@pytest.mark.unit
+def test_figure_legends_are_not_spliced_into_prose() -> None:
+    segments = extract_body_segments(JATS_NON_PROSE_FIXTURE)
+    body = " ".join(s.text for s in segments)
+    assert "Representative images" not in body
+    assert "Human prenatal HF" not in body
+    assert "Supplementary Table 22" not in body
+    # The prose either side of the removed <fig> survives, in order.
+    first = next(s.text for s in segments if "Hair pegs" in s.text)
+    assert first.index("Hair pegs") < first.index("dermis remained")
+
+
+@pytest.mark.unit
+def test_body_paragraphs_returned_in_document_order() -> None:
+    segments = extract_body_segments(JATS_NON_PROSE_FIXTURE)
+    texts = [s.text for s in segments]
+    standalone = next(i for i, t in enumerate(texts) if "standalone paragraph" in t)
+    results = next(i for i, t in enumerate(texts) if "Hair pegs" in t)
+    discussion = next(i for i, t in enumerate(texts) if "Nested inside a wrapper" in t)
+    assert results < standalone < discussion
+    # Paragraphs nested in non-<sec> wrappers are found, and keep their section.
+    assert segments[discussion].section == "Discussion"


### PR DESCRIPTION
Closes #35.

Three independent bugs in JATS extraction, all found while building the retrieval test
matrix on `test/retrieval-matrix`. `experiments/corpus.py` already worked around them;
the production services did not. Full evidence in #35.

### 1. Figure legends spliced onto body prose

`_text_of` skipped only `ref-list` and `table-wrap`. `<fig>`,
`<supplementary-material>`, `<boxed-text>` and `<disp-formula>` sit *inside* body `<p>`
in Nature-style JATS, so their text got concatenated onto the prose — one Gopee
paragraph picking up 2,396 characters of legend, ~12% of the indexed text across the
paper. Diluted chunks hurt ranking, and a reader can quote across the join, producing a
"quote" that is a real substring of our index but does not exist in the paper.

Fixed via a `_NON_PROSE_TAGS` set. Element **tails are now kept** — prose resuming after
a figure used to be silently dropped along with the figure.

### 2. Body-level `<p>` returned out of document order

`extract_body_segments` walked `body.findall("sec")` then appended `body.findall("p")`,
so paragraphs directly under `<body>` landed after every section, and `<p>` nested in
non-`sec` wrappers was missed. Replaced with one recursive document-order walk.

### 3. Zero references parsed for AAAS papers

`_parse_single_ref` reads `<pub-id>` / `<article-title>` / `<name><surname>`. Science
supplies none of those — one `<named-content content-type="citation-string">` blob plus
`<ext-link ext-link-type="doi|pmid|pmcid">`. Every Science reference parsed to a
`ResolvedRef` with all fields `None`, without raising, so an entire publisher class had
no citations to follow. Added ext-link and citation-string fallbacks, applied only where
the structured children are absent.

### Measured on `experiments/papers/{gopee2024,suo2022}.xml`

| | before | after |
|---|---|---|
| suo2022 (Science) refs with DOI | 0 / 103 | **99** |
| suo2022 refs with title | 0 | **97** |
| suo2022 refs with first author | 0 | **103** |
| gopee2024 extracted body chars | 106,474 | 97,438 |
| gopee2024 legend-spliced paragraphs | 36 | **0** |

Nature ref parsing is unchanged (96 DOIs, 94 titles either side). The residual
gopee2024 delta against `experiments/corpus.py` (97,438 vs 94,998) is the abstract plus
bracketed citation markers, both of which production keeps deliberately.

### Tests

- `tests/unit/test_jats_parser_dialects.py` (new) — AAAS mixed-citation, `et al.`
  author lists, google-scholar ext-links not mistaken for identifiers, structured
  `element-citation` still preferred, three citation-string layout variants, and a
  check that the parser claims nothing it cannot place.
- `tests/unit/test_local_snippet_index.py` — new fixture with `<fig>` inside a body
  `<p>`, a standalone body-level paragraph between two sections, and a `<p>` nested in a
  non-`sec` wrapper. Asserts no legend text survives, prose either side of a removed
  `<fig>` stays in order, and document order holds.

`uv run pytest -m unit` 369 passed. ruff clean. mypy unchanged from baseline (15
pre-existing missing-stub errors before and after; none in the changed code).

### Follow-on

Fix 1 changes the text the local index serves, so **every local snippet index needs
rebuilding** — the same rebuild #30 already requires after #23. Noted on #30.

#36 tracks the third §5 item from the Stage 3 handoff (quote validation pooling ASTA and
PMC renderings), left out of this PR because it is a schema change plus a checker
rework, not a contained fix.
