### PR TITLE
Curation guard: content is open, infrastructure needs the guide

### DIFF
--- a/.claude/hooks/curation_guard.py
+++ b/.claude/hooks/curation_guard.py
@@ -1,0 +1,222 @@
+#!/usr/bin/env python3
+"""PreToolUse hook: keep content sessions out of the infrastructure.
+
+The guard covers this repository and nothing else — scratch files, other
+checkouts and ``~/.claude`` are none of its business. Within the repository
+there are two zones. ``projects/`` and ``planning/`` hold content — per-atlas
+reports, traversal output, notes — and anyone may write there. Everything else
+is infrastructure: source, schemas, hooks, agents, skills, tests, docs and the
+root files.
+
+Who may write infrastructure:
+
+**Untrusted users** — no. The write is blocked and the agent is told to
+capture the request as a note under ``planning/`` instead.
+
+**Trusted users** (git ``user.email`` in :data:`TRUSTED_USERS`) — yes, but not
+until ``CLAUDE_dev.md`` has been loaded into the session. Until then the write
+is blocked with an instruction to read it. The agent reads the guide and
+retries, so the block clears itself; the point is that nobody edits the
+infrastructure without the conventions in front of them.
+
+Acknowledgement is read from the session transcript that Claude Code passes in
+the hook payload, by looking for the guide's own title line. Where no
+transcript is available the check cannot run, and trusted users are allowed
+through.
+
+Exit codes:
+  0 — allow the write
+  2 — block the write; stderr goes back to the agent
+
+https://docs.anthropic.com/en/docs/claude-code/hooks#exit-code-2-behavior
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+#: Git emails permitted to write infrastructure, once they have read the guide.
+TRUSTED_USERS = {
+    "dosumis@gmail.com",
+    "do12@sanger.ac.uk",
+}
+
+#: Top-level directories anyone may write.
+CONTENT_ZONES = ("projects", "planning")
+
+#: The guide a trusted user must have loaded before touching infrastructure.
+DEV_GUIDE = "CLAUDE_dev.md"
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+_WRITE_TOOLS = ("Write", "Edit", "MultiEdit")
+
+
+def current_user() -> str | None:
+    """Return the current git ``user.email``, or None if unavailable.
+
+    ``ATLAS_CHAT_HOOK_USER`` overrides it, so tests can drive the hook without
+    touching git config: unset falls through to git, empty string means no
+    configured user, anything else is used as-is.
+    """
+    override = os.environ.get("ATLAS_CHAT_HOOK_USER")
+    if override is not None:
+        return override or None
+    try:
+        result = subprocess.run(
+            ["git", "config", "user.email"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+    except (subprocess.SubprocessError, OSError):
+        return None
+    return result.stdout.strip() or None if result.returncode == 0 else None
+
+
+def is_content_path(file_path: Path) -> bool:
+    """True if the path is inside a content zone of this repository."""
+    try:
+        parts = file_path.resolve().relative_to(_REPO_ROOT).parts
+    except (ValueError, OSError):
+        return False
+    return bool(parts) and parts[0] in CONTENT_ZONES
+
+
+def is_in_repo(file_path: Path) -> bool:
+    """True if the path is inside this repository at all."""
+    try:
+        file_path.resolve().relative_to(_REPO_ROOT)
+    except (ValueError, OSError):
+        return False
+    return True
+
+
+def guide_marker() -> str | None:
+    """Return the dev guide's title line, used as proof it was loaded.
+
+    Taken from the file rather than hardcoded, so retitling the guide keeps
+    both sides in step.
+    """
+    try:
+        with (_REPO_ROOT / DEV_GUIDE).open(encoding="utf-8") as handle:
+            for line in handle:
+                if line.startswith("# "):
+                    return line.strip()
+    except OSError:
+        return None
+    return None
+
+
+def guide_was_read(transcript_path: str | None) -> bool:
+    """True if the dev guide's content appears in the session transcript.
+
+    Catches any route by which the content reached the model — the Read tool,
+    ``cat`` through Bash, or an ``@CLAUDE_dev`` import. Returns True when there
+    is no transcript to check, since the question cannot be answered and the
+    caller has already established trust.
+    """
+    if not transcript_path:
+        return True
+    path = Path(transcript_path)
+    if not path.is_file():
+        return True
+
+    marker = guide_marker()
+    needles = [f"@{Path(DEV_GUIDE).stem}"]
+    if marker:
+        needles.append(marker)
+
+    try:
+        with path.open(encoding="utf-8") as handle:
+            for line in handle:
+                try:
+                    text = json.dumps(json.loads(line), ensure_ascii=False)
+                except (json.JSONDecodeError, ValueError):
+                    text = line
+                if any(needle in text for needle in needles):
+                    return True
+    except OSError:
+        return True
+    return False
+
+
+def _block(message: list[str]) -> None:
+    print("\n" + "=" * 68, file=sys.stderr)
+    for line in message:
+        print(line, file=sys.stderr)
+    print("=" * 68 + "\n", file=sys.stderr)
+    sys.exit(2)
+
+
+def reject_untrusted(file_path: Path, user: str | None) -> None:
+    _block(
+        [
+            "BLOCKED: this session may not write infrastructure.",
+            "",
+            f"Target: {file_path}",
+            f"User:   {user or '(no git user.email set)'}",
+            "",
+            "Writable zones: " + ", ".join(f"{zone}/" for zone in CONTENT_ZONES),
+            "",
+            "Everything else in this repository — src/, tests/, docs/,",
+            ".claude/, root files — is infrastructure and needs a trusted git",
+            "identity. Paths outside the repository are unaffected.",
+            "",
+            "Capture the request as a note under planning/ and stop.",
+        ]
+    )
+
+
+def reject_unread_guide(file_path: Path, user: str | None) -> None:
+    _block(
+        [
+            f"BLOCKED: read {DEV_GUIDE} before editing infrastructure.",
+            "",
+            f"Target: {file_path}",
+            f"User:   {user}",
+            "",
+            f"You are trusted to change infrastructure, but {DEV_GUIDE} has not",
+            "been loaded in this session. It carries the conventions this change",
+            "has to follow — schema-first, declared input/output shapes, the",
+            "validator-hook requirement, testing and writing style.",
+            "",
+            f"Read {DEV_GUIDE}, then make the edit again.",
+        ]
+    )
+
+
+def main() -> None:
+    try:
+        payload = json.load(sys.stdin)
+    except (json.JSONDecodeError, ValueError):
+        sys.exit(0)
+
+    if payload.get("tool_name", "") not in _WRITE_TOOLS:
+        sys.exit(0)
+
+    raw_path = payload.get("tool_input", {}).get("file_path", "")
+    if not raw_path:
+        sys.exit(0)
+
+    file_path = Path(raw_path)
+    if not is_in_repo(file_path) or is_content_path(file_path):
+        sys.exit(0)
+
+    user = current_user()
+    if user not in TRUSTED_USERS:
+        reject_untrusted(file_path, user)
+
+    if not guide_was_read(payload.get("transcript_path")):
+        reject_unread_guide(file_path, user)
+
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,16 @@
 {
   "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Write|Edit|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "uv run python .claude/hooks/curation_guard.py"
+          }
+        ]
+      }
+    ],
     "PostToolUse": [
       {
         "matcher": "Write|Edit|MultiEdit",

--- a/CLAUDE_dev.md
+++ b/CLAUDE_dev.md
@@ -306,13 +306,30 @@ Prompts are co-located with the code/agents that use them, always as `*.prompt.y
 
 ## Curation-mode hook (how it works)
 
-The default session is curation/content mode. `.claude/hooks/curation_guard.py`
-(`PreToolUse` on `Edit|MultiEdit|Write`, registered in `.claude/settings.json`) lets
-non-developer users write **only** under `projects/` and `planning/`, and blocks
-everything else (`src/`, `.claude/`, schemas, docs, root files, anything outside the
-repo). The repo developer is recognised by `git config user.email` (in `TRUSTED_USERS`)
-and bypasses the gate; tests override the identity via `ATLAS_CHAT_HOOK_USER`. To do
-dev work you either have the trusted git identity or run an explicit dev session.
+`.claude/hooks/curation_guard.py` runs `PreToolUse` on `Write|Edit|MultiEdit`
+(registered in `.claude/settings.json`) and splits the repository in two.
+
+It covers this repository only — scratch files, other checkouts and `~/.claude`
+are unaffected. Inside it, `projects/` and `planning/` hold content and anyone may
+write there. Everything else — `src/`, `tests/`, `docs/`, `.claude/`, root files —
+is infrastructure:
+
+- **Untrusted users** cannot write it. The block tells the agent to capture the
+  request as a note under `planning/` instead.
+- **Trusted users** (git `user.email` in `TRUSTED_USERS`) can, but not until this
+  file has been loaded into the session. Until then the write is blocked with an
+  instruction to read it; the agent reads it and retries, so the block clears
+  itself. Nobody edits infrastructure without these conventions in front of them.
+
+Acknowledgement is read from the session transcript Claude Code passes in the hook
+payload, by looking for this file's own title line — so any route that puts the
+content in context counts (the Read tool, `cat`, an `@CLAUDE_dev` import). The
+marker is taken from the file rather than hardcoded, so retitling keeps both sides
+in step. Where no transcript is available the check cannot run and trusted users
+are allowed through.
+
+Tests override the identity via `ATLAS_CHAT_HOOK_USER`; the regression suite is
+`tests/unit/test_curation_guard.py`.
 
 ---
 

--- a/tests/unit/test_curation_guard.py
+++ b/tests/unit/test_curation_guard.py
@@ -1,0 +1,189 @@
+"""PreToolUse hook regression for curation_guard.py.
+
+Drives the hook via subprocess (like the other hook regressions), setting the
+git identity through ``ATLAS_CHAT_HOOK_USER``. Pins the three decisions the
+hook makes: content zones are open to everyone, infrastructure needs a trusted
+identity, and a trusted identity also needs CLAUDE_dev.md in the session.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+HOOK = REPO_ROOT / ".claude" / "hooks" / "curation_guard.py"
+
+TRUSTED = "dosumis@gmail.com"
+UNTRUSTED = "someone-else@example.com"
+
+
+def _run(
+    file_path: str,
+    user: str,
+    *,
+    tool: str = "Write",
+    transcript: Path | None = None,
+) -> subprocess.CompletedProcess:
+    payload: dict[str, object] = {
+        "tool_name": tool,
+        "tool_input": {"file_path": str(REPO_ROOT / file_path)},
+    }
+    if transcript is not None:
+        payload["transcript_path"] = str(transcript)
+    return subprocess.run(
+        [sys.executable, str(HOOK)],
+        input=json.dumps(payload),
+        capture_output=True,
+        text=True,
+        cwd=REPO_ROOT,
+        env={"ATLAS_CHAT_HOOK_USER": user, "PATH": "/usr/bin:/bin"},
+    )
+
+
+def _transcript(tmp_path: Path, *lines: object) -> Path:
+    path = tmp_path / "transcript.jsonl"
+    path.write_text("\n".join(json.dumps(line) for line in lines) + "\n")
+    return path
+
+
+def _guide_title() -> str:
+    for line in (REPO_ROOT / "CLAUDE_dev.md").read_text().splitlines():
+        if line.startswith("# "):
+            return line
+    raise AssertionError("CLAUDE_dev.md has no title line")
+
+
+# --- content zones: open to everyone ---------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("user", [TRUSTED, UNTRUSTED, ""])
+@pytest.mark.parametrize(
+    "path",
+    ["projects/x/reports/a.md", "planning/note.md"],
+)
+def test_content_zones_are_open(user: str, path: str, tmp_path: Path) -> None:
+    result = _run(path, user, transcript=_transcript(tmp_path, {"type": "user"}))
+    assert result.returncode == 0, result.stderr
+
+
+# --- infrastructure: trusted identity required ------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "path",
+    [
+        "src/atlas_chat/atlas_chat/services/atlas_paper.py",
+        "tests/unit/test_thing.py",
+        "docs/pipeline.md",
+        ".claude/hooks/check_report_refs.py",
+        "CLAUDE.md",
+    ],
+)
+def test_untrusted_cannot_write_infrastructure(path: str, tmp_path: Path) -> None:
+    result = _run(path, UNTRUSTED, transcript=_transcript(tmp_path, {"type": "user"}))
+    assert result.returncode == 2
+    assert "may not write infrastructure" in result.stderr
+
+
+@pytest.mark.unit
+def test_no_git_identity_is_untrusted(tmp_path: Path) -> None:
+    result = _run("src/thing.py", "", transcript=_transcript(tmp_path, {"type": "user"}))
+    assert result.returncode == 2
+    assert "no git user.email set" in result.stderr
+
+
+# --- infrastructure: trusted, but the guide must be in the session ----------
+
+
+@pytest.mark.unit
+def test_trusted_blocked_until_guide_is_read(tmp_path: Path) -> None:
+    transcript = _transcript(tmp_path, {"type": "user", "message": "make a change"})
+    result = _run("src/thing.py", TRUSTED, transcript=transcript)
+    assert result.returncode == 2
+    assert "CLAUDE_dev.md before editing infrastructure" in result.stderr
+
+
+@pytest.mark.unit
+def test_trusted_allowed_once_guide_content_is_in_transcript(tmp_path: Path) -> None:
+    transcript = _transcript(
+        tmp_path,
+        {"type": "user", "message": "read the guide"},
+        {"type": "user", "message": {"content": _guide_title() + "\n\nsome body"}},
+    )
+    result = _run("src/thing.py", TRUSTED, transcript=transcript)
+    assert result.returncode == 0, result.stderr
+
+
+@pytest.mark.unit
+def test_guide_title_survives_json_escaping(tmp_path: Path) -> None:
+    """The title has an em dash; transcripts store it escaped."""
+    escaped = json.dumps({"content": _guide_title()})  # — in the raw line
+    assert "\\u2014" in escaped or "—" not in _guide_title()
+    transcript = tmp_path / "transcript.jsonl"
+    transcript.write_text(escaped + "\n")
+    result = _run("src/thing.py", TRUSTED, transcript=transcript)
+    assert result.returncode == 0, result.stderr
+
+
+@pytest.mark.unit
+def test_at_import_counts_as_reading_the_guide(tmp_path: Path) -> None:
+    transcript = _transcript(tmp_path, {"type": "user", "message": "@CLAUDE_dev"})
+    result = _run("src/thing.py", TRUSTED, transcript=transcript)
+    assert result.returncode == 0, result.stderr
+
+
+@pytest.mark.unit
+def test_trusted_allowed_when_no_transcript_available() -> None:
+    result = _run("src/thing.py", TRUSTED)
+    assert result.returncode == 0, result.stderr
+
+
+@pytest.mark.unit
+def test_untrusted_still_blocked_without_a_transcript() -> None:
+    result = _run("src/thing.py", UNTRUSTED)
+    assert result.returncode == 2
+
+
+# --- scope ------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_non_write_tools_are_ignored(tmp_path: Path) -> None:
+    result = _run("src/thing.py", UNTRUSTED, tool="Read")
+    assert result.returncode == 0, result.stderr
+
+
+@pytest.mark.unit
+def test_missing_file_path_is_ignored() -> None:
+    result = subprocess.run(
+        [sys.executable, str(HOOK)],
+        input=json.dumps({"tool_name": "Write", "tool_input": {}}),
+        capture_output=True,
+        text=True,
+        cwd=REPO_ROOT,
+        env={"ATLAS_CHAT_HOOK_USER": UNTRUSTED, "PATH": "/usr/bin:/bin"},
+    )
+    assert result.returncode == 0, result.stderr
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("user", [TRUSTED, UNTRUSTED, ""])
+def test_paths_outside_the_repository_are_not_our_business(user: str, tmp_path: Path) -> None:
+    """Scratch files, other checkouts, ~/.claude — the guard covers this repo only."""
+    for target in (tmp_path / "scratch.txt", Path.home() / ".claude" / "settings.json"):
+        result = subprocess.run(
+            [sys.executable, str(HOOK)],
+            input=json.dumps({"tool_name": "Write", "tool_input": {"file_path": str(target)}}),
+            capture_output=True,
+            text=True,
+            cwd=REPO_ROOT,
+            env={"ATLAS_CHAT_HOOK_USER": user, "PATH": "/usr/bin:/bin"},
+        )
+        assert result.returncode == 0, f"{target}: {result.stderr}"


