### PR TITLE
Validate the CAS+ that is on disk, however it got there

### DIFF
--- a/.claude/hooks/check_cas_annotation.py
+++ b/.claude/hooks/check_cas_annotation.py
@@ -1,13 +1,30 @@
 #!/usr/bin/env python
-"""Claude Code hook: validate a project's CAS+ document against JSON Schema.
+"""Claude Code hook: validate a project's CAS+ document.
 
-Fires as a PostToolUse hook on Write/Edit to a project's CAS+ config —
-``cas.json`` — validating against ``cas_annotation.schema.json``. The generate-cas
-skill produces this file (it is agent output), so schema compliance is enforced
-here.
+Runs as a PostToolUse hook on ``Write|Edit|MultiEdit`` and on ``Bash``. It
+covers the two ways a ``cas.json`` changes during a session:
+
+* **An agent edits it.** The tool reports a ``file_path``; if that is a
+  ``cas.json``, it is validated.
+* **An agent's code writes it.** A script run through Bash reports no file path
+  at all, so the hook instead re-validates any ``cas.json`` under ``projects/``
+  whose size or mtime moved since the last run. A small cache under
+  ``.claude/`` keeps the common case to a few ``stat`` calls rather than a
+  parse of every document.
+
+The file is read **from disk** in both cases. An earlier version validated
+``tool_input["content"]``, which meant it checked what an agent said it was
+writing rather than what landed — invisible to scripts, and a spurious failure
+on ``Edit``, whose input carries ``old_string``/``new_string`` and no
+``content`` at all.
+
+Checks come from the package rather than being restated here:
+:func:`atlas_chat.validation.cas_checker.validate_cas_file` — schema shape plus
+the cross-field rules a schema cannot express (warnings by default, since a
+CAS+ document is filled in across passes).
 
 Exit codes:
