### PR TITLE
CAS+ schema: describe every field, and the two subatlas denominators

### DIFF
--- a/CLAUDE_dev.md
+++ b/CLAUDE_dev.md
@@ -162,6 +162,28 @@ Build infrastructure to ensure tha all JSON artefacts and markdown reports writt
 
 ---
 
+## Definition of done: the pipeline doc
+
+`docs/pipeline.md` is the implementation map — for each stage of processing, what
+runs, what it reads and writes, which schema its output conforms to, and which hook
+checks it. It is ordered by the chain of processing, from project setup through
+literature search to a finished report.
+
+**A piece of work is not complete until `docs/pipeline.md` reflects it.** Update it
+in the same commit as the change, on the branch where the change happens, so the
+doc arrives with the merge. That covers a new or changed skill, subagent, service,
+CLI, schema or hook; a change to what a stage reads or writes; and anything that
+closes or opens one of the gaps the doc lists.
+
+It also carries a "Not yet incorporated" section describing work finished on other
+branches. Move an entry out of that section as part of merging it.
+
+Single file for now, on purpose — the workflow is changing too fast for the
+bookkeeping of managed subdocuments to pay off. Split it (per-skill and per-agent
+pages, say) once the churn settles.
+
+---
+
 ## Testing
 
 ### Test-driven where it pays