### PR DESCRIPTION
Restores `.claude/hooks/curation_guard.py`, which was stranded on
`feat/orchestration-contracts` — a branch that was mostly reverted. `CLAUDE_dev.md`
on `dev` has described this hook for months while neither it nor its test existed.

## What changed against the original

The original didn't do what the guide said. The guide said a trusted git identity
bypassed the check; the code gave trusted users a *denylist* blocking `src/`,
`.claude/` and `tests/`, so between the two tiers nobody could write source at all.
The rejection told trusted users to "open a separate CLAUDE_dev.md session", which
the hook had no way to detect.

Now:

- `projects/` and `planning/` are open to everyone.
- Everything else in the repo is infrastructure: a trusted git identity, **and**
  `CLAUDE_dev.md` loaded into the session.
- Paths outside the repository are not the guard's business — scratch files, other
  checkouts, `~/.claude`.

## Checking that the guide was read

Claude Code passes `transcript_path` in the hook payload, so this is observable
rather than assumed. The hook scans the transcript for the guide's own title line,
which catches any route that put the content in context — the Read tool, `cat`
through Bash, an `@CLAUDE_dev` import. The marker is read from `CLAUDE_dev.md`
rather than hardcoded, so retitling keeps both sides in step; lines are JSON-decoded
before matching because the em dash in the title is stored escaped.

The block clears itself: the agent reads the guide and retries. Where no transcript
is available the check cannot run and trusted users pass.

Verified against two real session transcripts — one that had loaded the guide
(allowed) and one that had not (blocked).

## Also here

- `TRUSTED_USERS` is `dosumis@gmail.com` and `do12@sanger.ac.uk`.
- `tests/unit/test_curation_guard.py` — 23 cases: content zones, untrusted blocks,
  the guide condition, em-dash escaping, `@CLAUDE_dev`, missing transcript,
  non-write tools, outside-repo paths.
- `CLAUDE_dev.md`'s curation-hook section rewritten, since it described the opposite
  behaviour.

Full unit suite: 392 passed. Ruff clean.

## Worth knowing

Once this is on `dev` it governs agent writes in this repo, including infrastructure
edits made by a session that has not loaded the guide. That is the intent, but it
will change how dev sessions start.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
