### PR TITLE
Paper ingest: assemble one paper's readable content before any question

### DIFF
--- a/src/atlas_chat/atlas_chat/cli_paper_ingest.py
+++ b/src/atlas_chat/atlas_chat/cli_paper_ingest.py
@@ -1,0 +1,20 @@
+"""CLI for assembling one paper's readable content.
+
+Thin entry point so the ingest is usable without a Claude Code session:
+
+.. code-block:: bash
+
+    python -m atlas_chat.cli_paper_ingest --text paper.jats.xml --out ingest.json \
+        --doi 10.0000/example --store <supplement store> --limit-tokens 60000
+
+The implementation lives in :mod:`atlas_chat.services.paper_ingest`.
+"""
+
+from __future__ import annotations
+
+from atlas_chat.services.paper_ingest import build_parser, main
+
+__all__ = ["build_parser", "main"]
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/atlas_chat/atlas_chat/schemas/paper_ingest.schema.json
+++ b/src/atlas_chat/atlas_chat/schemas/paper_ingest.schema.json
@@ -1,0 +1,154 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "paper_ingest.schema.json",
+  "title": "PaperIngest",
+  "description": "Everything from one paper that is loaded into a reading agent's context before any question is asked. Assembled deterministically: no model is called. Text is carried inline rather than referenced, because the point of the object is to be read whole; a caller that only needs to know what is available should read the counts and gaps.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["source", "narrative", "budget"],
+  "properties": {
+    "paper": {
+      "type": "object",
+      "description": "Identifiers for the paper, as far as they are known. All optional: a paper may be reachable as text without any identifier resolving.",
+      "additionalProperties": false,
+      "properties": {
+        "doi": { "type": "string" },
+        "pmcid": { "type": "string" },
+        "title": { "type": "string" }
+      }
+    },
+    "source": {
+      "type": "object",
+      "description": "Where the text came from, and by what route, so a downstream grounding check can tell how faithfully it represents the published article.",
+      "additionalProperties": false,
+      "required": ["path", "kind"],
+      "properties": {
+        "path": {
+          "type": "string",
+          "description": "The file this was assembled from."
+        },
+        "kind": {
+          "type": "string",
+          "enum": ["jats", "pdf_text"],
+          "description": "Tagged article XML, or text recovered from a PDF. The distinction does real work downstream: PDF text has no reference markup, so no cited sentences are available, and its reading order is not guaranteed across a column boundary, so a quote spanning one may not correspond to anything a reader of the article would see."
+        }
+      }
+    },
+    "narrative": {
+      "type": "object",
+      "description": "The paper's body prose, with section headings retained inline, in document order.",
+      "additionalProperties": false,
+      "required": ["text", "n_chars"],
+      "properties": {
+        "text": { "type": "string" },
+        "n_chars": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "excluded_sections": {
+      "type": "array",
+      "description": "Sections held out of `narrative` because they describe how the work was done rather than what was found. Recorded by heading and size rather than carried, so that their exclusion is visible and reversible without doubling the object.",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["heading", "n_chars"],
+        "properties": {
+          "heading": { "type": "string" },
+          "n_chars": { "type": "integer", "minimum": 0 }
+        }
+      }
+    },
+    "legends": {
+      "type": "array",
+      "description": "Figure and table captions, kept as their own block and never merged into `narrative`. A caption is not body prose and must not read as though it were; separately, captions routinely carry naming information that appears nowhere in the body, so they cannot simply be dropped either.",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["text"],
+        "properties": {
+          "label": {
+            "type": "string",
+            "description": "The authors' own label for the figure or table, where the markup carries one."
+          },
+          "text": { "type": "string" }
+        }
+      }
+    },
+    "cited_sentences": {
+      "type": "array",
+      "description": "Sentences that carry a citation, each with the references it cites. Available only from tagged XML. Two uses: a citation on a sentence marks a claim as inherited rather than made by this paper, and the reference it resolves to is an exact onward target rather than a search result.",
+      "items": {
+        "type": "object",
+        "required": ["text", "ref_ids"],
+        "properties": {
+          "text": { "type": "string" },
+          "section": { "type": "string" },
+          "ref_ids": { "type": "array", "items": { "type": "string" } }
+        }
+      }
+    },
+    "references": {
+      "type": "object",
+      "description": "The reference list, keyed by the identifier `cited_sentences` uses. A key absent here is a marker the parser could not resolve, not an invented reference.",
+      "additionalProperties": { "type": "object" }
+    },
+    "supplement_prose": {
+      "type": "array",
+      "description": "Supplementary prose judged to bear on describing cell types, taken from the paper's supplement manifest. Only spans marked as folding in are carried; the rest are omitted, not summarised. Prose is included whole because it cannot be sliced by a query the way a table can.",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["text", "n_chars"],
+        "properties": {
+          "file_id": { "type": "string" },
+          "member_path": { "type": "string" },
+          "text_file": {
+            "type": "string",
+            "description": "Store-relative path the text was read from, so a claim can be traced back to it."
+          },
+          "description": {
+            "type": "string",
+            "description": "What this prose contains, carried through from the manifest."
+          },
+          "headings": {
+            "type": "array",
+            "description": "The headings of the spans carried, in order. Empty when the document was taken whole.",
+            "items": { "type": "string" }
+          },
+          "text": { "type": "string" },
+          "n_chars": { "type": "integer", "minimum": 0 }
+        }
+      }
+    },
+    "budget": {
+      "type": "object",
+      "description": "What the assembled object costs to read, and whether anything was left out to fit. A caller must be able to tell a complete ingest from a partial one without recounting.",
+      "additionalProperties": false,
+      "required": ["estimated_tokens", "truncated"],
+      "properties": {
+        "limit_tokens": {
+          "type": "integer",
+          "description": "The ceiling applied, when one was.",
+          "minimum": 0
+        },
+        "estimated_tokens": { "type": "integer", "minimum": 0 },
+        "truncated": {
+          "type": "boolean",
+          "description": "True when content was dropped to fit the ceiling. Every drop also appears in `gaps`, so a truncated ingest says what is missing rather than only that something is."
+        }
+      }
+    },
+    "gaps": {
+      "type": "array",
+      "description": "What could not be included, and why. A gap is a statement that something is unread — never that it holds nothing relevant.",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["what", "reason"],
+        "properties": {
+          "what": { "type": "string" },
+          "reason": { "type": "string" }
+        }
+      }
+    }
+  }
+}

