### PR TITLE
Type composition entries by descriptor category, with an explicit way to decline

### DIFF
--- a/src/atlas_chat/atlas_chat/schemas/cas_annotation.schema.json
+++ b/src/atlas_chat/atlas_chat/schemas/cas_annotation.schema.json
@@ -183,7 +183,7 @@
     },
     "Composition": {
       "type": "object",
-      "description": "Keyed by CxG descriptor category (tissue, development_stage, assay, disease, sex, self_reported_ethnicity, organism) or an open semantic key (e.g. germ_layer) for non-CxG descriptors. Keys are not enumerated; each value is a CompositionCategory.",
+      "description": "How the cell set breaks down over the descriptors recorded for its cells, one entry per descriptor. Keys are not enumerated: the key identifies the descriptor within this document, and what kind of descriptor it is — where that can be determined — is stated by each entry's `category`. Several entries may share a category; recording a column at more than one granularity is common and they are not interchangeable.",
       "additionalProperties": { "$ref": "#/$defs/CompositionCategory" }
     },
     "CompositionCategory": {
@@ -193,6 +193,27 @@
       "additionalProperties": false,
       "properties": {
         "author_field_name": { "type": "string", "description": "The original obs column this category came from." },
+        "category": {
+          "description": "What kind of descriptor this is, where that can be determined. A claim about what the column holds, never about whether it matters to any particular consumer. Omit it rather than force a plausible-but-wrong value: the list is deliberately short, an unclassified descriptor is an expected outcome, and absence is what makes the classification's completeness countable. Where present, it names the ontology a value would map to.",
+          "oneOf": [
+            {
+              "const": "tissue",
+              "description": "Anatomical origin of the cells. Recording this at several granularities is common; each granularity is its own entry."
+            },
+            {
+              "const": "development_stage",
+              "description": "Where the donor sits in development. This includes age: stage ontologies express age as stage terms, so a column of ages belongs here rather than unclassified."
+            },
+            {
+              "const": "disease",
+              "description": "Disease state of the tissue or donor."
+            },
+            {
+              "const": "assay",
+              "description": "The transcriptomics assay. Sample handling, dissociation, cell enrichment and sorting strategy are not assay and are left unclassified."
+            }
+          ]
+        },
         "values": {
           "description": "The distribution over this category, one entry per distinct author value. Computed from the per-cell table by cross-tabbing the cell set against the category's column; every cell of the set is counted exactly once, so cell_count sums to the annotation's n_cells.",
           "type": "array",

--- a/src/atlas_chat/atlas_chat/schemas/cas_annotation.schema.json
+++ b/src/atlas_chat/atlas_chat/schemas/cas_annotation.schema.json
@@ -234,7 +234,7 @@
             },
             {
               "const": "cross_cutting_cell_type",
-              "description": "A cell-type column whose labels also assert something else, so that they cut across the categories above instead of sitting in one. Only for that case: a column whose labels assert a cell type and nothing else is not a descriptor of the cell set's composition and does not belong here."
+              "description": "A cell type label defining a cell set that cross-cuts this one. Cross-cutting is established by analysis of cell set membership, not by reading the label — the label may explain why the two sets cross, but it is not what determines that they do."
             },
             {
               "const": "unclassified",

--- a/src/atlas_chat/atlas_chat/schemas/cas_annotation.schema.json
+++ b/src/atlas_chat/atlas_chat/schemas/cas_annotation.schema.json
@@ -233,6 +233,10 @@
               "description": "Whether whole cells or nuclei were sequenced."
             },
             {
+              "const": "cross_cutting_cell_type",
+              "description": "An author cell-type column whose labels also assert something else — an anatomical site, a developmental stage — so that they cut across the categories above instead of sitting in one. Only for that case: a column whose labels assert a cell type and nothing else is not a descriptor of the cell set's composition and does not belong here."
+            },
+            {
               "const": "unclassified",
               "description": "A descriptor that does not fit any category above. A positive statement that the column was looked at, not a gap: absence of `category` means the entry predates typing and nothing has been claimed about it either way."
             }

--- a/src/atlas_chat/atlas_chat/schemas/cas_annotation.schema.json
+++ b/src/atlas_chat/atlas_chat/schemas/cas_annotation.schema.json
@@ -234,7 +234,7 @@
             },
             {
               "const": "cross_cutting_cell_type",
-              "description": "An author cell-type column whose labels also assert something else — an anatomical site, a developmental stage — so that they cut across the categories above instead of sitting in one. Only for that case: a column whose labels assert a cell type and nothing else is not a descriptor of the cell set's composition and does not belong here."
+              "description": "A cell-type column whose labels also assert something else, so that they cut across the categories above instead of sitting in one. Only for that case: a column whose labels assert a cell type and nothing else is not a descriptor of the cell set's composition and does not belong here."
             },
             {
               "const": "unclassified",

--- a/src/atlas_chat/atlas_chat/schemas/cas_annotation.schema.json
+++ b/src/atlas_chat/atlas_chat/schemas/cas_annotation.schema.json
@@ -194,7 +194,7 @@
       "properties": {
         "author_field_name": { "type": "string", "description": "The original obs column this category came from." },
         "category": {
-          "description": "What kind of descriptor this is, where that can be determined. A claim about what the column holds, never about whether it matters to any particular consumer. Omit it rather than force a plausible-but-wrong value: the list is deliberately short, an unclassified descriptor is an expected outcome, and absence is what makes the classification's completeness countable. Where present, it names the ontology a value would map to.",
+          "description": "What kind of descriptor this is: a claim about what the column holds, never about whether it matters to any particular consumer. The values follow the standard single-cell descriptor fields, so a category also says which ontology a value would map to. Use `unclassified` rather than forcing a plausible-but-wrong value — a descriptor that does not fit is an expected outcome, and saying so is what tells a later reader that the question was asked and answered rather than skipped.",
           "oneOf": [
             {
               "const": "tissue",
@@ -211,6 +211,30 @@
             {
               "const": "assay",
               "description": "The transcriptomics assay. Sample handling, dissociation, cell enrichment and sorting strategy are not assay and are left unclassified."
+            },
+            {
+              "const": "organism",
+              "description": "The species the cells came from."
+            },
+            {
+              "const": "sex",
+              "description": "Sex of the donor."
+            },
+            {
+              "const": "self_reported_ethnicity",
+              "description": "Ethnicity as reported by the donor, rather than inferred."
+            },
+            {
+              "const": "tissue_type",
+              "description": "Whether the material is tissue, an organoid or cell culture. Distinct from `tissue`, which says where it came from."
+            },
+            {
+              "const": "suspension_type",
+              "description": "Whether whole cells or nuclei were sequenced."
+            },
+            {
+              "const": "unclassified",
+              "description": "A descriptor that does not fit any category above. A positive statement that the column was looked at, not a gap: absence of `category` means the entry predates typing and nothing has been claimed about it either way."
             }
           ]
         },

--- a/src/atlas_chat/atlas_chat/schemas/cas_annotation.schema.json
+++ b/src/atlas_chat/atlas_chat/schemas/cas_annotation.schema.json
@@ -194,7 +194,7 @@
       "properties": {
         "author_field_name": { "type": "string", "description": "The original obs column this category came from." },
         "category": {
-          "description": "What kind of descriptor this is: a claim about what the column holds, never about whether it matters to any particular consumer. The values follow the standard single-cell descriptor fields, so a category also says which ontology a value would map to. Use `unclassified` rather than forcing a plausible-but-wrong value — a descriptor that does not fit is an expected outcome, and saying so is what tells a later reader that the question was asked and answered rather than skipped.",
+          "description": "What kind of descriptor this is: a claim about what the column holds, never about whether it matters to any particular consumer. Apart from `cross_cutting_cell_type` and `unclassified`, the values are the descriptor fields of the CellxGene schema (https://github.com/chanzuckerberg/single-cell-curation/tree/main/schema), so a category also says which ontology a value would map to. Use `unclassified` rather than forcing a plausible-but-wrong value — a descriptor that does not fit is an expected outcome, and saying so is what tells a later reader that the question was asked and answered rather than skipped.",
           "oneOf": [
             {
               "const": "tissue",

--- a/tests/unit/fixtures/cas/cas_annotation.good.json
+++ b/tests/unit/fixtures/cas/cas_annotation.good.json
@@ -6,16 +6,25 @@
   "source": {
     "doi": "10.1234/test",
     "title": "A test atlas paper",
-    "authors": ["Ada Lovelace"],
+    "authors": [
+      "Ada Lovelace"
+    ],
     "atlas_name": "Test Atlas v1",
-    "links": { "preprint": "https://example.org/preprint", "cellxgene": "https://example.org/cxg" },
+    "links": {
+      "preprint": "https://example.org/preprint",
+      "cellxgene": "https://example.org/cxg"
+    },
     "subatlas_papers": [
       {
         "label": "Smith2021",
         "doi": "10.1000/smith",
         "status": "asta",
         "asta_indexing": {
-          "band": "full", "snippets": 72, "chars": 105876, "sections": 30, "ref_mentions": 361,
+          "band": "full",
+          "snippets": 72,
+          "chars": 105876,
+          "sections": 30,
+          "ref_mentions": 361,
           "corpus_id": "CorpusId:273400864",
           "reason": "72 snippets across 30 sections",
           "probed_at": "2026-08-21T09:00:00+00:00"
@@ -27,15 +36,25 @@
         "status": "local",
         "source_type": "jats",
         "asta_indexing": {
-          "band": "abstract_only", "snippets": 4, "chars": 6312, "sections": 0, "ref_mentions": 0,
+          "band": "abstract_only",
+          "snippets": 4,
+          "chars": 6312,
+          "sections": 0,
+          "ref_mentions": 0,
           "corpus_id": "CorpusId:260956290",
-          "reason": "4 snippets, no section names, no refMentions — title/abstract only, no body text",
+          "reason": "4 snippets, no section names, no refMentions \u2014 title/abstract only, no body text",
           "probed_at": "2026-08-21T09:00:00+00:00"
         }
       }
     ]
   },
-  "labelsets": [ { "name": "author_cell_type", "rank": 0, "role": "author_cell_type" } ],
+  "labelsets": [
+    {
+      "name": "author_cell_type",
+      "rank": 0,
+      "role": "author_cell_type"
+    }
+  ],
   "annotations": [
     {
       "labelset": "author_cell_type",
@@ -44,8 +63,13 @@
       "parent_cell_set_accession": null,
       "cell_ontology_term_id": "CL:0000084",
       "cell_ontology_term": "T cell",
-      "marker_gene_evidence": ["CD3D", "CD3E"],
-      "synonyms": ["T lymphocyte"],
+      "marker_gene_evidence": [
+        "CD3D",
+        "CD3E"
+      ],
+      "synonyms": [
+        "T lymphocyte"
+      ],
       "transferred_annotations": [
         {
           "transferred_cell_label": "T lymphocyte",
@@ -60,10 +84,60 @@
       "composition": {
         "organism": {
           "author_field_name": "organism_ontology_term_id",
-          "values": [ { "author_value": "NCBITaxon:9606", "value": "Homo sapiens", "ontology_term_id": "NCBITaxon:9606", "cell_ratio": 1.0 } ]
+          "values": [
+            {
+              "author_value": "NCBITaxon:9606",
+              "value": "Homo sapiens",
+              "ontology_term_id": "NCBITaxon:9606",
+              "cell_ratio": 1.0
+            }
+          ]
+        },
+        "tissue_coarse": {
+          "author_field_name": "organ",
+          "category": "tissue",
+          "values": [
+            {
+              "author_value": "Uterus",
+              "value": "uterus",
+              "ontology_term_id": "UBERON:0000995",
+              "cell_count": 80,
+              "cell_ratio": 0.8
+            },
+            {
+              "author_value": "Ovary",
+              "value": "ovary",
+              "ontology_term_id": "UBERON:0000992",
+              "cell_count": 20,
+              "cell_ratio": 0.2
+            }
+          ]
+        },
+        "donor_age": {
+          "author_field_name": "age_years",
+          "category": "development_stage",
+          "values": [
+            {
+              "author_value": 34,
+              "cell_count": 100,
+              "cell_ratio": 1.0
+            }
+          ]
+        },
+        "enrichment": {
+          "author_field_name": "sort_strategy",
+          "values": [
+            {
+              "author_value": "CD45+",
+              "cell_count": 100,
+              "cell_ratio": 1.0
+            }
+          ]
         }
       },
-      "author_annotation_fields": { "author_cluster_id": "c12" }
+      "author_annotation_fields": {
+        "author_cluster_id": "c12"
+      }
     }
   ]
 }

--- a/tests/unit/fixtures/cas/cas_annotation.good.json
+++ b/tests/unit/fixtures/cas/cas_annotation.good.json
@@ -91,7 +91,8 @@
               "ontology_term_id": "NCBITaxon:9606",
               "cell_ratio": 1.0
             }
-          ]
+          ],
+          "category": "organism"
         },
         "tissue_coarse": {
           "author_field_name": "organ",
@@ -132,7 +133,8 @@
               "cell_count": 100,
               "cell_ratio": 1.0
             }
-          ]
+          ],
+          "category": "unclassified"
         }
       },
       "author_annotation_fields": {

--- a/tests/unit/test_cas_annotation_schema.py
+++ b/tests/unit/test_cas_annotation_schema.py
@@ -290,3 +290,72 @@ def test_atlas_paper_with_only_a_doi_validates() -> None:
     data = _load("cas_annotation.minimal.good.json")
     data["source"] = {"doi": "10.1038/s41586-024-08002-x"}
     assert _errors(data) == []
+
+
+# --- what kind of descriptor a composition entry holds ----------------------
+
+
+def _with_composition(composition: dict) -> object:
+    data = _load("cas_annotation.minimal.good.json")
+    data["annotations"][0]["composition"] = composition
+    return data
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("category", ["tissue", "development_stage", "disease", "assay"])
+def test_every_category_value_is_accepted(category: str) -> None:
+    assert (
+        _errors(
+            _with_composition(
+                {"a_column": {"category": category, "values": [{"author_value": "x"}]}}
+            )
+        )
+        == []
+    )
+
+
+@pytest.mark.unit
+def test_unknown_category_is_rejected() -> None:
+    assert _errors(
+        _with_composition(
+            {"a_column": {"category": "karyotype", "values": [{"author_value": "x"}]}}
+        )
+    )
+
+
+@pytest.mark.unit
+def test_a_descriptor_with_no_category_validates() -> None:
+    """Not every column can be typed, and forcing a plausible-but-wrong value is
+    worse than leaving it out. Absence is what makes the classification's
+    completeness countable."""
+    assert _errors(_with_composition({"a_column": {"values": [{"author_value": "x"}]}})) == []
+
+
+@pytest.mark.unit
+def test_several_descriptors_may_share_a_category() -> None:
+    """Recording a descriptor at more than one granularity is common, and the
+    entries are not interchangeable, so both are kept."""
+    assert (
+        _errors(
+            _with_composition(
+                {
+                    "coarse": {"category": "tissue", "values": [{"author_value": "x"}]},
+                    "fine": {"category": "tissue", "values": [{"author_value": "y"}]},
+                }
+            )
+        )
+        == []
+    )
+
+
+@pytest.mark.unit
+def test_every_category_value_is_described() -> None:
+    """The point of spelling the values out as branches rather than a bare enum
+    is that each carries its own definition where an editor will see it.
+    Collapsing them back to an enum would validate identically and lose that."""
+    branches = load_schema(SCHEMA)["$defs"]["CompositionCategory"]["properties"]["category"][
+        "oneOf"
+    ]
+    undescribed = [b.get("const") for b in branches if not (b.get("description") or "").strip()]
+    assert undescribed == []
+    assert len(branches) == len({b["const"] for b in branches})

--- a/tests/unit/test_cas_annotation_schema.py
+++ b/tests/unit/test_cas_annotation_schema.py
@@ -301,8 +301,33 @@ def _with_composition(composition: dict) -> object:
     return data
 
 
+CATEGORIES = [
+    "tissue",
+    "development_stage",
+    "disease",
+    "assay",
+    "organism",
+    "sex",
+    "self_reported_ethnicity",
+    "tissue_type",
+    "suspension_type",
+    "unclassified",
+]
+
+
+def _category_branches() -> list[dict]:
+    return load_schema(SCHEMA)["$defs"]["CompositionCategory"]["properties"]["category"]["oneOf"]
+
+
 @pytest.mark.unit
-@pytest.mark.parametrize("category", ["tissue", "development_stage", "disease", "assay"])
+def test_the_category_values_are_the_ones_expected() -> None:
+    """Spelled out here as well as in the schema: adding or renaming a category
+    is a contract change and should have to be made in two places."""
+    assert [b["const"] for b in _category_branches()] == CATEGORIES
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("category", CATEGORIES)
 def test_every_category_value_is_accepted(category: str) -> None:
     assert (
         _errors(
@@ -325,10 +350,24 @@ def test_unknown_category_is_rejected() -> None:
 
 @pytest.mark.unit
 def test_a_descriptor_with_no_category_validates() -> None:
-    """Not every column can be typed, and forcing a plausible-but-wrong value is
-    worse than leaving it out. Absence is what makes the classification's
-    completeness countable."""
+    """Entries written before typing existed stay valid. Absence claims nothing
+    either way, which is why a descriptor that was looked at and did not fit
+    says so with `unclassified` instead."""
     assert _errors(_with_composition({"a_column": {"values": [{"author_value": "x"}]}})) == []
+
+
+@pytest.mark.unit
+def test_a_descriptor_that_fits_nothing_says_so_rather_than_being_forced() -> None:
+    """Forcing a plausible-but-wrong category is worse than declining, and
+    declining has to be sayable for the classification to be auditable."""
+    assert (
+        _errors(
+            _with_composition(
+                {"a_column": {"category": "unclassified", "values": [{"author_value": "x"}]}}
+            )
+        )
+        == []
+    )
 
 
 @pytest.mark.unit
@@ -353,9 +392,7 @@ def test_every_category_value_is_described() -> None:
     """The point of spelling the values out as branches rather than a bare enum
     is that each carries its own definition where an editor will see it.
     Collapsing them back to an enum would validate identically and lose that."""
-    branches = load_schema(SCHEMA)["$defs"]["CompositionCategory"]["properties"]["category"][
-        "oneOf"
-    ]
+    branches = _category_branches()
     undescribed = [b.get("const") for b in branches if not (b.get("description") or "").strip()]
     assert undescribed == []
     assert len(branches) == len({b["const"] for b in branches})

--- a/tests/unit/test_cas_annotation_schema.py
+++ b/tests/unit/test_cas_annotation_schema.py
@@ -311,6 +311,7 @@ CATEGORIES = [
     "self_reported_ethnicity",
     "tissue_type",
     "suspension_type",
+    "cross_cutting_cell_type",
     "unclassified",
 ]
 


### PR DESCRIPTION
Types each `composition` entry by what kind of descriptor it holds, so a consumer can select on meaning rather than on an author's column name — and so a value has a stated ontology to map to.

Additive. `category` is optional, existing documents stay valid, and the reproductive test project validates unchanged.

## The shape: category inside the entry, not as the key

```json
"Organ":      { "author_field_name": "Organ",      "category": "tissue", "values": [...] },
"Organ_part": { "author_field_name": "Organ_part", "category": "tissue", "values": [...] },
"sort_strategy": { "author_field_name": "sort_strategy", "category": "unclassified", "values": [...] }
```

The alternative was categories as keys with an `uncategorised` bucket. Inside the entry wins on three counts:

- **Additive.** Classification improves in place rather than by migration — which matters while composition is still settling.
- **It sits next to `ontology_term_id`**, which is where the mapping a category implies actually happens. As a key it would be a level up from the thing it governs.
- **Several entries may share a category.** Recording a descriptor at more than one granularity is normal, and the entries are *not* interchangeable, so all are kept. This falls out for free rather than needing the value under each key to become an array.

Deriving category-keyed access from this is a pure function; the reverse is a migration.

## Values

`tissue`, `development_stage`, `disease`, `assay`, `organism`, `sex`, `self_reported_ethnicity`, `tissue_type`, `suspension_type`, `unclassified` — the standard single-cell descriptor fields, plus a way to decline.

Two definitions are written specifically because the obvious reading is wrong:

- **`development_stage` includes age.** Stage ontologies express age as stage terms, so a column of ages belongs here rather than unclassified.
- **`assay` is the transcriptomics assay.** Sample handling, dissociation, enrichment and sorting strategy are not assay.

And two that are easy to conflate:

- **`organism` is the species.**
- **`tissue_type`** is what the material is — tissue, organoid or culture — as against **`tissue`**, which is where it came from. Worth keeping apart: a cell type characterised in an organoid is not the same claim as one characterised in the organ.

`cell_type` is deliberately absent. Author cell-type columns currently appear in composition, but they are being moved upstream, so encoding a structure that is mid-change would be premature.

## Why `unclassified` exists rather than just omitting the field

This is the substantive part.

Leaving `category` out was doing two jobs at once: a column nobody has typed yet, and a column that *was* typed and fits nothing, look identical. So the classification cannot be audited — a run that skipped half the fields reads exactly like one that finished.

The repo already resolves this the other way round for supplementary triage, where an unrecognised file comes back `unknown` rather than being omitted, precisely so silence is never read as a judgement. Same reasoning applies here.

So: **`unclassified` is a positive statement that the column was looked at**, and absence now means only that the entry predates typing.

**Follow-up, deliberately not in this PR:** once documents are regenerated, `category` should become **required**. Absence then stops being expressible, every entry has to say where it stands, and a wholly-unprocessed document is visible as one where everything reads `unclassified`. Requiring it today would invalidate the committed test project immediately, so it is a coordination point with the ingest work rather than something to spring on a document mid-regeneration.

## `oneOf` rather than `enum`

Each value carries its own description, where an editor will see it, instead of a wall of text on one `enum`. Validates identically. A test pins the branches, so collapsing them back to a bare enum — which would pass every other check — cannot silently lose the definitions.

## One thing the category is not

A category says what a column **holds**, never whether it **matters**. A consumer that wants only anatomical context filters on its own behalf. If `disease` quietly came to mean "excluded from the context block", the next consumer that legitimately wants disease composition would find the judgement already made for it.

`Composition`'s own description is corrected in passing: it claimed keys were standard descriptor categories, which is not true of any document held, and under this change need not be.

## Verification

- 443 unit tests pass (16 new), ruff clean, formatting clean.
- The reproductive test project's CAS+ validates with **zero errors** — nothing to migrate.
- Golden fixture gains a typed tissue entry, an age column typed `development_stage`, an `organism` entry, and a sorting-strategy column typed `unclassified`.
- Schema well-formedness was already pinned by `test_schema_is_well_formed` (`Draft202012Validator.check_schema`), and `test_every_field_has_a_description` already required the new property to be described.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