--- a/docs/pipeline.md
+++ b/docs/pipeline.md
@@ -1,0 +1,412 @@
+# The pipeline: what is actually built
+
+**Developer reference. Describes the `dev` branch as it stands.**
+
+This is the implementation map for atlas-chat: for each stage of processing, what
+runs, what it reads and writes, which schema the output conforms to, and which
+hook checks it. It is ordered by the chain of processing — project setup through
+literature search to a finished report — not by directory.
+
+It is deliberately more detailed and more developer-facing than `README.md`.
+
+Three neighbouring documents, so you know when to look elsewhere:
+
+- `CLAUDE.md` is the orchestrator's operating instructions — what to do at each
+  step, in the imperative. It is being rewritten; where it disagrees with this
+  file, this file describes the code.
+- `CLAUDE_dev.md` is how to build and extend the workflow: conventions, testing,
+  the schema-first rule.
+- `README.md` is the project overview for people who are not going to read either
+  of the above. It was last updated in June 2026 and is out of date.
+
+**Keeping it current:** a piece of work is not finished until this file reflects
+it. Update it in the same commit as the change, on the branch where the change
+happens.
+
+**Scope:** everything below is present on `dev` unless stated otherwise. A large
+amount of functionality is finished but still sitting on feature branches — see
+[Not yet incorporated](#not-yet-incorporated).
+
+---
+
+## 1. Project setup and inputs
+
+A project is a directory under `projects/{project}/`. The one required input is a
+CAS+ document describing the atlas and its cell-type annotations.
+
+**CAS+ config** — `projects/{project}/cas.json`, conforming to
+`schemas/cas_annotation.schema.json`. Carries the atlas `source` (DOI, title),
+the `composition` context (organism, stage, tissue), and the annotation list, each
+with a `cell_label` and `labelset`. Where an annotation came from an integrated
+upstream study, `transferred_annotations[]` records the subatlas paper and source
+taxonomy. Checked on write by `.claude/hooks/check_cas_annotation.py`.
+
+**Skill `generate-cas`** builds that document from whatever the project actually
+has: a bare list of labels, a spreadsheet or CSV, an AnnData `h5ad`/zarr `obs`, a
+CELLxGENE dataset, or a paper's supplementary table. It asks the user for anything
+not derivable from the source. This is the one place that normalises input shape;
+everything downstream can assume CAS+.
+
+**Skill `anndata-zarr-summary`** fetches `obs/` only from an AnnData-zarr store
+(never the expression matrix), over http(s), gs or file URLs, zarr v2 or v3. It
+produces per-cell-type co-annotation summaries and a `cell_type_annotations.json`.
+Note that this emits the *legacy flat* annotation file, not CAS+.
+
+**Skill `load-project-context`** reads the project's annotations, resolves the
+atlas CorpusId, scans any existing traversal output, and builds a session-level
+merged paper catalogue. Also still on the legacy flat file.
+
+**`services/atlas_paper.py`** holds the config dataclasses (`AtlasConfig`,
+`PaperIdentifiers`, `AtlasPaperData`) and `load_project_config()`.
+
+## 2. Working out which papers are in scope
+
+An atlas paper is rarely the only source. Cell types are frequently transferred in
+from upstream studies, and the evidence for a given label may live entirely in one
+of those.
+
+**`services/subatlas_resolver.py`** turns integration provenance into a list of
+papers. `parse_label()` and `read_provenance_labels()` read study labels out of the
+annotation data; `discover()` proposes candidate subatlas papers; `ingest()` adds
+them to the project corpus. Library only — no CLI yet.
+
+**`services/asta_indexing.py`** probes how much of a given paper ASTA actually
+indexed, and classifies it into a band (`probe()`, `classify_rows()`,
+`IndexingReport`). Results are cached (`probe_cached()`, `cached_bands()`,
+`clear_cache()`). This matters downstream: where a paper's band is
+`abstract_only`, only title and abstract were ever searchable, and the report
+synthesiser is instructed to say so in any claim resting on it.
+
+## 3. Supplementary material
+
+Markers and cluster-to-name mappings usually live in supplements rather than the
+paper body, so this gets its own subsystem: fetch, store, triage, index.
+
+**Fetch — `services/supplement_fetch.py`.** `resolve_pmcid()` and `fetch_jats()`
+get the paper; `fetch_bundle()` pulls the EuropePMC supplementary bundle, with
+`publisher_direct_url()` / `springer_url()` as a fallback where the bundle is
+absent. `verify_payload()` and `is_non_evidence()` discard junk. `should_attempt()`
+holds the retry policy. `fetch_supplements()` does one paper, `fetch_corpus()` does
+the project's whole paper set. Library only — no CLI.
+
+**Store — `services/supplement_store.py`**, with
+`python -m atlas_chat.cli_supplements` as the entry point. An on-disk store keyed
+by paper, holding the files plus a manifest that records what each file, sheet or
+page contains. Subcommands: `inventory` (build a manifest skeleton from JATS
+captions), `adopt` (take in manually downloaded files), `unpack` (archives),
+`outline` (structure of a spreadsheet or document), `text`, `slice` (read a named
+locator without opening the whole file), `show`, `check`, `papers`. The manifest
+conforms to `schemas/supplement_manifest.schema.json` and is checked on write by
+`.claude/hooks/check_supplement_manifest.py`. `cross_check_manifest()` and
+`validate_manifest()` provide the same checks programmatically.
+
+**Triage — `services/supplement_triage.py`.** Decides cheaply which files are worth
+indexing at all, from column signatures and captions: `classify_table()`,
+`classify_caption()`, `looks_per_cell()`, `triage_paper()`, `sheet_candidates()`,
+`indexable()`. The point is to avoid opening a 2 GB per-cell metadata table to
+discover it holds no cell-type names.
+
+**Skill `index-supplements`** drives the above: reads captions first, opens files
+only when captions do not answer the question, and writes the manifest. Declares
+`supplement_manifest.schema.json` as its output. Needs the `[supplements]` extra
+(openpyxl).
+
+## 4. Resolving the name and the source paper
+
+**Subagent `resolve-name`.** Takes an annotation label — often an abbreviation like
+`LC_1` or `F2` — and finds how the authors actually refer to that cell type, using
+snippet search scoped to the paper plus the supplement store. It also decides
+*which* paper the annotation genuinely comes from, atlas or subatlas, and emits the
+`source_paper` / `role` pair that every downstream piece of evidence carries for
+provenance.
+
+Prompt: `agents/name_resolver.prompt.yaml`. Output written to
+`projects/{project}/traversal_output/{cell_type}/name_resolution.json`.
+
+No declared input or output schema yet — the contract is prose in `CLAUDE.md`. The
+schema exists on the `query-decomposer` branch.
+
+## 5. Scanning supplements for a cell type
+
+**Subagent `scan-supplements`.** Given the resolved names and the supplement store,
+extracts marker genes with their evidence type, plus any other findings (function,
+spatial location, developmental timing) and exact supporting quotes. Every finding
+records its parent paper explicitly and a locator back into the store — the parent
+is not assumed to be the atlas.
+
+Prompt: `agents/supplementary_scanner.prompt.yaml`. Output:
+`supplementary_findings.json`, conforming to
+`schemas/supplementary_findings.schema.json`. Declares its output schema in
+front-matter, but no validator hook is registered for it.
+
+## 6. Citation traversal and evidence gathering
+
+The core of the literature search. A query is run against ASTA (Semantic Scholar)
+snippet search seeded on a known paper; the results are annotated programmatically;
+the agent reads only the slim annotated text and decides which citations to follow;
+the loop repeats to the configured depth.
+
+The design rule is that raw ASTA payloads never enter a model context. Retrieval,
+reference splicing and follow-set resolution all run in Python.
+
+**`cli_annotate.py`** — `python -m atlas_chat.cli_annotate` — is the sanctioned
+boundary. Subcommands:
+
+- `fetch` — call `snippet_search`, splice reference tokens into the sentence text,
+  write slim `annotated_snippet` records to disk, print only counts and a path.
+- `follow-set` — intersect the agent's proposed CorpusIds with the ids the
+  annotator actually emitted; write the deduped follow set plus rejects.
+- `show` — print one record's `annotated_text` and sentence spans.
+
+**`services/snippet_annotator.py`** does the work behind it: `project_snippet()`,
+`project_response()`, `resolve_follow_set()`.
+
+**`services/citation_traverser.py`** holds the traversal itself: `traverse()`,
+`traverse_annotated()` (ASTA), and `traverse_local()` (local index).
+
+**Local snippet index.** Where ASTA has not indexed a paper — fresh preprints,
+closed-access journals — `services/local_snippet_index.py` builds an ASTA-shaped
+index locally and traversal runs over both, merging results; local snippets are
+marked `source_method: "local_snippet"`. CLI:
+`python -m atlas_chat.services.local_snippet_index` with `build`, `add`, `remove`,
+`rebuild`, `check`, `list`, `search`. Supporting modules: `fetch_preprint.py` (DOI
+to local JATS), `_jats_parser.py` (sentence-level citation associations from JATS),
+`_pdf_parser.py` (PDF to paragraph segments). Driven by the `local-paper-index`
+skill. Needs the `[local-index]` extra (sentence-transformers, PyMuPDF).
+
+**Subagent `citation-traverse`.** Declares
+`schemas/citation_traverse_input.schema.json` in and
+`schemas/all_summaries.schema.json` out. It judges which spliced sentences are
+genuinely about the cell type and proposes which citations to follow; it does not
+call ASTA itself.
+
+Outputs: `all_summaries.json` and `paper_catalogue.json` in the traversal
+directory. Individual records are checked by `check_annotated_snippet.py`,
+`check_follow_set.py` and `check_evidence_summary.py` against
+`annotated_snippet.schema.json`, `follow_set.schema.json` and
+`evidence_summary.schema.json`.
+
+## 7. Report synthesis
+
+**Subagent `synthesize-report`** reads `name_resolution.json`,
+`supplementary_findings.json`, `all_summaries.json` and `paper_catalogue.json`, and
+writes `projects/{project}/reports/{cell_type}.md`.
+
+Prompt: `agents/report_synthesizer.prompt.yaml`, which is canonical and is imported
+by `CLAUDE.md`. The rules that matter: blockquotes may only be used for text
+verified as an exact substring of traversal evidence; supplement and name-resolution
+evidence is paraphrased with an inline citation instead; DOIs come only from the
+paper catalogue; where a paper's ASTA band is `abstract_only`, the claim says so.
+
+The subagent file has no YAML front-matter, so it declares no input or output
+schema.
+
+## 8. Validation
+
+**`validation/report_checker.py`** — `validate_report(report_path, traversal_dir)`
+returning `(passed, errors)`, built on the pure helpers `check_quotes()` and
+`check_references()`. Quote checking normalises whitespace, dashes and smart quotes
+and handles ellipsis-separated segments. Reference checking confirms every DOI in
+the report appears in the paper catalogue.
+
+The orchestrator calls this explicitly after synthesis and feeds any errors back to
+`synthesize-report`, up to two retries. `.claude/hooks/check_report_refs.py` runs
+the same checks on write as an extra guard for interactive sessions, but the
+correction loop does not depend on it.
+
+## 9. Cell Ontology mapping
+
+**Subagent `ontology-term-lookup`** searches OLS4 for CL terms using the report's
+own description plus alternative phrasings, compares candidate definitions against
+the report content, and classifies the match as exact, broad, narrow or none using
+SKOS vocabulary. Writes `cl_mapping.json`, conforming to
+`schemas/cl_mapping.schema.json`, checked by `.claude/hooks/check_cl_mapping.py`
+(which also enforces the `match_type` ↔ `skos_mapping` and `new_term_needed`
+consistency rules).
+
+The mapping is then written into the report header as a `Cell Ontology:` line with
+a PURL of the form `http://purl.obolibrary.org/obo/CL_NNNNNNN`.
+
+This is the worked exemplar for the input/output front-matter convention.
+
+## 10. New term request
+
+Runs only when `cl_mapping.json` has `new_term_needed: true`.
+
+**Subagent `cl-term-request`** drafts a CL new term request from the report and the
+mapping, following `docs/LLM_prompt_guidelines_for_CL_definitions.md`,
+`docs/relations_guide.md` and `docs/cl_new_term_request_template.md`. Produces
+`cl_term_request.json` — structured fields plus a pre-rendered `ntr_markdown` ready
+to paste into a GitHub issue — conforming to
+`schemas/cl_term_request.schema.json` and checked by
+`.claude/hooks/check_cl_term_request.py`.
+
+## 11. Posting to GitHub
+
+Optional, and never without explicit user confirmation, since it opens a public
+issue on `obophenotype/cell-ontology`. The current route is `gh issue create` with
+a `public_repo`-scoped token supplied as `GH_TOKEN` so the user's own credentials
+are untouched. The issue URL is appended to the report's Cell Ontology line.
+
+`src/github_app_posting/` implements a GitHub App alternative that posts under a
+bot identity without a personal token. Built, not yet wired into the workflow.
+
+---
+
+## Cross-cutting
+
+### Schemas and their validator hooks
+
+| Schema | Written by | Hook |
+| --- | --- | --- |
+| `cas_annotation` | `generate-cas` | `check_cas_annotation.py` |
+| `supplement_manifest` | `index-supplements`, supplement store | `check_supplement_manifest.py` |
+| `annotated_snippet` | `cli_annotate fetch` | `check_annotated_snippet.py` |
+| `follow_set` | `cli_annotate follow-set` | `check_follow_set.py` |
+| `evidence_summary` | `citation-traverse` | `check_evidence_summary.py` |
+| `all_summaries` | `citation-traverse` | none |
+| `supplementary_findings` | `scan-supplements` | none |
+| `citation_traverse_input` | orchestrator | n/a (input) |
+| `cl_mapping` | `ontology-term-lookup` | `check_cl_mapping.py` |
+| `cl_term_request` | `cl-term-request` | `check_cl_term_request.py` |
+| report markdown | `synthesize-report` | `check_report_refs.py` |
+
+Also present: `run_provenance` (used by `utils/provenance.py`), `workflow_output`
+(referenced from `validation/`), and `example_input` (example agent only).
+
+All hooks are registered as `PostToolUse` on `Write|Edit|MultiEdit` in
+`.claude/settings.json`.
+
+### Command-line entry points
+
+Everything reusable is callable without a Claude Code session:
+
+| Command | What it does |
+| --- | --- |
+| `python -m atlas_chat.cli_supplements` | supplement store: inventory, adopt, unpack, outline, text, slice, show, check, papers |
+| `python -m atlas_chat.cli_annotate` | traversal boundary: fetch, follow-set, show |
+| `python -m atlas_chat.services.local_snippet_index` | local index: build, add, remove, rebuild, check, list, search |
+| `python -m atlas_chat.services.fetch_preprint` | DOI to local JATS |
+| `python -m atlas_chat.services._jats_parser` | JATS citation extraction |
+
+`/run-workflow` (`.claude/commands/run-workflow.md`) switches a session into
+content mode by loading `CLAUDE.md`.
+
+### Where CAS+ lives
+
+CAS+ is owned here, in Atlas-reporter. `cxg-author-probe`
+(github.com/Cellular-Semantics/cxg-author-probe) stops at its three wire schemas
+— `probe-v1`, `picks-v1`, `pulled-v1`: it handles dataset formats, describes obs
+columns, picks the author cell-type columns and pulls them. It has no opinion
+about CAS.
+
+This needs stating explicitly because the repository has argued both ways. A
+July 2026 plan pushed CAS assembly upstream, making the module produce CAP+ and
+Atlas-reporter merely consume it; that position was later reversed. The
+consequence of the reversal is visible: `schemas/cas-v1.schema.json` on the
+module's unmerged `cas-annotation-upstream` branch is a near-copy of our
+`cas_annotation.schema.json` — identical `Annotation` definitions, differing only
+in `schema_version`/`data_provenance` upstream against `AstaIndexing` here, plus
+a looser `required`. Two copies, already drifting in both directions.
+
+Reconciling them into the one here, and porting the module's CAS assembler down
+rather than merging it up, are in
+`planning/plan_cxg_probe_integration_2026-09.md`. Until that happens, treat
+`src/atlas_chat/atlas_chat/schemas/cas_annotation.schema.json` as the only
+authority and the upstream branch as unadopted.
+
+That plan also settles how atlases are ingested. Extraction is improvised per
+atlas by an agent, under the rule that **the agent writes the script and the
+numbers come from the library** — a small set of functions with correctness rules
+that must hold identically across projects (profiling, assembly, validation, the
+summary). Ingest is iterative rather than single-pass: which papers are subatlases
+is setup knowledge, so CAS+ is enriched across passes, each with its script saved
+alongside its output. The schema's field descriptions are therefore the
+specification an agent works from, and 40 of 83 fields currently have none.
+
+The module is not yet a dependency on `dev`, and has no release — 0.1.0, no tags,
+no PyPI.
+
+### Known gaps on `dev`
+
+Real discrepancies, listed so nobody rediscovers them:
+
+- **`curation_guard.py` does not exist on `dev`.** `CLAUDE_dev.md` documents it
+  as a `PreToolUse` hook restricting non-developer writes to `projects/` and
+  `planning/`, and describes a regression test for it. The original lives on
+  `feat/orchestration-contracts`, and its behaviour did not match that
+  description. A reconstruction is on `feature/curation-guard` — see below.
+- **No validator hook** for `supplementary_findings` or `all_summaries`, though
+  both have schemas. `CLAUDE_dev.md` requires one per output schema.
+- **Most subagents declare no input/output front-matter** —
+  `resolve-name`, `cl-term-request` and `synthesize-report` declare nothing;
+  `scan-supplements` declares output only. Retrofitting these is the follow-up work
+  named in `CLAUDE_dev.md`.
+- **`CLAUDE.md`'s numbered workflow is behind the code.** It does not mention the
+  supplement store, triage, the snippet annotator, the subatlas resolver or ASTA
+  indexing bands. A rewrite is planned.
+- **Legacy annotation file still in use.** `load-project-context` and
+  `anndata-zarr-summary` work with the flat `cell_type_annotations.json`, not CAS+.
+- **No CLI** for `supplement_fetch` or `subatlas_resolver`, both of which are
+  otherwise service-shaped.
+- **Two CAS schemas exist**, one here and one on an unmerged `cxg-author-probe`
+  branch — see [Where CAS+ lives](#where-cas-lives).
+
+### Not yet incorporated
+
+Finished or near-finished work sitting on branches, not merged into `dev`.
+`planning/branch_state_and_merge_plan_2026-09.md` holds the merge plan.
+`feat/orchestration-contracts` is an older, partly-reverted branch: it holds
+eight input/output schemas and front-matter for all six subagents, some of it
+overfitted. Worth picking over, not merging.
+
+- **`feature/curation-guard`** — `curation_guard.py` reconstructed from
+  `feat/orchestration-contracts` and rebuilt: `projects/` and `planning/` open to
+  everyone, all other paths writable only by a trusted git identity, and only once
+  `CLAUDE_dev.md` has been loaded into the session (checked against the session
+  transcript). With `tests/unit/test_curation_guard.py` and a corrected
+  `CLAUDE_dev.md` description.
+- **`feature/pdf-text-extract`** (6 commits ahead) — PDF text extraction as a
+  service, CLI and skill; describing supplement units with Haiku subagents.
+- **`feature/lit-search-mvp`** (9 ahead) — query-driven selection of target cell
+  types over CAS+ and per-cell-type aspect decomposition; JATS-first routing and a
+  whole-text reader (`paper_router`, `jats_reader`); literature search as skills
+  (`gather-evidence`, `coverage`, `free-search`); blockquote attribution checking in
+  report validation; seeding traversal on the paper that defines the cell type.
+- **`feature/subatlas-consistency`** (5 ahead) — integration provenance produced
+  from `obs`; the subatlas contributor cutoff and its two denominators; the
+  consistency judgement and primacy call.
+- **`feature/subatlas-scoring`** (1 ahead) — scoring atlas cell sets against
+  subatlas cell sets, and cutting a read plan. Implements the four overlap
+  measures (`purity`, `fraction_of_subatlas_set`, `fraction_of_atlas_set`, `f1`)
+  over `subatlas_scores.schema.json`. It derives the per-subatlas-cell-set total
+  post hoc, by summing across a partition of the atlas, which fails on atlases
+  with no usable partition (a `degraded` run, where `fraction_of_subatlas_set`
+  and `f1` cannot be computed). The plan is to record that total at ingest
+  instead, where it is a direct count — see
+  `planning/plan_cxg_probe_integration_2026-09.md`. Merge this branch rather
+  than recomputing the measures.
+- **`query-decomposer`** (4 ahead, 23 behind) — the earlier home of the layer A/B
+  work now also carried on `lit-search-mvp`, plus `test_projects/` run tracking.
+  Largely superseded.
+- **`test/retrieval-matrix`** (12 ahead) — retrieval experiments, harness and
+  write-ups. Findings and data, not pipeline code.
+
+### Deprecated
+
+Kept for reference and regression comparison. Do not extend.
+
+- **`cli.py`** — the `atlas-report` console script.
+- **`graphs/`** — `report_graph.py`, `graph_agent.py`, `definitions.py`, the
+  PydanticAI graph orchestration.
+- **`llm/`** — `create_agent()` over `cellsem_llm_client`, the provider-neutral
+  factory used by the graph. This is the LLM-calling code, and it is deprecated
+  along with the pattern: model calls belong in subagents, not in Python. Services
+  prepare inputs and record outputs; they do not call a model.
+- **`agents/example_agent.py`** and `example_agent.prompt.yaml`.
+- The graph-era prompt YAMLs are a mixed case: `name_resolver`,
+  `supplementary_scanner`, `report_synthesizer` and `orchestrator` remain canonical
+  and are imported by `CLAUDE.md`; `snippet_summarizer.prompt.yaml` belongs to the
+  graph path only.
+- `services/europepmc.py` is documented as a client "for the programmatic graph
+  path".

--- a/docs/pipeline.md
+++ b/docs/pipeline.md
@@ -322,7 +322,14 @@ that must hold identically across projects (profiling, assembly, validation, the
 summary). Ingest is iterative rather than single-pass: which papers are subatlases
 is setup knowledge, so CAS+ is enriched across passes, each with its script saved
 alongside its output. The schema's field descriptions are therefore the
-specification an agent works from, and 40 of 83 fields currently have none.
+specification an agent works from; every field now carries one, and a test keeps
+it that way.
+
+`cas_annotation.schema.json` also carries the two denominators the subatlas
+overlap measures divide by — `SubatlasPaper.cell_sets[]` and
+`TransferredAnnotation.subatlas_contribution_cells` — both direct counts from the
+per-cell table. `title` and `source` are no longer required at the root, since a
+document assembled from a dataset does not yet know its paper.
 
 The module is not yet a dependency on `dev`, and has no release — 0.1.0, no tags,
 no PyPI.

--- a/planning/plan_cxg_probe_integration_2026-09.md
+++ b/planning/plan_cxg_probe_integration_2026-09.md
@@ -1,0 +1,359 @@
+# Plan: ingest to CAS+
+
+**Date:** 2026-09-06
+**Status:** plan for review — not started
+
+**Supersedes** the multi-source loader framework in
+`plan_project_initialization_v2_2026-06-23.md`, the ingestion half of
+`plan_cas_migration_bigbang_and_prog_agentic_split_2026-06-24.md`, and the
+repositioning in `notes_cxg_author_probe_future_upstream_2026-07-04.md`.
+
+---
+
+## The shape of it
+
+Atlases arrive however their authors left them: an h5ad with several obs fields
+alongside a spreadsheet and a supplementary table; an R frame; a directory of
+mtx and csv files. Agents work these out. A loader framework does not help, and
+the multi-source case — several sources for one atlas, needing reconciliation —
+is one no such framework was going to handle.
+
+So extraction is improvised per atlas, and the discipline sits elsewhere:
+
+> **The agent writes the script; the numbers come from the library.**
+
+An agent writing `n_cells: 78` into a document is asserting a number it did not
+compute. A library function doing a value count is reproducible and checkable.
+Which format, which library, how to get the columns out — all incidental, and
+all improvisable.
+
+Ingest is also **iterative**. Which papers are subatlases is setup knowledge, not
+data, and it is often filled in after the document is first populated. So CAS+ is
+enriched across passes rather than produced once, and each pass is a script saved
+with its output.
+
+## Where CAS+ lives
+
+**CAS+ is owned here.** `cxg-author-probe` keeps `probe-v1`, `picks-v1` and
+`pulled-v1`. It has no opinion about CAS.
+
+Those three wire shapes are small and stable, and they are the whole value of the
+coupling. CAS+ is about to grow composition, the subatlas denominators and
+atlas-paper provenance, none of which the module can populate. A schema with two
+owners is how we ended up with two copies of it: `schemas/cas-v1.schema.json` on
+the module's unmerged `cas-annotation-upstream` branch is a near-copy of our
+`cas_annotation.schema.json`, already drifting both ways.
+
+---
+
+## The work
+
+### 1. Fill in the CAS+ schema descriptions
+
+The schema is what an agent works from, so its field descriptions are the
+specification. **40 of 83 fields have no description at all** — most of
+`SubatlasPaper`, most of `AtlasPaper`, several `TransferredAnnotation` and
+`Labelset` fields.
+
+Say what each field means and how it would be computed or found from source. This
+is cheap and it is the highest-leverage work here. It is self-checking: if a
+description is not enough for an agent to populate the field, the description is
+wrong.
+
+In the same pass: fold in upstream's `schema_version` and `data_provenance`, keep
+`AstaIndexing`, add the two subatlas denominator fields below, and follow upstream
+in dropping `title` and `source` from `required`. **Require only what structure
+demands.** A document being enriched across passes is legitimately incomplete in
+between; completeness is checked where a field is used, not where it is written.
+
+### 2. The ingestion skill
+
+A skill, not a framework. Use an existing skill where one fits, otherwise
+improvise, aiming to produce CAS+ from whatever sources are to hand.
+
+It produces two artifacts and a script.
+
+**The cell table** — `pulled-v1` shape: a small JSON with `dataset_id`, `n_cells`
+and a `data_path` to a parquet sidecar holding `observation_joinid` plus one
+column per field. Cell IDs linked to annotation key/value pairs, whatever the
+source was. The expression matrix is never read; `matrix_file_id` records where
+it lives.
+
+**The field typing** — `picks-v1` shape, extended: which columns hold author
+cell-type annotations, which are covariates, which is the study reference, which
+carry transferred labels. Per-column tags with confidence and a one-line reason,
+plus `picker` recording who made each call — the benchmarked picker, a free
+agent, or the curator.
+
+**The script**, saved into the project, with its inputs pinned — source paths or
+accessions, and the library version. A script whose inputs float is a record of
+intent, not something that runs.
+
+The skill carries recipes rather than machinery: streaming obs from a remote h5ad
+without pulling the matrix; joining multi-file sources **on cell ID, never on row
+position** — a wrong-order join of the right length is silent and corrupts every
+count downstream.
+
+It must **stop and ask** when representations clash. Several cell-type columns
+that disagree, several developmental-stage encodings, sources that contradict
+each other: these need the curator, and resolving them is a normal outcome of
+ingest rather than a failure of it. Nothing should suggest that construction runs
+to completion regardless.
+
+### 3. The library
+
+Composable functions the agent calls as information arrives. Composing them is the
+intended use; reimplementing one is not. If a function does not fit a real atlas,
+that is a bug report against the library — say so in the skill, because an agent
+will otherwise helpfully write its own.
+
+The test for what belongs here: does it have a correctness rule that must be
+identical across projects?
+
+In the library:
+
+- **Profile a table** — per column: kind, dtype, exact `n_unique`, `n_categories`,
+  a sample. Structural facts only, so it generalises to a format nobody has seen.
+  It also decides which columns are worth showing to a judgment step: near-unique
+  columns are identifiers, constant columns say nothing. **It must record the
+  columns it withheld and why.** A dropped column cannot be picked and nobody
+  finds out, which is a failure a wrong pick does not have.
+- **Assemble** — the ported `cas.py`, grown: labelsets with rank by cardinality,
+  one annotation per cell set with `n_cells` and a deterministic accession,
+  parents where subsumption is strict, composition cross-tabs, the subatlas
+  denominators. Invariant assertions on what it is handed: columns the same
+  length, counts summing to the obs total, no ratio above one.
+- **Validate** against the schema.
+- **Summarise** — see below.
+
+Anything supplied rather than derived — the atlas DOI, the title, subatlas paper
+metadata — is passed as an argument, not typed into the document. `build_cas`
+already works this way. The document has exactly one writer.
+
+### 4. The summary, and the conversation after it
+
+A deterministic rendering of the produced CAS+ for the curator: per labelset, how
+many cell sets and whether their cells total the obs count; per contributing
+study, its contribution; the subsumption result and its exceptions; which columns
+the profile withheld; a few annotations shown in full.
+
+This is what makes asking for corrections real. A wrong cell-type column shows up
+at once as an implausible cell-set count; a bad labelset ranking shows up as a
+failed subsumption; a mis-filtered column shows up in the withheld list.
+
+### 5. Align the module, drop the rest
+
+Small changes upstream so the shapes fit this order of operations:
+
+- `pulled-v1` is documented as a pull *after* picking, its `picks` field being a
+  subset of `picks-v1.picks`. Here the order inverts — extract, then profile, then
+  type — so either relax that field's meaning or agree a reading where it lists
+  everything extracted.
+- `picks-v1` needs to carry more than author cell-type columns, and needs a little
+  structure beyond per-column tags (below).
+
+Adopt as a dependency: the picker and its prompt, benchmarked at n=73 (Jaccard
+0.81 against CL_KG curation) — the evaluation corpus is the asset, and forking it
+strands the benchmark. `probe()`, `pull_full_column()` and the readers behind them
+are convenient where they fit; nothing is required to route through them.
+
+Do not adopt: `cas-v1.schema.json`, or the CAS assembly on the unmerged branch.
+Port `cas.py` and its tests down. Two things on that branch are worth merging
+upstream and have nothing to do with CAS — the PostToolUse write-hook that gates
+on `schema_version`, and the CLI batch-robustness fix. Expect a small conflict in
+`cli.py` when cherry-picking them without the CAS commit.
+
+Upstream is at 0.1.0 with no tags and no PyPI release, so the dependency is a git
+pin until they cut one.
+
+---
+
+## Field typing cannot be closed, and should not pretend to be
+
+Some typing depends on knowledge that is not in the data. Judging which dataset a
+transferred label came from needs the list of subatlases, which is setup — and is
+sometimes filled in after the document is first populated.
+
+So typing is enriched like the document is. A column may be typed as carrying
+transferred labels from an unresolved source, and resolved to a named study in a
+later pass. The typing schema must permit that rather than requiring completeness
+at one moment.
+
+This also settles the picker-versus-agent question, which turns out not to be the
+distinction that matters. What matters is that a judgment lands in a **validated
+artifact** rather than being implicit in the extraction script. Once it is an
+artifact it appears in the summary, it diffs across runs, and a wrong call is
+fixed by correcting it and re-running. The picker is one producer of that
+artifact; an agent in conversation with the curator is another; `picker` records
+which.
+
+And determinism is satisfied either way: **given the same recorded judgments, the
+same CAS+ comes out.** Judgment is not deterministic by nature; the build is.
+
+### The one place per-column tags are not enough
+
+Transferred annotations are a relational judgment. The study column and the
+original-author-label column are a pair, and whether the atlas is integrated at
+all is a fact about the dataset rather than about any column. A flat
+`column → category` typing cannot express "this label column came from that study
+column", nor two integration sources encoded differently.
+
+So the typing needs a little structure: at minimum a transferred-label column
+naming the study column it pairs with.
+
+Look at `feature/subatlas-consistency` before designing this — it already produces
+`transferred_annotations` from obs, so it has a working answer to which signals
+identify the pair.
+
+---
+
+## Subatlas overlap measures — denominators at ingest
+
+### The four measures
+
+Per (atlas cell set, contributing study, subatlas cell set):
+
+- `purity` = `overlap_cells / subatlas_contribution_cells` — of what this study
+  contributed to this atlas cell set, the fraction that is this one subatlas cell
+  set. The denominator is the study's whole contribution, whatever it called the
+  cells, so purity is blind to how much of the atlas cell set came from elsewhere.
+- `fraction_of_subatlas_set` = `overlap_cells / subatlas_set_total_cells` — of
+  this subatlas cell set, the fraction that ended up here.
+- `fraction_of_atlas_set` = `overlap_cells / n_cells` — recorded, never gated. It
+  is confounded by every other study's cells, so a low value describes the atlas
+  cell set's mixture rather than the correspondence.
+- `f1` = harmonic mean of the first two. High only when both are, which is what a
+  one-to-one correspondence requires; neither alone discriminates.
+
+`feature/subatlas-scoring` implements all four over `subatlas_scores.schema.json`.
+Merge it, then change where the denominators come from.
+
+### Why they move to ingest
+
+That branch derives `subatlas_set_total_cells` post hoc from CAS+, by summing a
+subatlas cell set across a partition of the atlas — the hierarchy leaves, or one
+whole labelset. A partition is needed because CAS+ holds cell sets with counts,
+not cells. Where none is usable the run is marked `degraded`:
+`fraction_of_subatlas_set` and `f1` cannot be computed at all and the cutoff falls
+back to `purity_floor`.
+
+At ingest the problem does not arise. The table carries, per cell, the atlas
+label, the contributing study and the original author label, so every denominator
+is a direct count: cells with (study, source label); cells with (atlas cell set,
+study); cells with all three, which is the existing
+`TransferredAnnotation.cell_count`. No partition, no inference, nothing to
+degrade. The partition machinery, `basis`, `degraded`, `purity_floor` and
+`purity_only` all come out.
+
+### Where they live
+
+- **`SubatlasPaper.cell_sets[]`** — `{source_labelset, cell_label, n_cells}`. The
+  denominator table for `fraction_of_subatlas_set`. It describes the contributing
+  study rather than any one annotation, so it is stated once.
+  `SubatlasPaper.total_cells` already holds the study's overall contribution.
+- **`TransferredAnnotation.subatlas_contribution_cells`** — the study's
+  contribution to this atlas cell set. Repeated across entries of the same study
+  within an annotation; a cross-field test should assert the repeated values
+  agree. Recording it explicitly rather than summing the transferred entries
+  matters: they are exhaustive at ingest, but anything that later prunes them
+  would quietly shrink the denominator.
+
+`cell_count` and `cell_ratio` already exist, so `fraction_of_atlas_set` needs
+nothing new.
+
+### What it does not fix
+
+The counts stay obs-derived, so they measure cells from the subatlas cell set
+*present in the atlas*. Where an integration subsampled its source, that is not
+the published cell set's size, and `fraction_of_subatlas_set` is recall against
+the atlas's copy rather than against the original study. Computing at ingest
+removes an inference failure, not a provenance limit.
+
+Where a source has no per-cell data at all — a supplementary table of cell types
+and their sizes — labelsets, annotations and `n_cells` are still produced, but
+composition, subsumption and the denominators are not, because the joint
+distribution was summed away before we saw it. The summary must say which parts
+are absent and why. That limit is a property of the source, not of anything we
+build.
+
+---
+
+## The subsumption hierarchy
+
+Where an atlas has more than one author labelset, try to build a single
+inheritance hierarchy across them, and report where it cannot be done.
+
+The test is containment, not correlation: for each cell set in the finer labelset,
+are all of its cells inside one cell set of the coarser labelset? If some fine
+cell set splits across two or more coarser cell sets, the labelsets are not a
+hierarchy — either they cut the data differently, or the annotation is
+inconsistent.
+
+**`parent_cell_set_accession` is set only where subsumption is strict.** Where it
+fails the field is left unset and the exception is reported. This is a change to
+the assembler as it stands: `build_cas` assigns a parent by dominant coarser
+label, so it always produces an answer, including where no containment exists. A
+parent meaning "mostly inside" is a claim the field does not make, and it is
+invisible once written.
+
+The check is nearly free — `build_cas` already computes the cross-tab and takes
+`idxmax`; strict containment is the same cross-tab with one non-zero column per
+fine label, and the failures are the rows with more.
+
+Report exceptions with their numbers — this fine cell set has 312 cells in one
+coarse set and 47 in another — so the curator can see whether it is stray cells or
+a real disagreement.
+
+Anything treating `parent_cell_set_accession` as a total ordering needs checking
+against this. The scoring branch's `hierarchy_leaves` partition defines leaves as
+cell sets that are no other cell set's parent, which shifts under a stricter
+parent — though that partition is on its way out anyway.
+
+If a non-containment relationship is ever worth recording it is an overlap
+measure, not a parent, and it does not belong in CAS. Not proposed here.
+
+Skip it when there is only one author labelset.
+
+---
+
+## What we are not building
+
+- **The multi-source loader framework** — `anndata_loader`, `cellxgene_loader`,
+  `spreadsheet_loader`, `cap_loader`, the `data-sources` extra, `/init-project` as
+  a router.
+- **A reader layer of our own**, or any requirement to route through upstream's.
+- **Agentic reader improvisation as machinery.** The useful half is the invariant
+  assertions, which live in the assembler.
+- **`annotations_writer`'s sidecar files** — `co_annotations.json` and
+  `label_provenance.json` were workarounds for a schema that could not hold
+  covariates. CAS+ `composition` holds them.
+- **A separate hierarchy-checking module** — it is a cross-tab in the assembler.
+- **The six-layer testing taxonomy** — keep schema regression, deterministic
+  golden tests of the library, and golden-project regression.
+
+The field classifier — widening the picker from author cell-type columns to
+annotating what every column contains, in CxG category vocabulary — is not in
+scope here. It is a producer of the typing artifact, so it can arrive later
+without changing anything downstream. Note it types what a column *contains*;
+choosing the authoritative column for a category and resolving values to CURIEs
+is ontology work and stays here.
+
+---
+
+## Sequencing
+
+Merge `feature/subatlas-scoring` and `feature/subatlas-consistency` before the
+assembler work, or it will rebuild them. Merging the scoring branch is not the end
+of it: the measures stay, the post-hoc denominators are replaced by ingest-time
+counts, and the partition machinery comes out — best as a follow-up commit on top
+of the merge, so the two changes stay legible.
+
+## Open questions
+
+1. **Published subatlas cell-set sizes** — worth recovering from subatlas papers
+   later, or is the obs-derived count sufficient permanently?
+2. **Denominator scope** — every cell with (study, source label) in the table, or
+   only those carrying an atlas annotation? They differ wherever cells were
+   filtered out of the annotation.
+3. **`cell_set_accession` scheme** — namespacing and stability across re-runs.
+   Unresolved since June; `build_cas` currently uses `dataset_id:labelset:label`.

--- a/src/atlas_chat/atlas_chat/schemas/cas_annotation.schema.json
+++ b/src/atlas_chat/atlas_chat/schemas/cas_annotation.schema.json
@@ -4,7 +4,7 @@
   "title": "CAS Cell Annotation Collection (local extension)",
   "description": "A cell-set-level annotation collection shaped after the Cell Annotation Schema (CAS, general + BICAN) with local extensions: a per-cell-set 'composition' slot (the cell-set-level generalisation of CxG's cell-level descriptor fields), cell_count/cell_ratio on transferred annotations (reused for integration provenance), labelset 'rank'/'role', and a retained 'source' block carrying atlas-paper provenance for the report workflow. See planning/mockup_cas_cxg_annotations_2026-06-24.md.",
   "type": "object",
-  "required": ["title", "source", "labelsets", "annotations"],
+  "required": ["labelsets", "annotations"],
   "properties": {
     "title": {
       "type": "string",
@@ -21,6 +21,14 @@
     "cellannotation_schema_version": {
       "type": "string",
       "description": "CAS version this document targets."
+    },
+    "schema_version": {
+      "description": "Shape of this document. Consumers should gate on it. Distinct from cellannotation_schema_version, which is the CAS release the document targets.",
+      "const": "cas-plus-v1"
+    },
+    "data_provenance": {
+      "description": "Where the annotations were extracted from, and by what. Recorded so a document can be rebuilt from its sources.",
+      "$ref": "#/$defs/DataProvenance"
     },
     "source": {
       "$ref": "#/$defs/AtlasPaper",
@@ -45,7 +53,10 @@
       "required": ["name"],
       "properties": {
         "name": { "type": "string", "description": "Name of the annotation key (obs column)." },
-        "description": { "type": "string" },
+        "description": {
+          "description": "What this labelset is, in the authors' terms. Taken from the paper or the supplement where they describe the annotation round; left unset rather than guessed.",
+          "type": "string"
+        },
         "annotation_method": {
           "type": "string",
           "description": "How the annotations were made.",
@@ -62,12 +73,25 @@
           "examples": ["author_cell_type", "transferred", "cluster"]
         },
         "automated_annotation": {
+          "description": "Set only when annotation_method is algorithmic: which algorithm produced the labels, and where to find it. Populated from the paper's methods, not inferred from the column.",
           "type": "object",
           "properties": {
-            "algorithm_name": { "type": "string" },
-            "algorithm_version": { "type": "string" },
-            "algorithm_repo_url": { "type": "string" },
-            "reference_location": { "type": "string" }
+            "algorithm_name": {
+              "description": "Name of the clustering or label-transfer algorithm, as the authors give it.",
+              "type": "string"
+            },
+            "algorithm_version": {
+              "description": "Version of that algorithm, where the authors state one.",
+              "type": "string"
+            },
+            "algorithm_repo_url": {
+              "description": "Repository for the algorithm.",
+              "type": "string"
+            },
+            "reference_location": {
+              "description": "The reference dataset or taxonomy the labels were transferred from, where the method was label transfer.",
+              "type": "string"
+            }
           }
         }
       },
@@ -88,10 +112,22 @@
         "parent_cell_set_accession": { "type": ["string", "null"], "description": "Accession of the cell set that subsumes this one (hierarchy); null for root cell sets." },
         "n_cells": { "type": "integer", "minimum": 0, "description": "Local extension: number of cells in the set." },
         "rationale": { "type": "string", "description": "Free-text evidence/justification (report narrative)." },
-        "rationale_dois": { "type": "array", "items": { "type": "string" } },
-        "marker_gene_evidence": { "type": "array", "items": { "type": "string" } },
-        "negative_marker_gene_evidence": { "type": "array", "items": { "type": "string" } },
-        "synonyms": { "type": "array", "items": { "type": "string" } },
+        "rationale_dois": {
+          "description": "DOIs of the papers the rationale draws on. Written by the report step from the paper catalogue; every entry must appear there.",
+          "type": "array", "items": { "type": "string" }
+        },
+        "marker_gene_evidence": {
+          "description": "Gene symbols reported as markers for this cell set. From the paper's own differential-expression results or marker tables, not computed here.",
+          "type": "array", "items": { "type": "string" }
+        },
+        "negative_marker_gene_evidence": {
+          "description": "Gene symbols the authors report this cell set as lacking, where they say so explicitly.",
+          "type": "array", "items": { "type": "string" }
+        },
+        "synonyms": {
+          "description": "Other names the same cell set is given — in this paper, or in a contributing study. A synonym naming a subatlas cell set is treated as evidence of correspondence downstream.",
+          "type": "array", "items": { "type": "string" }
+        },
         "transferred_annotations": {
           "type": "array",
           "description": "CAS slot reused for integration provenance (author labels inherited from contributing datasets). See TransferredAnnotation.",
@@ -113,14 +149,31 @@
       "required": ["transferred_cell_label"],
       "additionalProperties": false,
       "properties": {
-        "transferred_cell_label": { "type": "string" },
+        "transferred_cell_label": {
+          "description": "The contributing study's own label for these cells, verbatim, as it appears in the source column of the atlas obs.",
+          "type": "string"
+        },
         "source_taxonomy": { "type": "string", "description": "Identifier of the source taxonomy/dataset the label came from: a CAS taxonomy accession (e.g. CCN20230722), a PURL, or a DOI." },
         "subatlas_paper": { "type": "string", "description": "The contributing subatlas the label was inherited from — a DOI, or a SubatlasPaper.label registered under source.subatlas_papers. If source_taxonomy is also set, the two should agree." },
-        "source_node_accession": { "type": "string" },
+        "source_node_accession": {
+          "description": "Accession of the matching cell set within source_taxonomy, where the source is a CAS taxonomy that has one.",
+          "type": "string"
+        },
         "source_labelset": { "type": "string", "description": "Name of the labelset within the source taxonomy/subatlas that the transferred label belongs to." },
-        "algorithm_name": { "type": "string" },
-        "comment": { "type": "string" },
+        "algorithm_name": {
+          "description": "The label-transfer method, where the atlas authors state one.",
+          "type": "string"
+        },
+        "comment": {
+          "description": "Free-text note about this transfer — anything worth recording that no other field holds.",
+          "type": "string"
+        },
         "cell_count": { "type": "integer", "minimum": 0, "description": "Local extension: cells in this set carrying the transferred label." },
+        "subatlas_contribution_cells": {
+          "description": "Local extension: every cell of this cell set that came from this contributing study, whatever the study called it. The denominator for purity. A direct count from the per-cell table, so it is the same for every transferred annotation naming the same study within this cell set. Recorded rather than summed from those entries, because anything that later prunes them would quietly shrink it.",
+          "type": "integer",
+          "minimum": 0
+        },
         "cell_ratio": { "type": "number", "minimum": 0, "maximum": 1, "description": "Local extension: fraction of the set carrying the transferred label." }
       }
     },
@@ -137,6 +190,7 @@
       "properties": {
         "author_field_name": { "type": "string", "description": "The original obs column this category came from." },
         "values": {
+          "description": "The distribution over this category, one entry per distinct author value. Computed from the per-cell table by cross-tabbing the cell set against the category's column; every cell of the set is counted exactly once, so cell_count sums to the annotation's n_cells.",
           "type": "array",
           "items": { "$ref": "#/$defs/CompositionValue" }
         }
@@ -151,8 +205,14 @@
         "author_value": { "type": ["string", "number"], "description": "Verbatim author value (may already be a CURIE)." },
         "value": { "type": "string", "description": "Human-readable mapped value." },
         "ontology_term_id": { "type": "string", "description": "Mapped ontology CURIE, e.g. UBERON:0000966, HsapDv:0000048." },
-        "cell_count": { "type": "integer", "minimum": 0 },
-        "cell_ratio": { "type": "number", "minimum": 0, "maximum": 1 }
+        "cell_count": {
+          "description": "Cells in this cell set carrying this author value. A direct count from the per-cell table.",
+          "type": "integer", "minimum": 0
+        },
+        "cell_ratio": {
+          "description": "cell_count divided by the cell set's n_cells.",
+          "type": "number", "minimum": 0, "maximum": 1
+        }
       }
     },
     "AtlasPaper": {
@@ -160,14 +220,38 @@
       "description": "Atlas publication provenance (retained local block, mirrors cell_type_annotation.schema.json).",
       "required": ["doi"],
       "properties": {
-        "doi": { "type": "string", "pattern": "^10\\.\\d{4,}(\\.\\d+)?/.+" },
-        "title": { "type": "string" },
-        "pmcid": { "type": "string" },
-        "pmid": { "type": "string" },
-        "abstract": { "type": "string" },
-        "authors": { "type": "array", "items": { "type": "string" } },
-        "local_text_path": { "type": "string" },
-        "subatlas_papers": { "type": "array", "items": { "$ref": "#/$defs/SubatlasPaper" } },
+        "doi": {
+          "description": "DOI of the paper describing this atlas. Supplied at setup rather than derived from the data.",
+          "type": "string", "pattern": "^10\\.\\d{4,}(\\.\\d+)?/.+"
+        },
+        "title": {
+          "description": "Title of the atlas paper.",
+          "type": "string"
+        },
+        "pmcid": {
+          "description": "PMC identifier, resolved from the DOI via Europe PMC. Absent where the paper is not in PMC.",
+          "type": "string"
+        },
+        "pmid": {
+          "description": "PubMed identifier, resolved from the DOI via Europe PMC.",
+          "type": "string"
+        },
+        "abstract": {
+          "description": "The paper's abstract, as retrieved.",
+          "type": "string"
+        },
+        "authors": {
+          "description": "Author names in publication order.",
+          "type": "array", "items": { "type": "string" }
+        },
+        "local_text_path": {
+          "description": "Path to a locally held full text for this paper, where one was built — for a preprint, or a closed-access paper that had to be fetched by hand.",
+          "type": "string"
+        },
+        "subatlas_papers": {
+          "description": "The contributing studies whose cells or annotations this atlas integrated. Compiled at setup: the atlas obs names them, but resolving each to a publication needs the curator. The list is often filled in after this document is first populated.",
+          "type": "array", "items": { "$ref": "#/$defs/SubatlasPaper" }
+        },
         "atlas_name": { "type": "string", "description": "Human-readable atlas name, e.g. 'Human Female Reproductive System Cell Atlas v1'." },
         "links": { "type": "object", "description": "Named external resources for the atlas as an open map of label -> URL/identifier, e.g. {\"preprint\": \"...\", \"cellxgene\": \"...\"}." }
       }
@@ -176,12 +260,35 @@
       "type": "object",
       "required": ["label"],
       "properties": {
-        "label": { "type": "string" },
-        "first_author": { "type": ["string", "null"] },
-        "year": { "type": ["integer", "null"] },
-        "venue": { "type": ["string", "null"] },
-        "total_cells": { "type": ["integer", "null"] },
-        "doi": { "type": "string" },
+        "label": {
+          "description": "The study as the atlas names it — the value appearing in the obs study column, e.g. 'Sridhar_et_al_2020'. The key everything else joins on, so it is recorded verbatim even where it is untidy.",
+          "type": "string"
+        },
+        "first_author": {
+          "description": "First author's surname, once the study has been resolved to a publication.",
+          "type": ["string", "null"]
+        },
+        "year": {
+          "description": "Publication year.",
+          "type": ["integer", "null"]
+        },
+        "venue": {
+          "description": "Journal or preprint server.",
+          "type": ["string", "null"]
+        },
+        "cell_sets": {
+          "description": "This study's own cell sets and their sizes within the atlas — the denominator table for fraction_of_subatlas_set. Counted across the whole atlas rather than within any one annotation, so it is stated here once. Direct counts from the per-cell table, so they measure cells from each source cell set that are present in the atlas; where an integration subsampled its source, that is not the published cell set's size.",
+          "type": "array",
+          "items": { "$ref": "#/$defs/SubatlasCellSet" }
+        },
+        "total_cells": {
+          "description": "Cells this study contributed to the atlas, across all of its labels. A direct count from the per-cell table, not a figure from the study's own paper.",
+          "type": ["integer", "null"]
+        },
+        "doi": {
+          "description": "DOI of the contributing study, once resolved. Absent where the source has no publication.",
+          "type": "string"
+        },
         "status": {
           "type": "string",
           "description": "Ingest route taken for this paper — how its text is reached. Distinct from asta_indexing.band, which is how much of it ASTA holds: a paper can be band 'abstract_only' in ASTA and still status 'local' because a JATS build succeeded.",
@@ -192,9 +299,18 @@
           "description": "Where the locally built text came from, when status is 'local'.",
           "enum": ["jats", "pdf"]
         },
-        "asta_indexing": { "$ref": "#/$defs/AstaIndexing" },
-        "proposed_doi": { "type": "string" },
-        "proposed": { "type": "array", "items": { "$ref": "#/$defs/SubatlasCandidate" } }
+        "asta_indexing": {
+          "description": "How much of this paper ASTA actually holds. Written by the indexing probe and cached here, so a claim resting on an abstract-only paper can be reported as such.",
+          "$ref": "#/$defs/AstaIndexing"
+        },
+        "proposed_doi": {
+          "description": "A candidate DOI awaiting the curator's confirmation. Distinct from doi, which is settled.",
+          "type": "string"
+        },
+        "proposed": {
+          "description": "Candidate publications for this study label, from a literature search, for the curator to choose between. Populated where the label could not be resolved automatically.",
+          "type": "array", "items": { "$ref": "#/$defs/SubatlasCandidate" }
+        }
       }
     },
     "AstaIndexing": {
@@ -211,20 +327,93 @@
         "chars": { "type": "integer", "minimum": 0, "description": "Total characters of indexed snippet text." },
         "sections": { "type": "integer", "minimum": 0, "description": "Distinct non-null section names — the body-text signal." },
         "ref_mentions": { "type": "integer", "minimum": 0, "description": "Inline reference mentions — the bibliography signal." },
-        "corpus_id": { "type": "string", "pattern": "^CorpusId:\\d+$" },
+        "corpus_id": {
+          "description": "Semantic Scholar CorpusId for the paper, as used to scope snippet search.",
+          "type": "string", "pattern": "^CorpusId:\\d+$"
+        },
         "reason": { "type": "string", "description": "Human-readable justification for the band." },
         "probed_at": { "type": "string", "description": "ISO 8601 timestamp of the probe; this block doubles as the probe cache." }
+      },
+      "additionalProperties": false
+    },
+    "SubatlasCellSet": {
+      "type": "object",
+      "description": "One cell set of a contributing study, with its size inside the atlas.",
+      "required": ["cell_label", "n_cells"],
+      "properties": {
+        "source_labelset": {
+          "description": "The labelset within the contributing study this cell set belongs to — the obs column its labels came from.",
+          "type": "string"
+        },
+        "cell_label": {
+          "description": "The contributing study's own name for the cell set, verbatim.",
+          "type": "string"
+        },
+        "n_cells": {
+          "description": "Cells carrying this label from this study, counted across the whole atlas.",
+          "type": "integer",
+          "minimum": 0
+        }
+      },
+      "additionalProperties": false
+    },
+    "DataProvenance": {
+      "type": "object",
+      "description": "Where the annotations came from and how they were extracted.",
+      "required": ["source_type"],
+      "properties": {
+        "source_type": {
+          "description": "The kind of source, in the extracting agent's own words — 'local_h5ad', 'cellxgene', 'h5ad + supplementary table'. Free text on purpose: sources include R frames, mtx and csv directories, spreadsheets and combinations of these, and any closed list would be wrong for the next atlas.",
+          "type": "string"
+        },
+        "dataset_id": {
+          "description": "Stable identifier for the source dataset, where it has one — a CELLxGENE dataset UUID, say.",
+          "type": "string"
+        },
+        "sources": {
+          "description": "The files, URLs or accessions actually read, one entry each. A list because an atlas is often assembled from several — a matrix alongside a spreadsheet and a supplementary table.",
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "n_cells_total": {
+          "description": "Cells in the source table. Every labelset's cell sets should sum to this unless some cells are unlabelled.",
+          "type": "integer",
+          "minimum": 0
+        },
+        "script_path": {
+          "description": "The extraction script that produced this document, kept so it can be rebuilt. Only reproducible if its inputs are pinned — paths or accessions, and the library version.",
+          "type": "string"
+        },
+        "extracted_at": {
+          "description": "ISO 8601 timestamp of the extraction.",
+          "type": "string"
+        }
       },
       "additionalProperties": false
     },
     "SubatlasCandidate": {
       "type": "object",
       "properties": {
-        "doi": { "type": "string" },
-        "title": { "type": "string" },
-        "year": { "type": ["integer", "null"] },
-        "corpus_id": { "type": "string" },
-        "venue": { "type": "string" }
+        "doi": {
+          "description": "DOI of the candidate publication.",
+          "type": "string"
+        },
+        "title": {
+          "description": "Title of the candidate publication.",
+          "type": "string"
+        },
+        "year": {
+          "description": "Publication year of the candidate.",
+          "type": ["integer", "null"]
+        },
+        "corpus_id": {
+          "description": "Semantic Scholar CorpusId of the candidate.",
+          "type": "string"
+        },
+        "venue": {
+          "description": "Journal or preprint server of the candidate.",
+          "type": "string"
+        }
       }
     }
   }

--- a/src/atlas_chat/atlas_chat/schemas/cas_annotation.schema.json
+++ b/src/atlas_chat/atlas_chat/schemas/cas_annotation.schema.json
@@ -218,10 +218,9 @@
     "AtlasPaper": {
       "type": "object",
       "description": "Atlas publication provenance (retained local block, mirrors cell_type_annotation.schema.json).",
-      "required": ["doi"],
       "properties": {
         "doi": {
-          "description": "DOI of the paper describing this atlas. Supplied at setup rather than derived from the data.",
+          "description": "DOI of the paper describing this atlas. Supplied at setup rather than derived from the data, and absent where there is not one yet — a pre-submission manuscript is recorded with a title and local_text_path instead. Nothing here is required, because the block is filled in across passes; that the paper can be cited or read is checked where it is used.",
           "type": "string", "pattern": "^10\\.\\d{4,}(\\.\\d+)?/.+"
         },
         "title": {
@@ -245,7 +244,7 @@
           "type": "array", "items": { "type": "string" }
         },
         "local_text_path": {
-          "description": "Path to a locally held full text for this paper, where one was built — for a preprint, or a closed-access paper that had to be fetched by hand.",
+          "description": "Path to a locally held full text for this paper, where one was built — for a preprint, a closed-access paper fetched by hand, or a manuscript that has not been submitted. Together with a title this is enough to work from when there is no DOI.",
           "type": "string"
         },
         "subatlas_papers": {

--- a/tests/unit/test_cas_annotation_schema.py
+++ b/tests/unit/test_cas_annotation_schema.py
@@ -267,3 +267,26 @@ def test_subatlas_cell_set_requires_a_label_and_a_count() -> None:
     data = _load("cas_annotation.good.json")
     data["source"]["subatlas_papers"][0]["cell_sets"] = [{"source_labelset": "celltype"}]
     assert _errors(data) != []
+
+
+@pytest.mark.unit
+def test_atlas_paper_without_a_doi_validates() -> None:
+    """A pre-submission manuscript has no DOI. What matters downstream is that
+    the paper can be cited or read, which a title and a local text satisfy —
+    and that is checked where the paper is used, not where it is written."""
+    data = _load("cas_annotation.minimal.good.json")
+    data["source"] = {
+        "title": "A cell atlas of the human female reproductive system",
+        "authors": ["Anon A"],
+        "local_text_path": "projects/x/papers/manuscript.md",
+    }
+    assert _errors(data) == []
+
+
+@pytest.mark.unit
+def test_atlas_paper_with_only_a_doi_validates() -> None:
+    """The other order: the curator supplies an identifier and the rest is
+    resolved in a later pass."""
+    data = _load("cas_annotation.minimal.good.json")
+    data["source"] = {"doi": "10.1038/s41586-024-08002-x"}
+    assert _errors(data) == []

--- a/tests/unit/test_cas_annotation_schema.py
+++ b/tests/unit/test_cas_annotation_schema.py
@@ -151,3 +151,119 @@ def test_source_type_is_constrained() -> None:
     data = _load("cas_annotation.good.json")
     data["source"]["subatlas_papers"][1]["source_type"] = "docx"
     assert _errors(data)
+
+
+# --- the descriptions are the specification --------------------------------
+
+
+def _walk_properties(node: object, path: str) -> list[tuple[str, dict]]:
+    found: list[tuple[str, dict]] = []
+    if not isinstance(node, dict):
+        return found
+    for name, subschema in (node.get("properties") or {}).items():
+        found.append((f"{path}.{name}", subschema))
+        found.extend(_walk_properties(subschema, f"{path}.{name}"))
+    if "items" in node:
+        found.extend(_walk_properties(node["items"], f"{path}[]"))
+    return found
+
+
+def _all_properties() -> list[tuple[str, dict]]:
+    schema = load_schema(SCHEMA)
+    found = _walk_properties(schema, "(root)")
+    for name, definition in (schema.get("$defs") or {}).items():
+        found.extend(_walk_properties(definition, name))
+    return found
+
+
+@pytest.mark.unit
+def test_every_field_has_a_description() -> None:
+    """An agent populates this document from the schema, so an undescribed
+    field is an unpopulatable one. Adding a field means describing it."""
+    bare = [p for p, s in _all_properties() if not (s.get("description") or "").strip()]
+    assert bare == []
+
+
+# --- assembled from a dataset ----------------------------------------------
+
+
+@pytest.mark.unit
+def test_document_without_paper_provenance_validates() -> None:
+    """A document assembled from a dataset does not yet know its paper.
+    Completeness is checked where a field is used, not where it is written."""
+    assert (
+        _errors(
+            {
+                "labelsets": [{"name": "celltype"}],
+                "annotations": [{"labelset": "celltype", "cell_label": "AC"}],
+            }
+        )
+        == []
+    )
+
+
+@pytest.mark.unit
+def test_data_provenance_records_several_sources() -> None:
+    data = _load("cas_annotation.minimal.good.json")
+    data["data_provenance"] = {
+        "source_type": "h5ad + supplementary table",
+        "sources": ["atlas.h5ad", "media-2.xlsx"],
+        "n_cells_total": 4212,
+        "script_path": "projects/x/ingest/extract.py",
+    }
+    assert _errors(data) == []
+
+
+@pytest.mark.unit
+def test_source_type_is_free_text() -> None:
+    """Sources include R frames, mtx directories and combinations; a closed
+    list would be wrong for the next atlas."""
+    data = _load("cas_annotation.minimal.good.json")
+    data["data_provenance"] = {"source_type": "seurat rds via SeuratDisk"}
+    assert _errors(data) == []
+
+
+@pytest.mark.unit
+def test_data_provenance_rejects_unknown_fields() -> None:
+    data = _load("cas_annotation.minimal.good.json")
+    data["data_provenance"] = {"source_type": "local_h5ad", "obs_column": "celltype"}
+    assert _errors(data) != []
+
+
+# --- the subatlas denominators ---------------------------------------------
+
+
+@pytest.mark.unit
+def test_subatlas_paper_carries_its_cell_sets() -> None:
+    """The denominator for fraction_of_subatlas_set: each contributing cell
+    set's size across the whole atlas, stated once per study."""
+    data = _load("cas_annotation.good.json")
+    data["source"]["subatlas_papers"][0]["cell_sets"] = [
+        {"source_labelset": "celltype_Smith2021", "cell_label": "AC", "n_cells": 412},
+        {"source_labelset": "celltype_Smith2021", "cell_label": "imGlia", "n_cells": 96},
+    ]
+    assert _errors(data) == []
+
+
+@pytest.mark.unit
+def test_transferred_annotation_carries_the_contribution() -> None:
+    """The denominator for purity: the study's whole contribution to this
+    cell set, whatever it called the cells."""
+    data = _load("cas_annotation.good.json")
+    data["annotations"][0]["transferred_annotations"][0]["subatlas_contribution_cells"] = 78
+    assert _errors(data) == []
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("value", [-1, 1.5, "78"])
+def test_contribution_must_be_a_non_negative_integer(value: object) -> None:
+    data = _load("cas_annotation.good.json")
+    data["annotations"][0]["transferred_annotations"][0]["subatlas_contribution_cells"] = value
+    assert _errors(data) != []
+
+
+@pytest.mark.unit
+def test_subatlas_cell_set_requires_a_label_and_a_count() -> None:
+    data = _load("cas_annotation.good.json")
+    data["source"]["subatlas_papers"][0]["cell_sets"] = [{"source_labelset": "celltype"}]
+    assert _errors(data) != []


### PR DESCRIPTION
First piece of #49. Schema only — no ingest code yet.

## Every field now has a description

An ingesting agent populates CAS+ by reading its schema, so the field descriptions *are* the specification. **40 of 83 fields had none** — most of `SubatlasPaper`, most of `AtlasPaper`, several `TransferredAnnotation` and `Labelset` fields — which means nobody could have populated them from the schema alone.

All of them now say what the field means and where its value comes from, and `test_every_field_has_a_description` keeps it that way. It is self-checking in the other direction too: if a description turns out not to be enough for an agent to populate the field, the description is what needs fixing.

## The two subatlas denominators

```
SubatlasPaper.cell_sets[]                         -> fraction_of_subatlas_set
TransferredAnnotation.subatlas_contribution_cells -> purity
```

Both are direct counts from the per-cell table rather than sums over a partition of the atlas. `feature/subatlas-scoring` currently derives the first post hoc by summing a subatlas cell set across the hierarchy leaves or a whole labelset, and marks the run `degraded` where no partition is usable — at which point `fraction_of_subatlas_set` and `f1` cannot be computed at all. Recording them at ingest removes that failure: at ingest the obs carries the atlas label, the study and the original author label per cell, so each denominator is a value count.

`subatlas_contribution_cells` is recorded rather than summed from the transferred annotations because those are exhaustive at ingest but anything that later prunes them would quietly shrink the denominator.

## `schema_version` and `data_provenance`

Folded in from the module's `cas-v1`, with one deliberate difference: **`source_type` is free text, not an enum.** Upstream's list is `manual`, `published_zarr`, `local_h5ad`, `local_zarr`, `cellxgene`, `cap`, `spreadsheet`. Atlases also arrive as R frames, directories of mtx and csv, and combinations — an h5ad alongside a spreadsheet alongside a supplementary table — so the closed list would be wrong for the next atlas. That is the contingent-enum case `CLAUDE_dev.md` warns about.

`obs_column` went with it: which column holds what belongs in the field typing artifact, not here. `sources` is a list rather than a single path, because multi-source atlases are the motivating case. `script_path` records the extraction script, since a document is only rebuildable if the code that made it was kept.

`schema_version` is `cas-plus-v1` — distinct from upstream's `cas-v1` because the shapes differ — and optional for now, since requiring it would invalidate every existing document. Worth requiring once documents are regenerated.

## `title` and `source` no longer required

A document assembled from a dataset does not yet know its paper, and CAS+ is enriched across passes rather than produced once — which papers are subatlases is setup knowledge that often arrives after a first pass. Completeness belongs where a field is used, not where it is written.

## Checks

380 unit tests pass, ruff clean. 11 new schema regressions covering the descriptions rule, documents without paper provenance, multi-source `data_provenance`, free-text `source_type`, `additionalProperties` teeth, and the two denominators including their non-negative-integer constraint.

The schema's hand-formatting is preserved — descriptions were inserted line-wise rather than via a JSON round-trip, so the diff shows the additions rather than a reformat of the whole file.

Refs #49, Cellular-Semantics/cxg-author-probe#4

🤖 Generated with [Claude Code](https://claude.com/claude-code)