--- a/src/atlas_chat/atlas_chat/services/paper_ingest.py
+++ b/src/atlas_chat/atlas_chat/services/paper_ingest.py
@@ -1,0 +1,514 @@
+"""Assemble what a reading agent is given about one paper, before any question.
+
+A paper is read whole rather than retrieved from: within a single paper there is
+nothing for a ranker to buy that reading the text does not already give. So the
+job here is not selection but assembly — gather the text a reader needs, keep
+the parts that must not be confused with each other apart, and say what could
+not be included.
+
+Three things are kept separate rather than concatenated, because each answers a
+different kind of question and misreading one as another is a real error:
+
+* **narrative** — the body prose, in document order, with its headings.
+* **legends** — figure and table captions. A caption is not body prose, and a
+  quote drawn from one should not read as though the authors wrote it in the
+  text. Captions cannot be dropped either: naming information often appears in
+  a caption and nowhere else.
+* **cited sentences** — sentences carrying a citation, with the references they
+  resolve to. A citation marks a claim as inherited rather than made here, and
+  the resolved reference is an exact onward target rather than a search result.
+  Available only from tagged XML.
+
+Supplementary prose is folded in from the paper's supplement manifest, which
+records which spans bear on describing cell types. Only those spans are carried.
+Tables are deliberately absent: prose has to be read whole because it cannot be
+sliced by a query, whereas a table can, and some are far too large to read.
+
+Nothing here calls a model, and nothing here fetches a paper: the text is taken
+from a path the caller supplies.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import re
+import xml.etree.ElementTree as ET
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+#: Rough characters per token, for reporting size rather than for billing.
+CHARS_PER_TOKEN = 4
+
+#: Sections whose titles say they describe how the work was done rather than
+#: what was found, or that carry no findings at all.
+_PROCESS_SECTION_TITLES = re.compile(
+    r"^(methods?|materials and methods|online methods|star.{0,2}methods|"
+    r"experimental procedures|acknowledge?ments?|author contributions|"
+    r"competing interests|data availability|code availability|references)\b",
+    re.I,
+)
+
+#: A section describing how populations were named or told apart is kept even
+#: where it sits among process description, because that is where cluster
+#: identifiers acquire the names everything downstream refers to them by.
+_NAMING_SECTION_TITLES = re.compile(
+    r"annotat|nomenclature|identificat|cell.?type|cell.?state|celltype|labell?ing",
+    re.I,
+)
+
+
+class PaperIngestError(RuntimeError):
+    """Raised when the supplied paper text cannot be assembled at all."""
+
+
+@dataclass
+class PaperIngest:
+    """One paper's readable content, assembled and accounted for."""
+
+    source_path: str
+    source_kind: str
+    narrative_text: str
+    paper: dict[str, str] = field(default_factory=dict)
+    excluded_sections: list[dict[str, Any]] = field(default_factory=list)
+    legends: list[dict[str, str]] = field(default_factory=list)
+    cited_sentences: list[dict[str, Any]] = field(default_factory=list)
+    references: dict[str, Any] = field(default_factory=dict)
+    supplement_prose: list[dict[str, Any]] = field(default_factory=list)
+    limit_tokens: int | None = None
+    truncated: bool = False
+    gaps: list[dict[str, str]] = field(default_factory=list)
+
+    @property
+    def estimated_tokens(self) -> int:
+        chars = len(self.narrative_text)
+        chars += sum(len(item["text"]) for item in self.legends)
+        chars += sum(len(item["text"]) for item in self.supplement_prose)
+        chars += sum(len(item["text"]) for item in self.cited_sentences)
+        return chars // CHARS_PER_TOKEN
+
+    def to_dict(self) -> dict[str, Any]:
+        out: dict[str, Any] = {
+            "source": {"path": self.source_path, "kind": self.source_kind},
+            "narrative": {
+                "text": self.narrative_text,
+                "n_chars": len(self.narrative_text),
+            },
+            "budget": {
+                "estimated_tokens": self.estimated_tokens,
+                "truncated": self.truncated,
+            },
+        }
+        if self.limit_tokens is not None:
+            out["budget"]["limit_tokens"] = self.limit_tokens
+        if self.paper:
+            out["paper"] = dict(self.paper)
+        for key, value in (
+            ("excluded_sections", self.excluded_sections),
+            ("legends", self.legends),
+            ("cited_sentences", self.cited_sentences),
+            ("supplement_prose", self.supplement_prose),
+            ("gaps", self.gaps),
+        ):
+            if value:
+                out[key] = value
+        if self.references:
+            out["references"] = self.references
+        return out
+
+
+# ------------------------------------------------------------------
+# Article text
+# ------------------------------------------------------------------
+
+
+def split_sections(
+    pairs: list[tuple[str, str]],
+) -> tuple[list[tuple[str, str]], list[dict[str, Any]]]:
+    """Partition ``(section, paragraph)`` pairs into kept prose and held-out sections.
+
+    Process description is held out on two grounds. A section is held out when its
+    own title says it is process description. It is also held out when it follows
+    the last section titled Discussion: process description is frequently split
+    into many specifically-titled leaf sections that say nothing about what they
+    are collectively, and their position is the only thing that identifies them.
+
+    A section whose title is about how populations were named or distinguished is
+    kept either way.
+
+    Where there is no section titled Discussion, position says nothing and only
+    the title test applies.
+
+    Args:
+        pairs: paragraphs in document order, each with the heading above it.
+
+    Returns:
+        The pairs to read, and a record of each held-out section with the number
+        of characters held out with it.
+    """
+    last_discussion = max(
+        (
+            i
+            for i, (section, _) in enumerate(pairs)
+            if (section or "").strip().lower() == "discussion"
+        ),
+        default=None,
+    )
+    kept: list[tuple[str, str]] = []
+    excluded: dict[str, int] = {}
+    for index, (section, text) in enumerate(pairs):
+        heading = (section or "").strip()
+        by_title = bool(_PROCESS_SECTION_TITLES.match(heading))
+        by_position = last_discussion is not None and index > last_discussion
+        if (by_title or by_position) and not _NAMING_SECTION_TITLES.search(heading):
+            excluded[section] = excluded.get(section, 0) + len(text)
+        else:
+            kept.append((section, text))
+    return kept, [{"heading": h, "n_chars": n} for h, n in excluded.items()]
+
+
+def render(pairs: list[tuple[str, str]]) -> str:
+    """Join ``(section, paragraph)`` pairs into text with headings interleaved."""
+    parts: list[str] = []
+    current: str | None = None
+    for section, text in pairs:
+        if section != current:
+            if section:
+                parts.append(f"\n## {section}\n")
+            current = section
+        parts.append(text)
+    return "\n".join(parts).strip()
+
+
+def extract_legends(xml: str) -> list[dict[str, str]]:
+    """Figure and table captions, each with the authors' label where present."""
+    root = ET.fromstring(re.sub(r"<!DOCTYPE[^>]*>", "", xml, count=1))
+    for elem in root.iter():
+        if "}" in elem.tag:
+            elem.tag = elem.tag.split("}", 1)[1]
+    legends: list[dict[str, str]] = []
+    for wrap in root.iter():
+        if wrap.tag not in ("fig", "table-wrap"):
+            continue
+        caption_el = wrap.find("caption")
+        if caption_el is None:
+            continue
+        caption = re.sub(r"\s+", " ", " ".join(caption_el.itertext())).strip()
+        if not caption:
+            continue
+        label_el = wrap.find("label")
+        label = (
+            re.sub(r"\s+", " ", " ".join(label_el.itertext())).strip()
+            if label_el is not None
+            else ""
+        )
+        legends.append({"label": label, "text": caption} if label else {"text": caption})
+    return legends
+
+
+def _cited_sentences(xml: str) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    from atlas_chat.services._jats_parser import parse_jats_citations
+
+    cited, refs = parse_jats_citations(xml)
+    sentences = [
+        {
+            "text": cs.text,
+            "section": cs.section,
+            "ref_ids": list(cs.ref_ids),
+        }
+        for cs in cited
+    ]
+    lookup = {
+        ref_id: {
+            key: value
+            for key, value in (
+                ("doi", ref.doi),
+                ("pmid", ref.pmid),
+                ("title", ref.title),
+                ("year", ref.year),
+                ("first_author", ref.first_author),
+            )
+            if value
+        }
+        for ref_id, ref in refs.items()
+    }
+    return sentences, lookup
+
+
+# ------------------------------------------------------------------
+# Supplementary prose
+# ------------------------------------------------------------------
+
+
+def _spans_of(pointer: dict[str, Any], text: str) -> tuple[str, list[str]]:
+    """The text to carry from one prose pointer, and the headings it came from.
+
+    A pointer judged section-wise carries only the spans marked as folding in;
+    one judged as a whole carries the whole document.
+    """
+    sections = pointer.get("sections") or []
+    picked = [s for s in sections if s.get("folds_in")]
+    if not picked:
+        return text, []
+    parts = [text[s["char_start"] : s["char_end"]] for s in picked]
+    return "\n\n".join(p.strip() for p in parts if p.strip()), [
+        s.get("heading", "") for s in picked
+    ]
+
+
+def supplement_prose(
+    store_root: str | Path, doi: str
+) -> tuple[list[dict[str, Any]], list[dict[str, str]]]:
+    """Prose spans from a paper's supplement manifest that fold into a read.
+
+    Args:
+        store_root: the supplement store holding this paper's manifest.
+        doi: the paper whose manifest to read.
+
+    Returns:
+        The spans to carry, and a gap for each pointer that should have folded in
+        but whose text could not be read.
+    """
+    from atlas_chat.services.supplement_store import load_manifest
+
+    root = Path(store_root)
+    manifest = load_manifest(root, doi)
+    if manifest is None:
+        return [], [{"what": f"supplements for {doi}", "reason": "no manifest in the store"}]
+
+    carried: list[dict[str, Any]] = []
+    gaps: list[dict[str, str]] = []
+    for pointer in manifest.get("prose") or []:
+        if not pointer.get("folds_in"):
+            continue
+        rel = pointer.get("text_file")
+        if not rel:
+            gaps.append(
+                {
+                    "what": pointer.get("file_id", "supplementary prose"),
+                    "reason": "folds in, but the manifest records no extracted text",
+                }
+            )
+            continue
+        path = root / rel
+        try:
+            text = path.read_text(encoding="utf-8", errors="replace")
+        except OSError as exc:
+            gaps.append({"what": rel, "reason": f"extracted text unreadable: {exc}"})
+            continue
+        span, headings = _spans_of(pointer, text)
+        if not span.strip():
+            gaps.append({"what": rel, "reason": "folds in, but the spans marked are empty"})
+            continue
+        item: dict[str, Any] = {"text": span, "n_chars": len(span), "text_file": rel}
+        for key in ("file_id", "member_path", "description"):
+            if pointer.get(key):
+                item[key] = pointer[key]
+        if headings:
+            item["headings"] = headings
+        carried.append(item)
+    return carried, gaps
+
+
+# ------------------------------------------------------------------
+# Assembly
+# ------------------------------------------------------------------
+
+
+def _fit(ingest: PaperIngest, limit_tokens: int) -> None:
+    """Drop content to fit a ceiling, lowest precedence first, recording each drop.
+
+    Precedence is the order the caller reads in: the article's own prose first,
+    then its captions, then supplementary prose. So supplementary prose goes
+    first and the narrative is only cut when nothing else is left to give.
+    """
+    ingest.limit_tokens = limit_tokens
+    if ingest.estimated_tokens <= limit_tokens:
+        return
+
+    while ingest.supplement_prose and ingest.estimated_tokens > limit_tokens:
+        dropped = ingest.supplement_prose.pop()
+        ingest.truncated = True
+        ingest.gaps.append(
+            {
+                "what": dropped.get("text_file", "supplementary prose"),
+                "reason": "dropped to fit the read budget",
+            }
+        )
+
+    if ingest.estimated_tokens > limit_tokens and ingest.legends:
+        n = len(ingest.legends)
+        ingest.legends = []
+        ingest.truncated = True
+        ingest.gaps.append(
+            {"what": f"{n} figure and table captions", "reason": "dropped to fit the read budget"}
+        )
+
+    if ingest.estimated_tokens > limit_tokens:
+        keep = limit_tokens * CHARS_PER_TOKEN
+        original = len(ingest.narrative_text)
+        ingest.narrative_text = ingest.narrative_text[:keep]
+        ingest.truncated = True
+        ingest.gaps.append(
+            {
+                "what": "the paper's narrative text",
+                "reason": (
+                    f"cut in document order at {keep} of {original} characters "
+                    "to fit the read budget; the tail is unread"
+                ),
+            }
+        )
+
+
+def ingest_paper(
+    text_path: str | Path,
+    *,
+    kind: str | None = None,
+    doi: str | None = None,
+    store_root: str | Path | None = None,
+    limit_tokens: int | None = None,
+) -> PaperIngest:
+    """Assemble one paper's readable content from a file on disk.
+
+    Args:
+        text_path: tagged article XML, or plain text recovered from a PDF.
+        kind: ``"jats"`` or ``"pdf_text"``. Inferred from the suffix when omitted.
+        doi: the paper's DOI, recorded on the result and used to find its
+            supplements. Without it no supplementary prose is looked for.
+        store_root: the supplement store to take prose from.
+        limit_tokens: ceiling on the assembled read. Content is dropped lowest
+            precedence first and every drop is recorded as a gap.
+
+    Returns:
+        The assembled content, with what it cost and what is missing.
+
+    Raises:
+        PaperIngestError: the file cannot be read, or holds no prose at all.
+    """
+    path = Path(text_path)
+    try:
+        raw = path.read_text(encoding="utf-8", errors="replace")
+    except OSError as exc:
+        raise PaperIngestError(f"cannot read {path}: {exc}") from exc
+
+    resolved_kind = kind or ("jats" if path.suffix.lower() in (".xml", ".jats") else "pdf_text")
+    ingest = PaperIngest(source_path=str(path), source_kind=resolved_kind, narrative_text="")
+    if doi:
+        ingest.paper["doi"] = doi
+
+    if resolved_kind == "jats":
+        from atlas_chat.services.local_snippet_index import extract_body_segments
+
+        try:
+            segments = extract_body_segments(raw)
+        except ET.ParseError as exc:
+            raise PaperIngestError(f"{path} is not parseable as article XML: {exc}") from exc
+        kept, excluded = split_sections([(seg.section, seg.text) for seg in segments])
+        ingest.narrative_text = render(kept)
+        ingest.excluded_sections = excluded
+        ingest.legends = extract_legends(raw)
+        ingest.cited_sentences, ingest.references = _cited_sentences(raw)
+    else:
+        ingest.narrative_text = raw.strip()
+        ingest.gaps.append(
+            {
+                "what": "cited sentences and the reference list",
+                "reason": (
+                    "the text came from a PDF, which carries no reference markup, "
+                    "so no citation can be resolved from it"
+                ),
+            }
+        )
+
+    if not ingest.narrative_text.strip():
+        raise PaperIngestError(f"{path} yielded no prose")
+
+    if store_root is not None:
+        if doi:
+            carried, gaps = supplement_prose(store_root, doi)
+            ingest.supplement_prose = carried
+            ingest.gaps.extend(gaps)
+        else:
+            ingest.gaps.append(
+                {
+                    "what": "supplementary prose",
+                    "reason": "a store was given but no DOI, so its manifest cannot be found",
+                }
+            )
+
+    if limit_tokens is not None:
+        _fit(ingest, limit_tokens)
+
+    return ingest
+
+
+def write_ingest(ingest: PaperIngest, out_path: str | Path) -> Path:
+    """Write an assembled ingest as JSON, having validated it against its schema.
+
+    Validation runs before the write, so an object that does not conform is never
+    left on disk for something downstream to read.
+
+    Raises:
+        jsonschema.ValidationError: the assembled object does not conform.
+    """
+    import jsonschema  # type: ignore[import-untyped]
+
+    from atlas_chat.schemas import load_schema
+
+    payload = ingest.to_dict()
+    jsonschema.validate(payload, load_schema("paper_ingest.schema.json"))
+    path = Path(out_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    return path
+
+
+# ------------------------------------------------------------------
+# CLI
+# ------------------------------------------------------------------
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="python -m atlas_chat.cli_paper_ingest",
+        description="Assemble one paper's readable content for a reading agent.",
+    )
+    parser.add_argument("--text", required=True, help="article XML, or text from a PDF")
+    parser.add_argument("--out", required=True, help="where to write the assembled JSON")
+    parser.add_argument("--kind", choices=["jats", "pdf_text"], help="default: from the suffix")
+    parser.add_argument("--doi", help="recorded on the result; needed to find supplements")
+    parser.add_argument("--store", help="supplement store to take prose from")
+    parser.add_argument("--limit-tokens", type=int, help="ceiling on the assembled read")
+    parser.add_argument("-v", "--verbose", action="store_true")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    logging.basicConfig(
+        level=logging.INFO if args.verbose else logging.WARNING, format="%(levelname)s: %(message)s"
+    )
+    try:
+        ingest = ingest_paper(
+            args.text,
+            kind=args.kind,
+            doi=args.doi,
+            store_root=args.store,
+            limit_tokens=args.limit_tokens,
+        )
+    except PaperIngestError as exc:
+        print(str(exc))
+        return 2
+    path = write_ingest(ingest, args.out)
+    print(
+        f"ingest: kind={ingest.source_kind} narrative_chars={len(ingest.narrative_text)} "
+        f"legends={len(ingest.legends)} cited_sentences={len(ingest.cited_sentences)} "
+        f"supplement_prose={len(ingest.supplement_prose)} "
+        f"tokens~{ingest.estimated_tokens} truncated={ingest.truncated} "
+        f"gaps={len(ingest.gaps)} -> {path}"
+    )
+    return 0