-    0 — valid, or file is not a cas.json, or jsonschema unavailable
+    0 — valid, nothing relevant changed, or the checker is unavailable
     2 — validation failed (Claude sees stderr and self-corrects)
 """
 
@@ -17,22 +34,48 @@ import json
 import sys
 from pathlib import Path
 
-SCHEMA_PATH = Path("src/atlas_chat/atlas_chat/schemas/cas_annotation.schema.json")
+CACHE = Path(".claude/.cas_state.json")
+SEARCH_ROOT = Path("projects")
 
 
-def _targets(file_path: str) -> bool:
-    return Path(file_path).name == "cas.json"
+def _is_cas(file_path: str) -> bool:
+    return bool(file_path) and Path(file_path).name == "cas.json"
 
 
-def _errors(data: object, schema: dict) -> list[str]:
-    import jsonschema
+def _fingerprint(path: Path) -> str:
+    stat = path.stat()
+    return f"{stat.st_size}:{stat.st_mtime_ns}"
 
-    validator = jsonschema.Draft202012Validator(schema)
-    errors: list[str] = []
-    for err in sorted(validator.iter_errors(data), key=lambda e: list(e.path)):
-        path = ".".join(str(p) for p in err.absolute_path)
-        errors.append(f"{path or '(root)'}: {err.message}")
-    return errors
+
+def _changed_on_disk() -> list[Path]:
+    """CAS+ documents whose bytes moved since the last run of this hook."""
+    if not SEARCH_ROOT.is_dir():
+        return []
+    try:
+        previous = json.loads(CACHE.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        previous = {}
+
+    current: dict[str, str] = {}
+    changed: list[Path] = []
+    for path in sorted(SEARCH_ROOT.rglob("cas.json")):
+        try:
+            mark = _fingerprint(path)
+        except OSError:
+            continue
+        key = str(path)
+        current[key] = mark
+        if previous.get(key) != mark:
+            changed.append(path)
+
+    try:
+        CACHE.parent.mkdir(parents=True, exist_ok=True)
+        CACHE.write_text(json.dumps(current, indent=0, sort_keys=True), encoding="utf-8")
+    except OSError:
+        pass
+
+    # First ever run: record the baseline, do not report every project as changed.
+    return [] if not previous else changed
 
 
 def main() -> int:
@@ -41,39 +84,34 @@ def main() -> int:
     except (json.JSONDecodeError, OSError):
         return 0
 
-    tool_input = hook_input.get("tool_input", {})
-    file_path = tool_input.get("file_path", "")
-    if not file_path or not _targets(file_path):
+    file_path = hook_input.get("tool_input", {}).get("file_path", "")
+
+    targets: list[Path] = []
+    if _is_cas(file_path):
+        targets.append(Path(file_path))
+    else:
+        targets.extend(_changed_on_disk())
+
+    if not targets:
         return 0
 
-    content = tool_input.get("content", "")
-    if not content:
-        print(f"{Path(file_path).name} is empty", file=sys.stderr)
-        return 2
-
     try:
-        data = json.loads(content)
-    except json.JSONDecodeError as exc:
-        print(f"{Path(file_path).name} is not valid JSON: {exc}", file=sys.stderr)
-        return 2
-
-    if not SCHEMA_PATH.exists():
-        return 0
-    try:
-        import jsonschema  # noqa: F401
+        from atlas_chat.validation.cas_checker import validate_cas_file
     except ImportError:
-        print("jsonschema not available — skipping cas_annotation check", file=sys.stderr)
+        print("atlas_chat not importable — skipping cas_annotation check", file=sys.stderr)
         return 0
 
-    errors = _errors(data, json.loads(SCHEMA_PATH.read_text()))
-    if not errors:
-        return 0
-
-    print("CAS_ANNOTATION VALIDATION FAILED", file=sys.stderr)
-    print(f"Fix these issues and rewrite {Path(file_path).name}:", file=sys.stderr)
-    for error in errors:
-        print(f"  - {error}", file=sys.stderr)
-    return 2
+    failed = False
+    for target in targets:
+        passed, messages = validate_cas_file(target)
+        if passed:
+            continue
+        failed = True
+        print("CAS_ANNOTATION VALIDATION FAILED", file=sys.stderr)
+        print(f"Fix these issues in {target}:", file=sys.stderr)
+        for message in messages:
+            print(f"  - {message}", file=sys.stderr)
+    return 2 if failed else 0
 
 
 if __name__ == "__main__":

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -37,6 +37,15 @@
             "command": "uv run python .claude/hooks/check_report_refs.py"
           }
         ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "uv run python .claude/hooks/check_cas_annotation.py"
+          }
+        ]
       }
     ]
   }

--- a/.claude/skills/generate-cas/SKILL.md
+++ b/.claude/skills/generate-cas/SKILL.md
@@ -63,8 +63,24 @@ Some fields are not derivable from the data — **ask the user** rather than gue
      unmapped author columns in `author_annotation_fields`.
    - Leave optional fields **absent** when unknown — downstream consumers are
      presence-aware.
-5. Write `projects/{project}/cas.json`. The `check_cas_annotation` PostToolUse hook
-   validates it against the schema; if it fails, read the errors and rewrite.
+5. Write `projects/{project}/cas.json`, then **validate it explicitly**:
+
+   ```bash
+   uv run python -m atlas_chat.cli_cas validate --cas projects/{project}/cas.json
+   ```
+
+   Exit 0 is valid, 1 invalid; read the errors and rewrite until it passes. Run
+   this whatever wrote the file — if you built the CAS+ with a script rather
+   than by writing it directly, the check still applies and is the only thing
+   that will catch a malformed document at the point it was made.
+
+   Warnings name cross-field problems the schema cannot express (a dangling
+   parent, counts that do not sum). They do not fail the run, because CAS+ is
+   filled in across passes — but read them: on a document you have just
+   finished, a warning is usually a real defect. Add `--strict` to fail on them.
+
+   The `check_cas_annotation` PostToolUse hook runs the same checks as a
+   backstop; it is not a substitute for the explicit call.
 
 ## Minimal case
 
@@ -85,4 +101,4 @@ A bare list of labels + a DOI is enough:
 - **Do not invent** markers, synonyms, or ontology terms. Carry them only if the
   source states them; otherwise leave absent for downstream steps to fill.
 - Prefer asking the user over guessing DOI / organism / which column is the label.
-- Output is `projects/{project}/cas.json`; schema compliance is enforced by the hook.
+- Output is `projects/{project}/cas.json`; validate it with `cli_cas validate` (the hook is a backstop, not the primary check).

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -9,6 +9,9 @@ uv run ruff check --fix src/ tests/
 echo "[githook] Checking formatting..."
 uv run ruff format --check src/ tests/
 
+echo "[githook] Validating CAS+ documents..."
+uv run python -m atlas_chat.cli_cas validate --discover projects/
+
 echo "[githook] Running unit tests..."
 uv run pytest -m unit
 

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ projects/test_projects/**/runs/
 projects/**/supplements/**/files/
 projects/**/supplements/incoming/*
 !projects/**/supplements/incoming/README.md
+
+# CAS+ hook change-detection cache (local, per-checkout)
+.claude/.cas_state.json

--- a/src/atlas_chat/atlas_chat/cli_cas.py
+++ b/src/atlas_chat/atlas_chat/cli_cas.py
@@ -1,0 +1,89 @@
+"""CLI for CAS+ validation.
+
+Thin entry point so a CAS+ document is checkable without a Claude Code session —
+by a script that just wrote one, by a git hook, or by CI:
+
+.. code-block:: bash
+
+    python -m atlas_chat.cli_cas validate --cas projects/p/cas.json
+    python -m atlas_chat.cli_cas validate --cas a/cas.json b/cas.json --strict
+    python -m atlas_chat.cli_cas validate --discover projects/
+
+Exit codes:
+    0 — every document valid
+    1 — at least one document invalid
+    2 — usage or IO error (no document could be read)
+
+The implementation lives in :mod:`atlas_chat.validation.cas_checker`.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from collections.abc import Sequence
+from pathlib import Path
+
+from atlas_chat.validation.cas_checker import validate_cas_file
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="cli_cas", description="Validate CAS+ documents.")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    validate = sub.add_parser("validate", help="Validate one or more CAS+ documents.")
+    validate.add_argument(
+        "--cas", nargs="*", default=[], metavar="PATH", help="CAS+ document(s) to validate."
+    )
+    validate.add_argument(
+        "--discover",
+        metavar="DIR",
+        help="Also validate every cas.json found beneath DIR.",
+    )
+    validate.add_argument(
+        "--strict",
+        action="store_true",
+        help="Treat cross-field warnings as failures.",
+    )
+    validate.add_argument(
+        "--quiet", action="store_true", help="Print nothing; signal through the exit code."
+    )
+    return parser
+
+
+def _targets(args: argparse.Namespace) -> list[Path]:
+    paths = [Path(p) for p in args.cas]
+    if args.discover:
+        paths.extend(sorted(Path(args.discover).rglob("cas.json")))
+    seen: dict[Path, None] = {}
+    for path in paths:
+        seen.setdefault(path.resolve(), None)
+        continue
+    return [Path(p) for p in seen]
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    targets = _targets(args)
+    if not targets:
+        print("nothing to validate: pass --cas and/or --discover", file=sys.stderr)
+        return 2
+
+    failed = False
+    for target in targets:
+        passed, messages = validate_cas_file(target, strict=args.strict)
+        if not passed:
+            failed = True
+        if args.quiet:
+            continue
+        label = "OK" if passed else "FAILED"
+        print(f"{label}: {target}")
+        for message in messages:
+            print(f"  - {message}")
+    return 1 if failed else 0
+
+
+__all__ = ["build_parser", "main"]
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/atlas_chat/atlas_chat/validation/cas_checker.py
+++ b/src/atlas_chat/atlas_chat/validation/cas_checker.py
@@ -1,0 +1,213 @@
+"""Validate a project's CAS+ document.
+
+One implementation, three callers: the ``cas_annotation`` Claude Code hook, the
+``cli_cas`` command line, and CI over the committed test-project fixtures. They
+must not drift, so all three read the file from disk through
+:func:`validate_cas_file` rather than validating whatever a caller happens to
+hold in memory.
+
+Two layers of checking:
+
+* **Shape** — the JSON Schema at ``cas_annotation.schema.json``.
+* **Cross-field rules the schema cannot express** — references that must
+  resolve, and counts that must agree. These are reported as warnings by
+  default and as errors under ``strict``, because a CAS+ document is filled in
+  across passes and a partially-populated one is legitimately incomplete rather
+  than wrong.
+"""
+
+from __future__ import annotations
+
+import json
+from collections import defaultdict
+from pathlib import Path
+from typing import Any
+
+from ..schemas import load_schema
+
+CAS_SCHEMA = "cas_annotation.schema.json"
+
+
+def schema_errors(document: Any, schema: dict[str, Any] | None = None) -> list[str]:
+    """Return JSON Schema violations, one readable line each."""
+    import jsonschema
+
+    validator = jsonschema.Draft202012Validator(schema or load_schema(CAS_SCHEMA))
+    errors: list[str] = []
+    for error in sorted(validator.iter_errors(document), key=lambda e: list(e.path)):
+        location = ".".join(str(part) for part in error.absolute_path)
+        errors.append(f"{location or '(root)'}: {error.message}")
+    return errors
+
+
+def cross_field_errors(document: Any) -> list[str]:
+    """Return violations of rules the JSON Schema cannot express.
+
+    Every rule here is skipped when the field it depends on is absent — the
+    point is to catch a document that contradicts itself, not one that is
+    merely incomplete.
+    """
+    if not isinstance(document, dict):
+        return []
+
+    problems: list[str] = []
+    annotations = document.get("annotations") or []
+    labelsets = document.get("labelsets") or []
+
+    declared = {ls.get("name") for ls in labelsets if isinstance(ls, dict)}
+    accessions = {
+        a.get("cell_set_accession")
+        for a in annotations
+        if isinstance(a, dict) and a.get("cell_set_accession")
+    }
+    registry = {
+        p.get("label")
+        for p in (document.get("source") or {}).get("subatlas_papers") or []
+        if isinstance(p, dict)
+    }
+
+    for index, annotation in enumerate(annotations):
+        if not isinstance(annotation, dict):
+            continue
+        where = annotation.get("cell_set_accession") or f"annotations[{index}]"
+
+        labelset = annotation.get("labelset")
+        if labelset is not None and labelset not in declared:
+            problems.append(f"{where}: labelset {labelset!r} is not declared in labelsets")
+
+        parent = annotation.get("parent_cell_set_accession")
+        if parent is not None and parent not in accessions:
+            problems.append(
+                f"{where}: parent_cell_set_accession {parent!r} matches no cell_set_accession"
+            )
+        if parent is not None and parent == annotation.get("cell_set_accession"):
+            problems.append(f"{where}: parent_cell_set_accession points at itself")
+
+        problems.extend(_composition_errors(where, annotation))
+        problems.extend(_transfer_errors(where, annotation, registry))
+
+    problems.extend(_subatlas_paper_errors(document))
+    return problems
+
+
+def _composition_errors(where: str, annotation: dict[str, Any]) -> list[str]:
+    """A composition category partitions the cell set, so its counts sum to n_cells."""
+    problems: list[str] = []
+    n_cells = annotation.get("n_cells")
+    if n_cells is None:
+        return problems
+    for name, category in (annotation.get("composition") or {}).items():
+        if not isinstance(category, dict):
+            continue
+        values = category.get("values") or []
+        counts = [v.get("cell_count") for v in values if isinstance(v, dict)]
+        if not counts or any(c is None for c in counts):
+            continue
+        total = sum(counts)
+        if total != n_cells:
+            problems.append(
+                f"{where}: composition.{name} cell_count sums to {total}, but n_cells is {n_cells}"
+            )
+    return problems
+
+
+def _transfer_errors(
+    where: str, annotation: dict[str, Any], registry: set[str | None]
+) -> list[str]:
+    """Transferred annotations reference a registered study and agree on the denominator."""
+    problems: list[str] = []
+    transfers = annotation.get("transferred_annotations") or []
+    n_cells = annotation.get("n_cells")
+    contributions: dict[str, set[int]] = defaultdict(set)
+
+    for transfer in transfers:
+        if not isinstance(transfer, dict):
+            continue
+        paper = transfer.get("subatlas_paper")
+        if paper is not None and registry and paper not in registry:
+            problems.append(f"{where}: subatlas_paper {paper!r} is not in source.subatlas_papers")
+
+        count = transfer.get("cell_count")
+        if count is not None and n_cells is not None and count > n_cells:
+            problems.append(
+                f"{where}: transferred {transfer.get('transferred_cell_label')!r} "
+                f"cell_count {count} exceeds n_cells {n_cells}"
+            )
+
+        contribution = transfer.get("subatlas_contribution_cells")
+        if contribution is not None:
+            key = paper or transfer.get("source_labelset") or transfer.get("source_taxonomy")
+            if key is not None:
+                contributions[str(key)].add(contribution)
+
+    for key, seen in contributions.items():
+        if len(seen) > 1:
+            problems.append(
+                f"{where}: subatlas_contribution_cells disagrees for {key!r}: "
+                f"{sorted(seen)} — it is one count per (cell set, study)"
+            )
+    return problems
+
+
+def _subatlas_paper_errors(document: dict[str, Any]) -> list[str]:
+    """A study's own cell sets partition its contribution, so they sum to total_cells."""
+    problems: list[str] = []
+    for paper in (document.get("source") or {}).get("subatlas_papers") or []:
+        if not isinstance(paper, dict):
+            continue
+        total = paper.get("total_cells")
+        cell_sets = paper.get("cell_sets")
+        if total is None or not cell_sets:
+            continue
+        counts = [s.get("n_cells") for s in cell_sets if isinstance(s, dict)]
+        if any(c is None for c in counts):
+            continue
+        summed = sum(counts)
+        if summed != total:
+            problems.append(
+                f"source.subatlas_papers[{paper.get('label')!r}]: cell_sets n_cells "
+                f"sums to {summed}, but total_cells is {total}"
+            )
+    return problems
+
+
+def validate_cas_document(document: Any, *, strict: bool = False) -> tuple[bool, list[str]]:
+    """Validate an already-parsed CAS+ document. Returns ``(passed, messages)``."""
+    errors = schema_errors(document)
+    if errors:
+        return False, errors
+
+    warnings = cross_field_errors(document)
+    if not warnings:
+        return True, []
+    if strict:
+        return False, warnings
+    return True, [f"warning: {w}" for w in warnings]
+
+
+def validate_cas_file(path: str | Path, *, strict: bool = False) -> tuple[bool, list[str]]:
+    """Validate the CAS+ document at ``path``, reading it from disk.
+
+    Reading the file rather than trusting a caller's copy is the whole point: it
+    is what lets one implementation serve an agent's edit, a script's write and
+    a CI run alike.
+    """
+    target = Path(path)
+    if not target.exists():
+        return False, [f"{target}: no such file"]
+    try:
+        document = json.loads(target.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        return False, [f"{target}: not valid JSON: {exc}"]
+    except OSError as exc:
+        return False, [f"{target}: could not be read: {exc}"]
+    return validate_cas_document(document, strict=strict)
+
+
+__all__ = [
+    "CAS_SCHEMA",
+    "cross_field_errors",
+    "schema_errors",
+    "validate_cas_document",
+    "validate_cas_file",
+]

--- a/tests/unit/test_cas_annotation_hook.py
+++ b/tests/unit/test_cas_annotation_hook.py
@@ -1,8 +1,15 @@
 """PostToolUse hook regression for check_cas_annotation.py.
 
-Drives the hook via subprocess (like the other hook regressions): a valid
-``cas.json`` exits 0, an invalid one exits 2, and a non-``cas.json`` file is
-ignored. Reuses the CAS fixtures from test_cas_annotation_schema.
+Drives the hook via subprocess (like the other hook regressions). The hook reads
+the document **from disk**, so every case here writes a real file: that is the
+behaviour under test, not an implementation detail. Three call shapes are
+covered, because the hook is registered for all of them:
+
+* ``Write`` — carries ``file_path`` and ``content``;
+* ``Edit`` — carries ``file_path`` but no ``content`` (the shape that used to
+  fail spuriously with "cas.json is empty");
+* ``Bash`` — carries neither, standing in for an agent's script writing the
+  file, which the hook catches by noticing the bytes on disk moved.
 """
 
 from __future__ import annotations
@@ -23,33 +30,113 @@ def _load(name: str) -> object:
     return json.loads((FIXTURES / name).read_text())
 
 
-def _run_hook(file_path: str, payload: object) -> subprocess.CompletedProcess:
-    hook_input = json.dumps(
-        {"tool_input": {"file_path": file_path, "content": json.dumps(payload)}}
-    )
+def _run(hook_input: dict, cwd: Path) -> subprocess.CompletedProcess:
     return subprocess.run(
         [sys.executable, str(HOOK)],
-        input=hook_input,
+        input=json.dumps(hook_input),
         capture_output=True,
         text=True,
-        cwd=REPO_ROOT,
+        cwd=cwd,
     )
+
+
+def _project(tmp_path: Path, payload: object, name: str = "cas.json") -> Path:
+    target = tmp_path / "projects" / "p"
+    target.mkdir(parents=True, exist_ok=True)
+    path = target / name
+    path.write_text(json.dumps(payload))
+    return path
 
 
 @pytest.mark.unit
-def test_hook_accepts_valid_cas() -> None:
-    r = _run_hook("projects/x/cas.json", _load("cas_annotation.minimal.good.json"))
+def test_write_accepts_valid_cas(tmp_path: Path) -> None:
+    path = _project(tmp_path, _load("cas_annotation.minimal.good.json"))
+    r = _run(
+        {"tool_name": "Write", "tool_input": {"file_path": str(path), "content": "ignored"}},
+        tmp_path,
+    )
     assert r.returncode == 0, r.stderr
 
 
 @pytest.mark.unit
-def test_hook_rejects_invalid_cas() -> None:
-    r = _run_hook("projects/x/cas.json", _load("cas_annotation.bad.json"))
+def test_write_rejects_invalid_cas(tmp_path: Path) -> None:
+    path = _project(tmp_path, _load("cas_annotation.bad.json"))
+    r = _run(
+        {"tool_name": "Write", "tool_input": {"file_path": str(path), "content": "ignored"}},
+        tmp_path,
+    )
     assert r.returncode == 2
     assert "VALIDATION FAILED" in r.stderr
 
 
 @pytest.mark.unit
-def test_hook_ignores_non_cas_files() -> None:
-    r = _run_hook("projects/x/notes.txt", {"anything": 1})
+def test_edit_shape_has_no_content_and_still_validates(tmp_path: Path) -> None:
+    """An Edit carries old_string/new_string, never content — it must not fail for that."""
+    path = _project(tmp_path, _load("cas_annotation.minimal.good.json"))
+    r = _run(
+        {
+            "tool_name": "Edit",
+            "tool_input": {"file_path": str(path), "old_string": "a", "new_string": "b"},
+        },
+        tmp_path,
+    )
+    assert r.returncode == 0, r.stderr
+    assert "is empty" not in r.stderr
+
+
+@pytest.mark.unit
+def test_edit_shape_still_catches_an_invalid_document(tmp_path: Path) -> None:
+    path = _project(tmp_path, _load("cas_annotation.bad.json"))
+    r = _run(
+        {
+            "tool_name": "Edit",
+            "tool_input": {"file_path": str(path), "old_string": "a", "new_string": "b"},
+        },
+        tmp_path,
+    )
+    assert r.returncode == 2
+    assert "VALIDATION FAILED" in r.stderr
+
+
+@pytest.mark.unit
+def test_validates_what_is_on_disk_not_what_the_tool_reported(tmp_path: Path) -> None:
+    """The claimed content is irrelevant; the file is the source of truth."""
+    path = _project(tmp_path, _load("cas_annotation.bad.json"))
+    claimed = json.dumps(_load("cas_annotation.minimal.good.json"))
+    r = _run(
+        {"tool_name": "Write", "tool_input": {"file_path": str(path), "content": claimed}},
+        tmp_path,
+    )
+    assert r.returncode == 2, "a valid-looking content payload must not excuse a bad file"
+
+
+@pytest.mark.unit
+def test_bash_catches_a_document_written_by_code(tmp_path: Path) -> None:
+    """No file_path at all — the script path, caught by the change scan."""
+    bash = {"tool_name": "Bash", "tool_input": {"command": "python build_cas.py"}}
+
+    _project(tmp_path, _load("cas_annotation.minimal.good.json"))
+    assert _run(bash, tmp_path).returncode == 0  # first run records the baseline
+
+    _project(tmp_path, _load("cas_annotation.bad.json"))  # a script rewrites it
+    r = _run(bash, tmp_path)
+    assert r.returncode == 2
+    assert "VALIDATION FAILED" in r.stderr
+
+
+@pytest.mark.unit
+def test_bash_is_quiet_when_nothing_changed(tmp_path: Path) -> None:
+    bash = {"tool_name": "Bash", "tool_input": {"command": "ls"}}
+    _project(tmp_path, _load("cas_annotation.bad.json"))
+    assert _run(bash, tmp_path).returncode == 0, "baseline run must not fire"
+    assert _run(bash, tmp_path).returncode == 0, "unchanged file must not fire"
+
+
+@pytest.mark.unit
+def test_ignores_non_cas_files(tmp_path: Path) -> None:
+    path = _project(tmp_path, {"anything": 1}, name="notes.json")
+    r = _run(
+        {"tool_name": "Write", "tool_input": {"file_path": str(path), "content": "{}"}},
+        tmp_path,
+    )
     assert r.returncode == 0

--- a/tests/unit/test_cas_checker.py
+++ b/tests/unit/test_cas_checker.py
@@ -1,0 +1,190 @@
+"""Unit tests for the shared CAS+ checker and its CLI.
+
+The cross-field rules are the point: they catch documents a JSON Schema calls
+valid. Each is asserted to fire on a contradiction and stay silent on a merely
+incomplete document, since CAS+ is filled in across passes.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from atlas_chat.cli_cas import main as cli_main
+from atlas_chat.validation.cas_checker import (
+    cross_field_errors,
+    validate_cas_document,
+    validate_cas_file,
+)
+
+
+def _doc(**overrides) -> dict:
+    base = {
+        "labelsets": [{"name": "L1"}],
+        "annotations": [
+            {
+                "labelset": "L1",
+                "cell_label": "a",
+                "cell_set_accession": "X:1",
+                "n_cells": 100,
+            }
+        ],
+    }
+    base.update(overrides)
+    return base
+
+
+@pytest.mark.unit
+def test_clean_document_passes() -> None:
+    passed, messages = validate_cas_document(_doc())
+    assert passed and messages == []
+
+
+@pytest.mark.unit
+def test_schema_violation_fails() -> None:
+    passed, messages = validate_cas_document({"labelsets": [], "annotations": [{}]})
+    assert not passed
+    assert any("labelset" in m for m in messages)
+
+
+@pytest.mark.unit
+def test_undeclared_labelset_is_caught() -> None:
+    doc = _doc()
+    doc["annotations"][0]["labelset"] = "nope"
+    assert any("is not declared" in m for m in cross_field_errors(doc))
+
+
+@pytest.mark.unit
+def test_dangling_parent_is_caught() -> None:
+    doc = _doc()
+    doc["annotations"][0]["parent_cell_set_accession"] = "X:missing"
+    assert any("matches no cell_set_accession" in m for m in cross_field_errors(doc))
+
+
+@pytest.mark.unit
+def test_self_parent_is_caught() -> None:
+    doc = _doc()
+    doc["annotations"][0]["parent_cell_set_accession"] = "X:1"
+    assert any("points at itself" in m for m in cross_field_errors(doc))
+
+
+@pytest.mark.unit
+def test_composition_counts_must_sum_to_n_cells() -> None:
+    doc = _doc()
+    doc["annotations"][0]["composition"] = {
+        "tissue": {"values": [{"author_value": "skin", "cell_count": 60}]}
+    }
+    assert any("sums to 60" in m for m in cross_field_errors(doc))
+
+
+@pytest.mark.unit
+def test_composition_without_counts_is_not_flagged() -> None:
+    """Incomplete is not wrong — a category with no counts says nothing to contradict."""
+    doc = _doc()
+    doc["annotations"][0]["composition"] = {"tissue": {"values": [{"author_value": "skin"}]}}
+    assert cross_field_errors(doc) == []
+
+
+@pytest.mark.unit
+def test_disagreeing_contribution_denominator_is_caught() -> None:
+    """The rule plan_cxg_probe_integration_2026-09.md asks for by name."""
+    doc = _doc()
+    doc["annotations"][0]["transferred_annotations"] = [
+        {"transferred_cell_label": "a", "source_labelset": "s", "subatlas_contribution_cells": 30},
+        {"transferred_cell_label": "b", "source_labelset": "s", "subatlas_contribution_cells": 31},
+    ]
+    assert any("disagrees" in m for m in cross_field_errors(doc))
+
+
+@pytest.mark.unit
+def test_agreeing_contribution_denominator_is_fine() -> None:
+    doc = _doc()
+    doc["annotations"][0]["transferred_annotations"] = [
+        {"transferred_cell_label": "a", "source_labelset": "s", "subatlas_contribution_cells": 30},
+        {"transferred_cell_label": "b", "source_labelset": "s", "subatlas_contribution_cells": 30},
+    ]
+    assert cross_field_errors(doc) == []
+
+
+@pytest.mark.unit
+def test_transferred_count_cannot_exceed_the_cell_set() -> None:
+    doc = _doc()
+    doc["annotations"][0]["transferred_annotations"] = [
+        {"transferred_cell_label": "a", "cell_count": 101}
+    ]
+    assert any("exceeds n_cells" in m for m in cross_field_errors(doc))
+
+
+@pytest.mark.unit
+def test_unregistered_subatlas_paper_is_caught() -> None:
+    doc = _doc(source={"subatlas_papers": [{"label": "known"}]})
+    doc["annotations"][0]["transferred_annotations"] = [
+        {"transferred_cell_label": "a", "subatlas_paper": "unknown"}
+    ]
+    assert any("not in source.subatlas_papers" in m for m in cross_field_errors(doc))
+
+
+@pytest.mark.unit
+def test_subatlas_cell_sets_must_sum_to_total_cells() -> None:
+    doc = _doc(
+        source={
+            "subatlas_papers": [
+                {
+                    "label": "s",
+                    "total_cells": 100,
+                    "cell_sets": [{"cell_label": "x", "n_cells": 90}],
+                }
+            ]
+        }
+    )
+    assert any("sums to 90" in m for m in cross_field_errors(doc))
+
+
+@pytest.mark.unit
+def test_warnings_pass_by_default_and_fail_under_strict() -> None:
+    doc = _doc()
+    doc["annotations"][0]["parent_cell_set_accession"] = "X:missing"
+    passed, messages = validate_cas_document(doc)
+    assert passed and any(m.startswith("warning:") for m in messages)
+    assert validate_cas_document(doc, strict=True)[0] is False
+
+
+@pytest.mark.unit
+def test_missing_and_malformed_files_report_rather_than_raise(tmp_path: Path) -> None:
+    assert validate_cas_file(tmp_path / "absent.json")[0] is False
+    broken = tmp_path / "cas.json"
+    broken.write_text("{not json")
+    passed, messages = validate_cas_file(broken)
+    assert not passed and any("not valid JSON" in m for m in messages)
+
+
+@pytest.mark.unit
+def test_cli_exit_codes(tmp_path: Path, capsys: pytest.CaptureFixture) -> None:
+    good = tmp_path / "cas.json"
+    good.write_text(json.dumps(_doc()))
+    assert cli_main(["validate", "--cas", str(good)]) == 0
+
+    bad = tmp_path / "bad" / "cas.json"
+    bad.parent.mkdir()
+    bad.write_text(json.dumps({"annotations": [{}]}))
+    assert cli_main(["validate", "--cas", str(bad)]) == 1
+    assert cli_main(["validate"]) == 2
+
+
+@pytest.mark.unit
+def test_cli_discovers_cas_files(tmp_path: Path) -> None:
+    (tmp_path / "p").mkdir()
+    (tmp_path / "p" / "cas.json").write_text(json.dumps({"annotations": [{}]}))
+    assert cli_main(["validate", "--discover", str(tmp_path), "--quiet"]) == 1
+
+
+@pytest.mark.unit
+def test_committed_test_project_fixtures_validate() -> None:
+    """CI gate: every fixture the workflow is developed against must be valid."""
+    root = Path(__file__).resolve().parents[2] / "projects" / "test_projects"
+    fixtures = sorted(root.rglob("cas.json"))
+    assert fixtures, "no test-project CAS+ fixtures found"
+    for fixture in fixtures:
+        passed, messages = validate_cas_file(fixture)
+        assert passed, f"{fixture}: {messages}"


### PR DESCRIPTION
Fixes the hook blind spots in #55 and adds the CLI that issue asks for.

## The bug

`check_cas_annotation.py` validated `tool_input["content"]` — what an agent
*said* it was writing, never the file. Three consequences:

1. **A `cas.json` written by code was never checked.** The reproductive-atlas
   fixture is built by a script; schema conformance had to be checked by hand.
2. **Every `Edit` failed spuriously.** The hook is registered on
   `Write|Edit|MultiEdit`, but only `Write` supplies `content`. An `Edit` carries
   `old_string`/`new_string`, so the empty-guard fired and the hook exited 2 with
   "cas.json is empty" on a valid document. Measured before the fix:
   `Edit`-shaped → exit 2, `Write`-shaped valid → exit 0.
3. **A valid-looking payload excused a bad file** — nothing compared the two.

## The fix — three triggers, one implementation

| path | trigger |
|---|---|
| agent writes/edits | PostToolUse `Write\|Edit\|MultiEdit` → validate the file at `file_path` |
| **agent's code writes** | PostToolUse `Bash` → re-validate any `cas.json` under `projects/` whose bytes moved |
| anything else | `cli_cas validate`, called by `generate-cas`, pre-commit and a unit test |

All read from disk, all share `validation/cas_checker.py`.

The Bash trigger is the one #55 did not cover. A script leaves no file path, so
the hook keeps a size+mtime cache under `.claude/` (gitignored) and validates
only what changed — **0.08s** when nothing did, which is what makes it tolerable
after every Bash call. Verified end to end against the real committed fixture: a
script mangling it is caught, an unchanged tree is silent.

## Cross-field checks

The rules a JSON Schema cannot express: labelsets and parents that resolve,
composition counts summing to `n_cells`, transferred counts not exceeding the
cell set, `subatlas_contribution_cells` agreeing across siblings of the same
study (asked for by name in `plan_cxg_probe_integration_2026-09.md`), and
`cell_sets[].n_cells` summing to `total_cells`.

**Warnings by default, errors under `--strict`** — a CAS+ document is filled in
across passes, so incomplete must not read as wrong. Each rule is skipped when
the field it depends on is absent.

## A real finding from the strict pass

`--strict` over the committed fixtures is not clean, and the cause is genuine
rather than a false positive:

```
HCArepro:L4:0016: composition.Target_cell_population cell_count sums to 9406, but n_cells is 10169
```

Checked against the source parquet: that cell set has two values for
`Target_cell_population` — `'Not applicable'` (9406) and `''` (763), no NaNs. The
builder drops the empty-string bucket, so 763 cells vanish from the
distribution. It affects **98 annotations, and only this one category**.

That contradicts `CompositionCategory`'s stated invariant ("every cell of the set
is counted exactly once, so cell_count sums to the annotation's n_cells"). It is
a modelling decision, not corruption — either the empty bucket should be carried,
or the schema's claim needs softening. **For the atlas branch to decide; nothing
here blocks on it**, which is precisely why warnings do not fail by default.

## Checks

- 449 unit tests pass (25 new: 8 hook, 17 checker/CLI).
- Ruff lint and format clean.
- New hook tests cover all three call shapes, including the previously untested
  `Edit` path and a case asserting the file beats the reported content.
- `test_committed_test_project_fixtures_validate` gates the fixtures in CI.

Closes #55.