--- a/tests/unit/test_paper_ingest.py
+++ b/tests/unit/test_paper_ingest.py
@@ -1,0 +1,343 @@
+"""Unit tests for assembling one paper's readable content."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import jsonschema
+import pytest
+from atlas_chat.services.paper_ingest import (
+    CHARS_PER_TOKEN,
+    PaperIngestError,
+    extract_legends,
+    ingest_paper,
+    main,
+    render,
+    split_sections,
+    supplement_prose,
+    write_ingest,
+)
+
+from atlas_chat.schemas import load_schema
+
+pytestmark = pytest.mark.unit
+
+
+ARTICLE = """<article>
+  <front><article-meta><abstract><p>An abstract sentence.</p></abstract></article-meta></front>
+  <body>
+    <sec><title>Results</title>
+      <p>A population was identified in the tissue.</p>
+      <p>It resembles one described before <xref ref-type="bibr" rid="R1">1</xref>.</p>
+      <fig><label>Fig. 1</label><caption><p>ABC, a longer name for ABC.</p></caption></fig>
+    </sec>
+    <sec><title>Discussion</title><p>A closing thought.</p></sec>
+    <sec><title>Methods</title><p>Cells were dissociated and sequenced.</p></sec>
+  </body>
+  <back><ref-list>
+    <ref id="R1"><element-citation>
+      <person-group><name><surname>Someone</surname></name></person-group>
+      <article-title>An earlier description</article-title>
+      <year>2020</year>
+      <pub-id pub-id-type="doi">10.1234/earlier</pub-id>
+    </element-citation></ref>
+  </ref-list></back>
+</article>
+"""
+
+
+def _write(tmp_path: Path, name: str, text: str) -> Path:
+    path = tmp_path / name
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+# ------------------------------------------------------------------
+# Pure helpers
+# ------------------------------------------------------------------
+
+
+def test_split_sections_holds_out_process_sections_and_records_their_size():
+    kept, excluded = split_sections(
+        [("Results", "aaa"), ("Methods", "bbbb"), ("Discussion", "cc"), ("Methods", "d")]
+    )
+    assert [s for s, _ in kept] == ["Results", "Discussion"]
+    assert excluded == [{"heading": "Methods", "n_chars": 5}]
+
+
+def test_without_a_discussion_section_only_the_title_test_applies():
+    """Position says nothing when there is no boundary to be after."""
+    kept, excluded = split_sections([("", "orphan prose"), ("Tissue processing", "protocol")])
+    assert len(kept) == 2
+    assert excluded == []
+
+
+def test_sections_after_the_last_discussion_are_held_out():
+    kept, excluded = split_sections(
+        [
+            ("Results", "a finding"),
+            ("Discussion", "a closing thought"),
+            ("Tissue acquisition and processing", "a protocol"),
+            ("H&E staining and imaging", "another protocol"),
+        ]
+    )
+    assert [s for s, _ in kept] == ["Results", "Discussion"]
+    assert {s["heading"] for s in excluded} == {
+        "Tissue acquisition and processing",
+        "H&E staining and imaging",
+    }
+
+
+def test_a_naming_section_is_kept_wherever_it_sits():
+    """Cluster identifiers acquire their names in these sections."""
+    kept, _ = split_sections(
+        [
+            ("Discussion", "a closing thought"),
+            ("Tissue acquisition and processing", "a protocol"),
+            ("Data integration and annotation", "clusters were named"),
+            ("Methods", "a protocol"),
+            ("Cell type annotation", "more naming"),
+        ]
+    )
+    assert [s for s, _ in kept] == [
+        "Discussion",
+        "Data integration and annotation",
+        "Cell type annotation",
+    ]
+
+
+def test_render_writes_each_heading_once():
+    text = render([("Results", "one"), ("Results", "two"), ("Discussion", "three")])
+    assert text.count("## Results") == 1
+    assert text.index("## Results") < text.index("## Discussion")
+
+
+def test_extract_legends_keeps_the_authors_label():
+    legends = extract_legends(ARTICLE)
+    assert legends == [{"label": "Fig. 1", "text": "ABC, a longer name for ABC."}]
+
+
+# ------------------------------------------------------------------
+# Assembly from article XML
+# ------------------------------------------------------------------
+
+
+def test_legend_text_is_not_in_the_narrative(tmp_path):
+    """A caption must not read as though the authors wrote it in the body."""
+    ingest = ingest_paper(_write(tmp_path, "article.xml", ARTICLE))
+    assert "a longer name for ABC" in ingest.legends[0]["text"]
+    assert "a longer name for ABC" not in ingest.narrative_text
+
+
+def test_narrative_holds_results_and_discussion_but_not_methods(tmp_path):
+    ingest = ingest_paper(_write(tmp_path, "article.xml", ARTICLE))
+    assert "A population was identified" in ingest.narrative_text
+    assert "A closing thought" in ingest.narrative_text
+    assert "dissociated and sequenced" not in ingest.narrative_text
+    assert [s["heading"] for s in ingest.excluded_sections] == ["Methods"]
+    assert ingest.excluded_sections[0]["n_chars"] > 0
+
+
+def test_cited_sentences_resolve_to_the_reference_list(tmp_path):
+    ingest = ingest_paper(_write(tmp_path, "article.xml", ARTICLE), doi="10.1234/paper")
+    assert ingest.cited_sentences, "a sentence carrying a citation should be recorded"
+    assert any("R1" in cs["ref_ids"] for cs in ingest.cited_sentences)
+    assert ingest.references["R1"]["doi"] == "10.1234/earlier"
+    assert ingest.paper["doi"] == "10.1234/paper"
+
+
+def test_pdf_text_records_that_no_citation_can_be_resolved(tmp_path):
+    ingest = ingest_paper(_write(tmp_path, "paper.txt", "Some recovered prose."))
+    assert ingest.source_kind == "pdf_text"
+    assert ingest.cited_sentences == []
+    assert any("reference markup" in gap["reason"] for gap in ingest.gaps)
+
+
+def test_empty_text_is_an_error_not_an_empty_ingest(tmp_path):
+    with pytest.raises(PaperIngestError):
+        ingest_paper(_write(tmp_path, "empty.txt", "   \n  "))
+
+
+def test_unparseable_xml_is_an_error(tmp_path):
+    with pytest.raises(PaperIngestError):
+        ingest_paper(_write(tmp_path, "broken.xml", "<article><body>"))
+
+
+def test_missing_file_is_an_error(tmp_path):
+    with pytest.raises(PaperIngestError):
+        ingest_paper(tmp_path / "absent.xml")
+
+
+# ------------------------------------------------------------------
+# Supplementary prose
+# ------------------------------------------------------------------
+
+
+def _store_with_prose(tmp_path: Path, doi: str, pointers: list[dict]) -> Path:
+    from atlas_chat.services.supplement_store import manifest_path
+
+    root = tmp_path / "store"
+    path = manifest_path(root, doi)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps({"manifest_version": 1, "paper": {"doi": doi}, "prose": pointers}),
+        encoding="utf-8",
+    )
+    return root
+
+
+def test_only_spans_marked_as_folding_in_are_carried(tmp_path):
+    doi = "10.1234/paper"
+    text = "KEEP THIS SPAN\n\nDROP THIS SPAN"
+    root = _store_with_prose(
+        tmp_path,
+        doi,
+        [
+            {
+                "file_id": "s1",
+                "text_file": "extracted/s1.txt",
+                "folds_in": True,
+                "sections": [
+                    {"heading": "Naming", "char_start": 0, "char_end": 14, "folds_in": True},
+                    {"heading": "Protocol", "char_start": 16, "char_end": 30, "folds_in": False},
+                ],
+            }
+        ],
+    )
+    (root / "extracted").mkdir(parents=True)
+    (root / "extracted" / "s1.txt").write_text(text, encoding="utf-8")
+
+    carried, gaps = supplement_prose(root, doi)
+    assert gaps == []
+    assert carried[0]["text"] == "KEEP THIS SPAN"
+    assert carried[0]["headings"] == ["Naming"]
+
+
+def test_a_pointer_without_section_picks_is_carried_whole(tmp_path):
+    doi = "10.1234/paper"
+    root = _store_with_prose(
+        tmp_path, doi, [{"file_id": "s1", "text_file": "s1.txt", "folds_in": True}]
+    )
+    (root / "s1.txt").write_text("The whole document.", encoding="utf-8")
+    carried, gaps = supplement_prose(root, doi)
+    assert carried[0]["text"] == "The whole document."
+    assert "headings" not in carried[0]
+    assert gaps == []
+
+
+def test_prose_that_does_not_fold_in_is_omitted_not_summarised(tmp_path):
+    doi = "10.1234/paper"
+    root = _store_with_prose(
+        tmp_path, doi, [{"file_id": "s1", "text_file": "s1.txt", "folds_in": False}]
+    )
+    (root / "s1.txt").write_text("Sequencing protocol.", encoding="utf-8")
+    carried, gaps = supplement_prose(root, doi)
+    assert carried == []
+    assert gaps == []
+
+
+def test_unreadable_extracted_text_is_a_gap_not_a_silent_omission(tmp_path):
+    doi = "10.1234/paper"
+    root = _store_with_prose(
+        tmp_path, doi, [{"file_id": "s1", "text_file": "missing.txt", "folds_in": True}]
+    )
+    carried, gaps = supplement_prose(root, doi)
+    assert carried == []
+    assert len(gaps) == 1 and "unreadable" in gaps[0]["reason"]
+
+
+def test_no_manifest_is_a_gap(tmp_path):
+    carried, gaps = supplement_prose(tmp_path / "store", "10.1234/absent")
+    assert carried == []
+    assert "no manifest" in gaps[0]["reason"]
+
+
+def test_a_store_without_a_doi_cannot_be_used_and_says_so(tmp_path):
+    ingest = ingest_paper(_write(tmp_path, "a.xml", ARTICLE), store_root=tmp_path / "store")
+    assert any("no DOI" in gap["reason"] for gap in ingest.gaps)
+
+
+# ------------------------------------------------------------------
+# Budget
+# ------------------------------------------------------------------
+
+
+def test_supplementary_prose_is_dropped_before_the_papers_own_text(tmp_path):
+    doi = "10.1234/paper"
+    root = _store_with_prose(
+        tmp_path, doi, [{"file_id": "s1", "text_file": "s1.txt", "folds_in": True}]
+    )
+    (root / "s1.txt").write_text("x" * 4000, encoding="utf-8")
+
+    ingest = ingest_paper(
+        _write(tmp_path, "a.xml", ARTICLE), doi=doi, store_root=root, limit_tokens=200
+    )
+    assert ingest.truncated
+    assert ingest.supplement_prose == []
+    assert "A population was identified" in ingest.narrative_text
+    assert any("read budget" in gap["reason"] for gap in ingest.gaps)
+
+
+def test_narrative_is_only_cut_when_nothing_else_is_left_to_give(tmp_path):
+    ingest = ingest_paper(_write(tmp_path, "a.xml", ARTICLE), limit_tokens=1)
+    assert ingest.truncated
+    assert ingest.legends == []
+    assert len(ingest.narrative_text) <= CHARS_PER_TOKEN
+    assert any("unread" in gap["reason"] for gap in ingest.gaps)
+
+
+def test_a_read_within_budget_is_not_marked_truncated(tmp_path):
+    ingest = ingest_paper(_write(tmp_path, "a.xml", ARTICLE), limit_tokens=100_000)
+    assert ingest.truncated is False
+    assert ingest.gaps == []
+
+
+# ------------------------------------------------------------------
+# The written object
+# ------------------------------------------------------------------
+
+
+def test_written_ingest_validates_against_its_schema(tmp_path):
+    ingest = ingest_paper(_write(tmp_path, "a.xml", ARTICLE), doi="10.1234/paper")
+    out = write_ingest(ingest, tmp_path / "ingest.json")
+    payload = json.loads(out.read_text())
+    jsonschema.validate(payload, load_schema("paper_ingest.schema.json"))
+    assert payload["source"]["kind"] == "jats"
+    assert payload["narrative"]["n_chars"] == len(ingest.narrative_text)
+
+
+def test_empty_collections_are_omitted_rather_than_written_as_empty(tmp_path):
+    ingest = ingest_paper(_write(tmp_path, "p.txt", "Recovered prose."))
+    payload = ingest.to_dict()
+    assert "legends" not in payload
+    assert "supplement_prose" not in payload
+
+
+# ------------------------------------------------------------------
+# CLI
+# ------------------------------------------------------------------
+
+
+def test_cli_writes_an_ingest_and_reports_what_it_holds(tmp_path, capsys):
+    out = tmp_path / "ingest.json"
+    code = main(
+        ["--text", str(_write(tmp_path, "a.xml", ARTICLE)), "--out", str(out), "--doi", "10.1/x"]
+    )
+    assert code == 0
+    assert json.loads(out.read_text())["paper"]["doi"] == "10.1/x"
+    assert "narrative_chars=" in capsys.readouterr().out
+
+
+def test_cli_exits_nonzero_when_the_text_cannot_be_assembled(tmp_path, capsys):
+    code = main(
+        [
+            "--text",
+            str(_write(tmp_path, "empty.txt", "  ")),
+            "--out",
+            str(tmp_path / "ingest.json"),
+        ]
+    )
+    assert code == 2
+    assert not (tmp_path / "ingest.json").exists()
+    assert "no prose" in capsys.readouterr().out


### PR DESCRIPTION
Assembles what a reading agent is given about one paper, before any question is asked — items 1, 2 and 4 of the ingest specification in `planning/literature_reader_subagent_design_2026-09.md`. Item 3, the CAS+ subject block, is deliberately left out: it is loaded per cell type at question time rather than once per paper, and two design questions about it are still open (the transfer long tail, and how much of the transfer judgement belongs upstream).

`services/paper_ingest.py` + `python -m atlas_chat.cli_paper_ingest`, against a new `paper_ingest.schema.json`.

## What it produces

Three things kept apart rather than concatenated, because reading one as another is a real error:

| | |
|---|---|
| `narrative` | body prose in document order, with headings |
| `legends` | figure and table captions, as their own block |
| `cited_sentences` + `references` | sentences carrying a citation, with the references they resolve to |

A caption must not read as though the authors wrote it in the text — and it cannot be dropped either, because naming information often appears in a caption and nowhere else. A citation on a sentence marks a claim as inherited rather than made by this paper, and the reference it resolves to is an exact onward target rather than a search result.

Supplementary prose folds in from the paper's supplement manifest, carrying only the spans already marked `folds_in` — the whole document where it was judged whole, or just the picked sections by their recorded offsets. Tables stay out: prose has to be read whole because it cannot be sliced by a query, whereas a table can, and some are far too large to read.

## Holding out process description took two goes

The conservative rule is to match section titles and hold out nothing else, on the grounds that a positional rule generalises from one publisher's conventions. Measuring it showed that conservative is not the same as safe. Across three publishers it caught **a 96-character stub on one paper and nothing at all on the other two**, while 35–60% of each narrative was protocol prose.

What identifies those sections is position, not title: they sit after the last Discussion, individually titled ("Fallopian tube tissue dissociation", "H&E staining and imaging"), saying nothing about what they collectively are.

But cutting on position alone discards the sections where clusters acquire their names — the highest-value text in the paper for this purpose. Every paper measured has some: four on one, two each on the others.

So both tests apply, and a title about naming or identifying populations is kept either way. **That is the rule already established for supplementary prose in `assess-supplement-content`, not a new one.** Where a paper has no section titled Discussion, position says nothing and only the title test applies.

| narrative | title test only | both tests |
|---|---|---|
| paper A | 75,039 ch | **56,318 ch** (~14k tok) |
| paper B | 99,583 ch | **50,082 ch** (~12k tok) |
| paper C | 57,168 ch | **34,921 ch** (~8k tok) |

## Boundaries

- **Takes a text path; does not acquire papers.** Article XML or text recovered from a PDF. Acquisition stays a separate concern, and adding it later does not change this interface.
- **Nothing here calls a model.**
- **Output paths are inputs.** Nothing derives a project layout for itself.
- PDF-sourced text is tagged as such and records that no citation can be resolved from it, because it carries no reference markup. Its reading order is not guaranteed across a column boundary either, which is a grounding hazard worth keeping visible (see #36).

## Budget and gaps

Over budget, content is dropped **lowest precedence first** — supplementary prose, then captions, and the narrative only when nothing else is left to give. Every drop is recorded as a gap rather than silently applied, so a partial ingest says what is missing rather than only that something is. A gap is always a statement that something is *unread*, never that it holds nothing relevant.

Validation runs **before** the write, so a non-conforming object is never left on disk for something downstream to read.

## Verification

- 26 unit tests, 96% of the module; 453 unit tests pass overall; ruff clean; mypy at the branch baseline.
- Live on three papers from three publishers: 76 / 134 / 89 cited sentences, 7 / 15 / 6 legends, nothing truncated, no gaps.

**Not yet exercised on real data:** `supplement_prose` came back empty on all three live runs, because no manifest on disk carries `prose` pointers yet — that machinery landed after those stores were built. The code path is unit-tested but has never seen a real flagged supplement, and that is the first thing to check once a store is re-indexed.

One knowingly loose match: a section titled for a cell-type enrichment analysis is kept as a naming section on one paper. It is small, and the asymmetry is deliberate — a wrong keep costs a read, a wrong drop loses evidence.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
