### PR TITLE
Refresh the reproductive test project CAS+ with typed composition

### DIFF
--- a/projects/test_projects/hca_reproductive/cas.json
+++ b/projects/test_projects/hca_reproductive/cas.json
@@ -54,28 +54,9 @@
     "PLVAP"
    ],
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Endo_ven_apcv",
-       "cell_count": 4851,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Endo_ven_apcv",
-       "cell_count": 4851,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Uterus",
@@ -101,6 +82,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Whole_Uterus",
@@ -171,6 +153,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Endometrium",
@@ -261,6 +244,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -281,6 +265,7 @@
     },
     "Developmental_stage": {
      "author_field_name": "Developmental_stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Adult",
@@ -296,6 +281,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "70",
@@ -511,6 +497,7 @@
     },
     "Tanner Stage": {
      "author_field_name": "Tanner Stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Pubic V/Genitals-Breast V",
@@ -536,6 +523,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Postmenopausal",
@@ -621,6 +609,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "control",
@@ -696,6 +685,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -801,6 +791,7 @@
     },
     "Observed_pathology": {
      "author_field_name": "Observed_pathology",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -826,6 +817,7 @@
     },
     "Sampled_site_condition": {
      "author_field_name": "Sampled_site_condition",
+     "category": "disease",
      "values": [
       {
        "author_value": "normal",
@@ -1008,28 +1000,9 @@
    ],
    "comment": "Minted generic leaf for celltype_HCA_fine='Endo_ven_pcv' (13904 cells). The master L1-L4 nomenclature terminates at L3 'Post-capillary venous endothelial' with no finer label, so these author-labelled cells — pericytes/etc. the annotators did NOT assign to a finer subtype — had no leaf of their own; the parent node is retained as a pure supertype. cell_label inherited from the supertype nomenclature.",
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Endo_ven_pcv",
-       "cell_count": 13904,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Endo_ven_pcv",
-       "cell_count": 13904,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Uterus",
@@ -1070,6 +1043,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Whole_Uterus",
@@ -1215,6 +1189,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Myometrium",
@@ -1380,6 +1355,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -1410,6 +1386,7 @@
     },
     "Developmental_stage": {
      "author_field_name": "Developmental_stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Adult",
@@ -1440,6 +1417,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -1735,6 +1713,7 @@
     },
     "Tanner Stage": {
      "author_field_name": "Tanner Stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Pubic V/Genitals-Breast V",
@@ -1775,6 +1754,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -1890,6 +1870,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Postmenopausal",
@@ -2005,6 +1986,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "control",
@@ -2180,6 +2162,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -2390,6 +2373,7 @@
     },
     "Observed_pathology": {
      "author_field_name": "Observed_pathology",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -2425,6 +2409,7 @@
     },
     "Sampled_site_condition": {
      "author_field_name": "Sampled_site_condition",
+     "category": "disease",
      "values": [
       {
        "author_value": "normal",
@@ -2689,28 +2674,9 @@
     "tPCV"
    ],
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Endo_ven_tpcv",
-       "cell_count": 16892,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Endo_ven_tpcv",
-       "cell_count": 16892,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Uterus",
@@ -2741,6 +2707,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Myometrium",
@@ -2821,6 +2788,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Myometrium",
@@ -2926,6 +2894,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -2946,6 +2915,7 @@
     },
     "Developmental_stage": {
      "author_field_name": "Developmental_stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Adult",
@@ -2971,6 +2941,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "31",
@@ -3251,6 +3222,7 @@
     },
     "Tanner Stage": {
      "author_field_name": "Tanner Stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Pubic V/Genitals-Breast V",
@@ -3286,6 +3258,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Postmenopausal",
@@ -3381,6 +3354,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "control",
@@ -3556,6 +3530,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -3766,6 +3741,7 @@
     },
     "Observed_pathology": {
      "author_field_name": "Observed_pathology",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -3796,6 +3772,7 @@
     },
     "Sampled_site_condition": {
      "author_field_name": "Sampled_site_condition",
+     "category": "disease",
      "values": [
       {
        "author_value": "normal",
@@ -4058,6 +4035,7 @@
    "composition": {
     "celltype_HCA_fine": {
      "author_field_name": "celltype_HCA_fine",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Endo_cap_APCDD1",
@@ -4071,23 +4049,9 @@
       }
      ]
     },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Endo_cap_APCDD1",
-       "cell_count": 4691,
-       "cell_ratio": 0.6463
-      },
-      {
-       "author_value": "unknown",
-       "cell_count": 2567,
-       "cell_ratio": 0.3537
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Uterus",
@@ -4113,6 +4077,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Endometrium",
@@ -4228,6 +4193,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Endometrium",
@@ -4353,6 +4319,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -4383,6 +4350,7 @@
     },
     "Developmental_stage": {
      "author_field_name": "Developmental_stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Adult",
@@ -4413,6 +4381,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -4643,6 +4612,7 @@
     },
     "Tanner Stage": {
      "author_field_name": "Tanner Stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Pubic V/Genitals-Breast V",
@@ -4678,6 +4648,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -4758,6 +4729,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -4868,6 +4840,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "control",
@@ -5008,6 +4981,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -5183,6 +5157,7 @@
     },
     "Observed_pathology": {
      "author_field_name": "Observed_pathology",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -5218,6 +5193,7 @@
     },
     "Sampled_site_condition": {
      "author_field_name": "Sampled_site_condition",
+     "category": "disease",
      "values": [
       {
        "author_value": "normal",
@@ -5417,28 +5393,9 @@
    ],
    "comment": "Minted generic leaf for celltype_HCA_fine='Epi_CervixSquamous' (1138 cells). The master L1-L4 nomenclature terminates at L3 'Cervix squamous epithelial' with no finer label, so these author-labelled cells — pericytes/etc. the annotators did NOT assign to a finer subtype — had no leaf of their own; the parent node is retained as a pure supertype. cell_label inherited from the supertype nomenclature.",
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Epi_CervixSquamous",
-       "cell_count": 1138,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Epi_CervixSquamous",
-       "cell_count": 1138,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Cervix",
@@ -5459,6 +5416,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "cervix",
@@ -5479,6 +5437,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "unknown",
@@ -5504,6 +5463,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -5519,6 +5479,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "35-65",
@@ -5579,6 +5540,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Unknown",
@@ -5624,6 +5586,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "control",
@@ -5639,6 +5602,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -5664,6 +5628,7 @@
     },
     "Observed_pathology": {
      "author_field_name": "Observed_pathology",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not_applicable",
@@ -5684,6 +5649,7 @@
     },
     "Sampled_site_condition": {
      "author_field_name": "Sampled_site_condition",
+     "category": "disease",
      "values": [
       {
        "author_value": "normal",
@@ -5712,28 +5678,9 @@
     "MKI67"
    ],
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Epi_CervixSquamous_Cyc",
-       "cell_count": 409,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Epi_CervixSquamous_Cyc",
-       "cell_count": 409,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Cervix",
@@ -5749,6 +5696,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "cervix",
@@ -5764,6 +5712,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "unknown",
@@ -5779,6 +5728,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "35-65",
@@ -5799,6 +5749,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Unknown",
@@ -5814,6 +5765,7 @@
     },
     "Observed_pathology": {
      "author_field_name": "Observed_pathology",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not_applicable",
@@ -5842,28 +5794,9 @@
     "MKI67"
    ],
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Epi_EndoCil_Cyc",
-       "cell_count": 1975,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Epi_EndoCil_Cyc",
-       "cell_count": 1975,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Endometrium",
@@ -5884,6 +5817,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Endometrium",
@@ -5904,6 +5838,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -5919,6 +5854,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "31",
@@ -6049,6 +5985,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Proliferative",
@@ -6134,6 +6071,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "control",
@@ -6164,6 +6102,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -6229,6 +6168,7 @@
     },
     "Observed_pathology": {
      "author_field_name": "Observed_pathology",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -6254,6 +6194,7 @@
     },
     "Sampled_site_condition": {
      "author_field_name": "Sampled_site_condition",
+     "category": "disease",
      "values": [
       {
        "author_value": "normal",
@@ -6371,28 +6312,9 @@
     "SPDEF"
    ],
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Epi_EndoCil_Diff",
-       "cell_count": 8903,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Epi_EndoCil_Diff",
-       "cell_count": 8903,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Endometrium",
@@ -6418,6 +6340,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Superficial_Endometrium",
@@ -6443,6 +6366,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -6458,6 +6382,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "18-34",
@@ -6603,6 +6528,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Secretory Early-Mid",
@@ -6698,6 +6624,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "control",
@@ -6748,6 +6675,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -6833,6 +6761,7 @@
     },
     "Observed_pathology": {
      "author_field_name": "Observed_pathology",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -6868,6 +6797,7 @@
     },
     "Sampled_site_condition": {
      "author_field_name": "Sampled_site_condition",
+     "category": "disease",
      "values": [
       {
        "author_value": "normal",
@@ -7096,28 +7026,9 @@
     "LGR5"
    ],
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Epi_EndoCil_eProf",
-       "cell_count": 1014,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Epi_EndoCil_eProf",
-       "cell_count": 1014,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Endometrium",
@@ -7138,6 +7049,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Superficial_Endometrium",
@@ -7163,6 +7075,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -7178,6 +7091,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "35",
@@ -7278,6 +7192,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Proliferative",
@@ -7348,6 +7263,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "control",
@@ -7378,6 +7294,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -7438,6 +7355,7 @@
     },
     "Observed_pathology": {
      "author_field_name": "Observed_pathology",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -7463,6 +7381,7 @@
     },
     "Sampled_site_condition": {
      "author_field_name": "Sampled_site_condition",
+     "category": "disease",
      "values": [
       {
        "author_value": "normal",
@@ -7659,28 +7578,9 @@
     "10.1093/humrep/dex289"
    ],
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Epi_EndoGlandBas",
-       "cell_count": 748,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Epi_EndoGlandBas",
-       "cell_count": 748,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Endometrium",
@@ -7701,6 +7601,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Superficial_Endometrium",
@@ -7721,6 +7622,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -7736,6 +7638,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "24",
@@ -7811,6 +7714,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Proliferative Early",
@@ -7856,6 +7760,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "endometriosis",
@@ -7871,6 +7776,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "endometriosis",
@@ -7901,6 +7807,7 @@
     },
     "Observed_pathology": {
      "author_field_name": "Observed_pathology",
+     "category": "disease",
      "values": [
       {
        "author_value": "endometriosis",
@@ -7916,6 +7823,7 @@
     },
     "Sampled_site_condition": {
      "author_field_name": "Sampled_site_condition",
+     "category": "disease",
      "values": [
       {
        "author_value": "endometriosis",
@@ -8034,28 +7942,9 @@
     "WIF1"
    ],
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Epi_EndoGlandBas_WIF1",
-       "cell_count": 1694,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Epi_EndoGlandBas_WIF1",
-       "cell_count": 1694,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Endometrium",
@@ -8081,6 +7970,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Endometrium",
@@ -8111,6 +8001,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -8126,6 +8017,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "24",
@@ -8256,6 +8148,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Proliferative Late",
@@ -8341,6 +8234,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "control",
@@ -8376,6 +8270,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -8441,6 +8336,7 @@
     },
     "Observed_pathology": {
      "author_field_name": "Observed_pathology",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -8466,6 +8362,7 @@
     },
     "Sampled_site_condition": {
      "author_field_name": "Sampled_site_condition",
+     "category": "disease",
      "values": [
       {
        "author_value": "normal",
@@ -8602,28 +8499,9 @@
    ],
    "comment": "media-4 description: While PAEP is not specific to this population;but these upregulate PAEP",
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Epi_EndoGlandFun_Menstr",
-       "cell_count": 4248,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Epi_EndoGlandFun_Menstr",
-       "cell_count": 4248,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Mentrual fluid",
@@ -8644,6 +8522,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Mentrual fluid",
@@ -8669,6 +8548,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -8684,6 +8564,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "24",
@@ -8779,6 +8660,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Menstrual",
@@ -8834,6 +8716,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "Unknown",
@@ -8879,6 +8762,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Unknown",
@@ -8959,6 +8843,7 @@
     },
     "Observed_pathology": {
      "author_field_name": "Observed_pathology",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -8984,6 +8869,7 @@
     },
     "Sampled_site_condition": {
      "author_field_name": "Sampled_site_condition",
+     "category": "disease",
      "values": [
       {
        "author_value": "Unknown",
@@ -9087,28 +8973,9 @@
     "SCGB2A2"
    ],
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Epi_EndoGlandFun_Prof",
-       "cell_count": 23099,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Epi_EndoGlandFun_Prof",
-       "cell_count": 23099,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Endometrium",
@@ -9134,6 +9001,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Endometrium",
@@ -9159,6 +9027,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -9174,6 +9043,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "35",
@@ -9314,6 +9184,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Proliferative",
@@ -9409,6 +9280,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "control",
@@ -9454,6 +9326,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -9534,6 +9407,7 @@
     },
     "Observed_pathology": {
      "author_field_name": "Observed_pathology",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -9569,6 +9443,7 @@
     },
     "Sampled_site_condition": {
      "author_field_name": "Sampled_site_condition",
+     "category": "disease",
      "values": [
       {
        "author_value": "normal",
@@ -9819,28 +9694,9 @@
     "MKI67"
    ],
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Epi_EndoGlandFun_Prof_Cyc",
-       "cell_count": 12815,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Epi_EndoGlandFun_Prof_Cyc",
-       "cell_count": 12815,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Endometrium",
@@ -9861,6 +9717,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Superficial_Endometrium",
@@ -9881,6 +9738,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -9896,6 +9754,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "33",
@@ -10031,6 +9890,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Proliferative",
@@ -10116,6 +9976,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "control",
@@ -10151,6 +10012,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -10221,6 +10083,7 @@
     },
     "Observed_pathology": {
      "author_field_name": "Observed_pathology",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -10256,6 +10119,7 @@
     },
     "Sampled_site_condition": {
      "author_field_name": "Sampled_site_condition",
+     "category": "disease",
      "values": [
       {
        "author_value": "normal",
@@ -10524,28 +10388,9 @@
    ],
    "comment": "media-4 description: While PAEP is not specific to this population;but these upregulate PAEP",
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Epi_EndoGlandFun_emSec",
-       "cell_count": 18366,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Epi_EndoGlandFun_emSec",
-       "cell_count": 18366,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Endometrium",
@@ -10571,6 +10416,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Superficial_Endometrium",
@@ -10596,6 +10442,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -10611,6 +10458,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "18-34",
@@ -10731,6 +10579,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Secretory Mid",
@@ -10806,6 +10655,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "control",
@@ -10841,6 +10691,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -10906,6 +10757,7 @@
     },
     "Observed_pathology": {
      "author_field_name": "Observed_pathology",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -10931,6 +10783,7 @@
     },
     "Sampled_site_condition": {
      "author_field_name": "Sampled_site_condition",
+     "category": "disease",
      "values": [
       {
        "author_value": "normal",
@@ -11235,28 +11088,9 @@
     "SCGB2A2"
    ],
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Epi_EndoGlandFun_lProf",
-       "cell_count": 11900,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Epi_EndoGlandFun_lProf",
-       "cell_count": 11900,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Superficial_Endometrium",
@@ -11272,6 +11106,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -11287,6 +11122,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "33",
@@ -11392,6 +11228,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Secretory Early",
@@ -11462,6 +11299,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "endometriosis",
@@ -11492,6 +11330,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "endometriosis",
@@ -11552,6 +11391,7 @@
     },
     "Observed_pathology": {
      "author_field_name": "Observed_pathology",
+     "category": "disease",
      "values": [
       {
        "author_value": "endometriosis",
@@ -11582,6 +11422,7 @@
     },
     "Sampled_site_condition": {
      "author_field_name": "Sampled_site_condition",
+     "category": "disease",
      "values": [
       {
        "author_value": "endometriosis",
@@ -11796,28 +11637,9 @@
    ],
    "comment": "media-4 description: While PAEP is not specific to this population;but these upregulate PAEP",
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Epi_EndoGlandFun_lSec",
-       "cell_count": 1467,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Epi_EndoGlandFun_lSec",
-       "cell_count": 1467,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Endometrium",
@@ -11833,6 +11655,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Superficial_Endometrium",
@@ -11848,6 +11671,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -11863,6 +11687,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "18-34",
@@ -11953,6 +11778,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Secretory Late",
@@ -11998,6 +11824,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "control",
@@ -12028,6 +11855,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -12068,6 +11896,7 @@
     },
     "Observed_pathology": {
      "author_field_name": "Observed_pathology",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -12098,6 +11927,7 @@
     },
     "Sampled_site_condition": {
      "author_field_name": "Sampled_site_condition",
+     "category": "disease",
      "values": [
       {
        "author_value": "normal",
@@ -12249,28 +12079,9 @@
    ],
    "comment": "media-4 description: While PAEP is not specific to this population;but these upregulate PAEP",
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Epi_EndoGlandFun_mSec",
-       "cell_count": 25233,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Epi_EndoGlandFun_mSec",
-       "cell_count": 25233,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Endometrium",
@@ -12296,6 +12107,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Endometrium",
@@ -12321,6 +12133,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -12336,6 +12149,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "18-34",
@@ -12466,6 +12280,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Secretory Mid",
@@ -12556,6 +12371,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "control",
@@ -12591,6 +12407,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -12656,6 +12473,7 @@
     },
     "Observed_pathology": {
      "author_field_name": "Observed_pathology",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -12681,6 +12499,7 @@
     },
     "Sampled_site_condition": {
      "author_field_name": "Sampled_site_condition",
+     "category": "disease",
      "values": [
       {
        "author_value": "normal",
@@ -12962,28 +12781,9 @@
     "WNT7A"
    ],
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Epi_EndoGlandLum_Prof",
-       "cell_count": 9672,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Epi_EndoGlandLum_Prof",
-       "cell_count": 9672,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Endometrium",
@@ -13009,6 +12809,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Superficial_Endometrium",
@@ -13034,6 +12835,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -13049,6 +12851,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "18-34",
@@ -13184,6 +12987,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Proliferative",
@@ -13274,6 +13078,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "control",
@@ -13309,6 +13114,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -13379,6 +13185,7 @@
     },
     "Observed_pathology": {
      "author_field_name": "Observed_pathology",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -13409,6 +13216,7 @@
     },
     "Sampled_site_condition": {
      "author_field_name": "Sampled_site_condition",
+     "category": "disease",
      "values": [
       {
        "author_value": "normal",
@@ -13687,28 +13495,9 @@
     "IL6"
    ],
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Epi_EndoGlandLum_eSec",
-       "cell_count": 24,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Epi_EndoGlandLum_eSec",
-       "cell_count": 24,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Endometrium",
@@ -13724,6 +13513,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -13739,6 +13529,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "41",
@@ -13774,6 +13565,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Secretory Mid",
@@ -13794,6 +13586,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "control",
@@ -13809,6 +13602,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -13824,6 +13618,7 @@
     },
     "Observed_pathology": {
      "author_field_name": "Observed_pathology",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -13839,6 +13634,7 @@
     },
     "Sampled_site_condition": {
      "author_field_name": "Sampled_site_condition",
+     "category": "disease",
      "values": [
       {
        "author_value": "normal",
@@ -13881,28 +13677,9 @@
     "SPDEF"
    ],
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Epi_EndoGlandLum_mSec",
-       "cell_count": 12046,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Epi_EndoGlandLum_mSec",
-       "cell_count": 12046,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Endometrium",
@@ -13928,6 +13705,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Superficial_Endometrium",
@@ -13953,6 +13731,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -13968,6 +13747,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "18-34",
@@ -14093,6 +13873,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Secretory Early-Mid",
@@ -14188,6 +13969,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "control",
@@ -14238,6 +14020,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -14313,6 +14096,7 @@
     },
     "Observed_pathology": {
      "author_field_name": "Observed_pathology",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -14343,6 +14127,7 @@
     },
     "Sampled_site_condition": {
      "author_field_name": "Sampled_site_condition",
+     "category": "disease",
      "values": [
       {
        "author_value": "normal",
@@ -14650,38 +14435,9 @@
    "cell_ontology_term": "glandular epithelial cell of endometrium",
    "comment": "media-4 description: Heterogeneous population;depends on the hormonal treatment",
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Epi_EndoGland_nEMC",
-       "cell_count": 18196,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Epi_EndoGland_nEMC",
-       "cell_count": 18196,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA_broad": {
-     "author_field_name": "celltype_HCA_broad",
-     "values": [
-      {
-       "author_value": "Epi_EndoGland",
-       "cell_count": 18196,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Endometrium",
@@ -14707,6 +14463,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Superficial_Endometrium",
@@ -14732,6 +14489,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -14747,6 +14505,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "22",
@@ -14892,6 +14651,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Hormones",
@@ -14987,6 +14747,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "endometriosis",
@@ -15042,6 +14803,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -15132,6 +14894,7 @@
     },
     "Observed_pathology": {
      "author_field_name": "Observed_pathology",
+     "category": "disease",
      "values": [
       {
        "author_value": "endometriosis",
@@ -15167,6 +14930,7 @@
     },
     "Sampled_site_condition": {
      "author_field_name": "Sampled_site_condition",
+     "category": "disease",
      "values": [
       {
        "author_value": "endometriosis",
@@ -15394,28 +15158,9 @@
     "MKI67"
    ],
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Epi_FallopianCil_Cyc",
-       "cell_count": 547,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Epi_FallopianCil_Cyc",
-       "cell_count": 547,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Fallopian Tube Ampulla",
@@ -15436,6 +15181,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Fallopian Tube Ampulla",
@@ -15456,6 +15202,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Unknown",
@@ -15506,6 +15253,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Unknown",
@@ -15604,28 +15352,9 @@
     "SPDEF"
    ],
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Epi_FallopianCil_Diff",
-       "cell_count": 12869,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Epi_FallopianCil_Diff",
-       "cell_count": 12869,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Fallopian Tube Fimbria",
@@ -15651,6 +15380,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Fallopian Tube Fimbria",
@@ -15686,6 +15416,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Unknown",
@@ -15776,6 +15507,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Unknown",
@@ -15876,28 +15608,9 @@
     "CDC20B"
    ],
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Epi_FallopianCil_Early",
-       "cell_count": 460,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Epi_FallopianCil_Early",
-       "cell_count": 460,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Fallopian Tube Ampulla",
@@ -15923,6 +15636,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Fallopian Tube Ampulla",
@@ -15948,6 +15662,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Unknown",
@@ -16023,6 +15738,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Unknown",
@@ -16097,18 +15813,9 @@
     "DNAH12"
    ],
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Epi_FallopianCil_Fetal",
-       "cell_count": 516,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Ovary",
@@ -16124,6 +15831,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Gonad_and_extragonadal",
@@ -16164,6 +15872,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Gonad_and_extragonadal",
@@ -16204,6 +15913,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "21",
@@ -16337,28 +16047,9 @@
     "MKI67"
    ],
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Epi_FallopianSec_Cyc",
-       "cell_count": 560,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Epi_FallopianSec_Cyc",
-       "cell_count": 560,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Fallopian Tube Ampulla",
@@ -16384,6 +16075,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Fallopian Tube Ampulla",
@@ -16409,6 +16101,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Unknown",
@@ -16499,6 +16192,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Unknown",
@@ -16606,18 +16300,9 @@
     "ERP27"
    ],
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Epi_FallopianSec_Fetal",
-       "cell_count": 12310,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Reproductive tract",
@@ -16638,6 +16323,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Gonad_and_extragonadal",
@@ -16698,6 +16384,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Gonad_and_extragonadal",
@@ -16758,6 +16445,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -16778,6 +16466,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -16793,6 +16482,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "21",
@@ -17136,18 +16826,9 @@
    "cell_ontology_term_id": "CL:4030006",
    "cell_ontology_term": "fallopian tube secretory epithelial cell",
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Epi_FallopianSec_OVGP1hi_EstrInd",
-       "cell_count": 17601,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Fallopian Tube Ampulla",
@@ -17173,6 +16854,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Fallopian Tube Ampulla",
@@ -17208,6 +16890,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Unknown",
@@ -17298,6 +16981,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Unknown",
@@ -17408,28 +17092,9 @@
     "SPDEF"
    ],
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Epi_FallopianSec_OVGP1lo",
-       "cell_count": 13587,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Epi_FallopianSec_OVGP1lo",
-       "cell_count": 13587,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Fallopian Tube Ampulla",
@@ -17455,6 +17120,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Fallopian Tube Ampulla",
@@ -17490,6 +17156,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "30",
@@ -17580,6 +17247,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Unknown",
@@ -17679,28 +17347,9 @@
     "KRTDAP"
    ],
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Epi_GenitalSurf_Fetal",
-       "cell_count": 1482,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA_broad": {
-     "author_field_name": "celltype_HCA_broad",
-     "values": [
-      {
-       "author_value": "Epi_GenitalSurf",
-       "cell_count": 1482,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "uterus, cervix, vagina",
@@ -17751,6 +17400,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "uterus, cervix, vagina",
@@ -17801,6 +17451,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -17811,6 +17462,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "15",
@@ -17981,28 +17633,9 @@
     "FXYD2"
    ],
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Epi_MesonephricTub_Fetal",
-       "cell_count": 7359,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA_broad": {
-     "author_field_name": "celltype_HCA_broad",
-     "values": [
-      {
-       "author_value": "Epi_MesonephricTub",
-       "cell_count": 7359,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Reproductive tract",
@@ -18023,6 +17656,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Whole_tract",
@@ -18103,6 +17737,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Whole_tract",
@@ -18183,6 +17818,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -18203,6 +17839,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "5.6",
@@ -18650,28 +18287,9 @@
     "WNT3"
    ],
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Epi_PrepuceSquamous_Fetal",
-       "cell_count": 2097,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA_broad": {
-     "author_field_name": "celltype_HCA_broad",
-     "values": [
-      {
-       "author_value": "Epi_PrepuceSquamous",
-       "cell_count": 2097,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "external genitalia",
@@ -18702,6 +18320,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "External genitalia",
@@ -18732,6 +18351,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -18742,6 +18362,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "12",
@@ -18895,28 +18516,9 @@
     "PSCA"
    ],
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Epi_UrethralSquamous_Fetal",
-       "cell_count": 1649,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA_broad": {
-     "author_field_name": "celltype_HCA_broad",
-     "values": [
-      {
-       "author_value": "Epi_UrethralSquamous",
-       "cell_count": 1649,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Reproductive tract",
@@ -18937,6 +18539,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Vagina",
@@ -18997,6 +18600,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Vagina",
@@ -19057,6 +18661,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -19067,6 +18672,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "19",
@@ -19247,28 +18853,9 @@
     "DLX5"
    ],
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Epi_Uterocervical_Fetal",
-       "cell_count": 7640,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA_broad": {
-     "author_field_name": "celltype_HCA_broad",
-     "values": [
-      {
-       "author_value": "Epi_Uterocervical",
-       "cell_count": 7640,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Reproductive tract",
@@ -19284,6 +18871,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "uterus, cervix, vagina",
@@ -19359,6 +18947,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "uterus, cervix, vagina",
@@ -19434,6 +19023,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -19449,6 +19039,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "18",
@@ -19673,18 +19264,9 @@
     "PRAC1"
    ],
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Epi_Vagina_Lower_Fetal",
-       "cell_count": 6047,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Reproductive tract",
@@ -19700,6 +19282,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "uterus, cervix, vagina",
@@ -19770,6 +19353,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "uterus, cervix, vagina",
@@ -19840,6 +19424,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -19850,6 +19435,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "18",
@@ -20082,18 +19668,9 @@
     "FOXA1"
    ],
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Epi_Vagina_Upper_Fetal",
-       "cell_count": 980,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Reproductive tract",
@@ -20109,6 +19686,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "uterus, cervix, vagina",
@@ -20149,6 +19727,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "uterus, cervix, vagina",
@@ -20189,6 +19768,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "18",
@@ -20323,28 +19903,9 @@
    "cell_ontology_term_id": "CL:1100001",
    "cell_ontology_term": "secretory epithelial cell",
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Epi_reteOvarii_Fetal_Undiff",
-       "cell_count": 5796,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA_broad": {
-     "author_field_name": "celltype_HCA_broad",
-     "values": [
-      {
-       "author_value": "Epi_reteOvarii",
-       "cell_count": 5796,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Ovary",
@@ -20365,6 +19926,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Gonad_and_extragonadal",
@@ -20400,6 +19962,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Gonad_and_extragonadal",
@@ -20435,6 +19998,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -20455,6 +20019,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "8.6",
@@ -20863,18 +20428,9 @@
    "cell_ontology_term": "primary oocyte",
    "comment": "Minted generic leaf for celltype_HCA_fine='Germcell_PrimaryOocyte_ZP4neg' (760 cells). The master L1-L4 nomenclature terminates at L3 'Primary oocyte' with no finer label, so these author-labelled cells — pericytes/etc. the annotators did NOT assign to a finer subtype — had no leaf of their own; the parent node is retained as a pure supertype. cell_label inherited from the supertype nomenclature.",
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Germcell_PrimaryOocyte_ZP4neg",
-       "cell_count": 760,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Ovary",
@@ -20890,6 +20446,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Gonad_and_extragonadal",
@@ -20915,6 +20472,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Gonad_and_extragonadal",
@@ -20940,6 +20498,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -20960,6 +20519,7 @@
     },
     "Developmental_stage": {
      "author_field_name": "Developmental_stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Fetal",
@@ -20975,6 +20535,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -20995,6 +20556,7 @@
     },
     "Tanner Stage": {
      "author_field_name": "Tanner Stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -21010,6 +20572,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "17",
@@ -21065,6 +20628,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -21164,18 +20728,9 @@
    "cell_ontology_term_id": "CL:0000654",
    "cell_ontology_term": "primary oocyte",
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Germcell_PrimaryOocyte_ZP4pos",
-       "cell_count": 391,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Ovarian Cortex",
@@ -21206,6 +20761,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Cortex_outer",
@@ -21241,6 +20797,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "unknown",
@@ -21266,6 +20823,7 @@
     },
     "Developmental_stage": {
      "author_field_name": "Developmental_stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "paediatric",
@@ -21291,6 +20849,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "4",
@@ -21381,6 +20940,7 @@
     },
     "Tanner Stage": {
      "author_field_name": "Tanner Stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Pubic I/Genitals-Breast I",
@@ -21416,6 +20976,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -21451,6 +21012,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Paediatric",
@@ -21471,6 +21033,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "control",
@@ -21551,6 +21114,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -21702,18 +21266,9 @@
     "WNT4"
    ],
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Gonadal_preGranulosa-OSEderived_early",
-       "cell_count": 6659,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Ovary",
@@ -21734,6 +21289,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Gonad",
@@ -21764,6 +21320,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Gonad",
@@ -21794,6 +21351,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -21814,6 +21372,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -21829,6 +21388,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "10",
@@ -22189,18 +21749,9 @@
     "WNT4"
    ],
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Gonadal_preGranulosa-OSEderived_late",
-       "cell_count": 50633,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Ovary",
@@ -22216,6 +21767,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Gonad_and_extragonadal",
@@ -22271,6 +21823,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Gonad_and_extragonadal",
@@ -22326,6 +21879,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -22346,6 +21900,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -22361,6 +21916,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "10",
@@ -22899,18 +22455,9 @@
     "FSHR"
    ],
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Granulosa_AMHneg_Atretic",
-       "cell_count": 2960,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Ovarian Cortex",
@@ -22936,6 +22483,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Cortex_outer",
@@ -22981,6 +22529,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "unknown",
@@ -23001,6 +22550,7 @@
     },
     "Developmental_stage": {
      "author_field_name": "Developmental_stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "paediatric",
@@ -23026,6 +22576,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "5",
@@ -23146,6 +22697,7 @@
     },
     "Tanner Stage": {
      "author_field_name": "Tanner Stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Pubic I/Genitals-Breast I",
@@ -23181,6 +22733,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Paediatric",
@@ -23201,6 +22754,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "Supratentorial ependymoma WHO Grade II",
@@ -23346,6 +22900,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Supratentorial ependymoma WHO Grade II",
@@ -23577,18 +23132,9 @@
     "FSHR"
    ],
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Granulosa_AMHneg_Squamous",
-       "cell_count": 5644,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Ovarian Cortex",
@@ -23614,6 +23160,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Cortex_outer",
@@ -23644,6 +23191,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "unknown",
@@ -23664,6 +23212,7 @@
     },
     "Developmental_stage": {
      "author_field_name": "Developmental_stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "paediatric",
@@ -23689,6 +23238,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "5",
@@ -23804,6 +23354,7 @@
     },
     "Tanner Stage": {
      "author_field_name": "Tanner Stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Pubic I/Genitals-Breast I",
@@ -23839,6 +23390,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Paediatric",
@@ -23859,6 +23411,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "Supratentorial ependymoma WHO Grade II",
@@ -24004,6 +23557,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Supratentorial ependymoma WHO Grade II",
@@ -24239,28 +23793,9 @@
     "COL2A1"
    ],
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Granulosa_AMHpos_Atretic",
-       "cell_count": 5440,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Granulosa_AMHpos_Atretic",
-       "cell_count": 5440,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Ovarian Cortex",
@@ -24286,6 +23821,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Antral_follicle",
@@ -24326,6 +23862,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "unknown",
@@ -24346,6 +23883,7 @@
     },
     "Developmental_stage": {
      "author_field_name": "Developmental_stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "paediatric",
@@ -24371,6 +23909,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "31",
@@ -24491,6 +24030,7 @@
     },
     "Tanner Stage": {
      "author_field_name": "Tanner Stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Pubic I/Genitals-Breast I",
@@ -24526,6 +24066,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Paediatric",
@@ -24546,6 +24087,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "Stroke",
@@ -24691,6 +24233,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Stroke",
@@ -24953,28 +24496,9 @@
     "COL2A1"
    ],
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Granulosa_AMHpos_Cyc",
-       "cell_count": 8927,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Granulosa_AMHpos_Cyc",
-       "cell_count": 8927,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Ovarian Cortex",
@@ -25000,6 +24524,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Follicle_Inner_cortex",
@@ -25045,6 +24570,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "unknown",
@@ -25065,6 +24591,7 @@
     },
     "Developmental_stage": {
      "author_field_name": "Developmental_stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "paediatric",
@@ -25090,6 +24617,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "2",
@@ -25205,6 +24733,7 @@
     },
     "Tanner Stage": {
      "author_field_name": "Tanner Stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Pubic I/Genitals-Breast I",
@@ -25235,6 +24764,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Paediatric",
@@ -25255,6 +24785,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "Sickle Cell Disease",
@@ -25375,6 +24906,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Sickle Cell Disease",
@@ -25587,18 +25119,9 @@
    "cell_ontology_term_id": "CL:0000501",
    "cell_ontology_term": "granulosa cell",
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Granulosa_AMHpos_Steroidogenic",
-       "cell_count": 15814,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Ovarian Cortex",
@@ -25624,6 +25147,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Follicle",
@@ -25669,6 +25193,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "unknown",
@@ -25689,6 +25214,7 @@
     },
     "Developmental_stage": {
      "author_field_name": "Developmental_stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "paediatric",
@@ -25714,6 +25240,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "2",
@@ -25849,6 +25376,7 @@
     },
     "Tanner Stage": {
      "author_field_name": "Tanner Stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Pubic I/Genitals-Breast I",
@@ -25884,6 +25412,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Paediatric",
@@ -25904,6 +25433,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "Sickle Cell Disease",
@@ -26039,6 +25569,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Sickle Cell Disease",
@@ -26282,18 +25813,9 @@
    "cell_ontology_term_id": "CL:0000501",
    "cell_ontology_term": "granulosa cell",
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Granulosa_AMHpos_nonSteroidogenic",
-       "cell_count": 694,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Ovarian Cortex",
@@ -26314,6 +25836,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Cortex_outer",
@@ -26339,6 +25862,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "unknown",
@@ -26359,6 +25883,7 @@
     },
     "Developmental_stage": {
      "author_field_name": "Developmental_stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "paediatric",
@@ -26384,6 +25909,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "7",
@@ -26504,6 +26030,7 @@
     },
     "Tanner Stage": {
      "author_field_name": "Tanner Stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Pubic I/Genitals-Breast I",
@@ -26534,6 +26061,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Paediatric",
@@ -26549,6 +26077,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "Beta Thalassaemia",
@@ -26669,6 +26198,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Beta Thalassaemia",
@@ -26865,18 +26395,9 @@
    "cell_ontology_term_id": "CL:0000501",
    "cell_ontology_term": "granulosa cell",
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Granulosa_AMHpos_nonSteroidogenic_early",
-       "cell_count": 1267,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Ovarian Cortex",
@@ -26902,6 +26423,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Cortex_outer",
@@ -26932,6 +26454,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "unknown",
@@ -26952,6 +26475,7 @@
     },
     "Developmental_stage": {
      "author_field_name": "Developmental_stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "paediatric",
@@ -26977,6 +26501,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "5",
@@ -27097,6 +26622,7 @@
     },
     "Tanner Stage": {
      "author_field_name": "Tanner Stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Pubic I/Genitals-Breast I",
@@ -27132,6 +26658,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Paediatric",
@@ -27152,6 +26679,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "Supratentorial ependymoma WHO Grade II",
@@ -27297,6 +26825,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Supratentorial ependymoma WHO Grade II",
@@ -27528,28 +27057,9 @@
     "FSHR"
    ],
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Granulosa_sq_Fetal",
-       "cell_count": 3928,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA_broad": {
-     "author_field_name": "celltype_HCA_broad",
-     "values": [
-      {
-       "author_value": "Granulosa_sq",
-       "cell_count": 3928,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Gonad_and_extragonadal",
@@ -27565,6 +27075,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Gonad_and_extragonadal",
@@ -27580,6 +27091,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -27600,6 +27112,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -27615,6 +27128,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "17",
@@ -27873,28 +27387,9 @@
     "10.1126/science.aah4573"
    ],
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Immune_ASDC",
-       "cell_count": 69,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Immune_ASDC",
-       "cell_count": 69,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Uterus",
@@ -27925,6 +27420,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Mentrual fluid",
@@ -27985,6 +27481,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Mentrual fluid",
@@ -28050,6 +27547,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -28070,6 +27568,7 @@
     },
     "Developmental_stage": {
      "author_field_name": "Developmental_stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Adult",
@@ -28090,6 +27589,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "37",
@@ -28190,6 +27690,7 @@
     },
     "Tanner Stage": {
      "author_field_name": "Tanner Stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Pubic V/Genitals-Breast V",
@@ -28210,6 +27711,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -28225,6 +27727,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Menstrual",
@@ -28280,6 +27783,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "control",
@@ -28325,6 +27829,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -28375,6 +27880,7 @@
     },
     "Observed_pathology": {
      "author_field_name": "Observed_pathology",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -28400,6 +27906,7 @@
     },
     "Sampled_site_condition": {
      "author_field_name": "Sampled_site_condition",
+     "category": "disease",
      "values": [
       {
        "author_value": "normal",
@@ -28464,28 +27971,9 @@
     "KIT"
    ],
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Immune_BasoEosino",
-       "cell_count": 40,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Immune_BasoEosino",
-       "cell_count": 40,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Uterus",
@@ -28511,6 +27999,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Endometrium",
@@ -28556,6 +28045,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Superficial_Endometrium",
@@ -28606,6 +28096,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -28621,6 +28112,7 @@
     },
     "Developmental_stage": {
      "author_field_name": "Developmental_stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Adult",
@@ -28636,6 +28128,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "42",
@@ -28686,6 +28179,7 @@
     },
     "Tanner Stage": {
      "author_field_name": "Tanner Stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Pubic V/Genitals-Breast V",
@@ -28701,6 +28195,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -28721,6 +28216,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Proliferative",
@@ -28756,6 +28252,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "control",
@@ -28776,6 +28273,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -28796,6 +28294,7 @@
     },
     "Observed_pathology": {
      "author_field_name": "Observed_pathology",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -28816,6 +28315,7 @@
     },
     "Sampled_site_condition": {
      "author_field_name": "Sampled_site_condition",
+     "category": "disease",
      "values": [
       {
        "author_value": "normal",
@@ -28879,28 +28379,9 @@
     "SELL"
    ],
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Immune_CD4_NaiveT",
-       "cell_count": 6169,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Immune_CD4_NaiveT",
-       "cell_count": 6169,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Uterus",
@@ -28941,6 +28422,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Mentrual fluid",
@@ -29061,6 +28543,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Mentrual fluid",
@@ -29201,6 +28684,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -29226,6 +28710,7 @@
     },
     "Developmental_stage": {
      "author_field_name": "Developmental_stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Adult",
@@ -29251,6 +28736,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "27",
@@ -29491,6 +28977,7 @@
     },
     "Tanner Stage": {
      "author_field_name": "Tanner Stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Pubic V/Genitals-Breast V",
@@ -29521,6 +29008,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -29576,6 +29064,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Menstrual",
@@ -29656,6 +29145,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "Hypothyroidism",
@@ -29776,6 +29266,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Hypothyroidism",
@@ -29921,6 +29412,7 @@
     },
     "Observed_pathology": {
      "author_field_name": "Observed_pathology",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -29956,6 +29448,7 @@
     },
     "Sampled_site_condition": {
      "author_field_name": "Sampled_site_condition",
+     "category": "disease",
      "values": [
       {
        "author_value": "normal",
@@ -30093,28 +29586,9 @@
     "CD4"
    ],
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Immune_CD4_T_Unpolarised",
-       "cell_count": 13177,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Immune_CD4_T_Unpolarised",
-       "cell_count": 13177,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Uterus",
@@ -30150,6 +29624,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Endometrium",
@@ -30250,6 +29725,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Endometrium",
@@ -30375,6 +29851,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -30400,6 +29877,7 @@
     },
     "Developmental_stage": {
      "author_field_name": "Developmental_stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Adult",
@@ -30430,6 +29908,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "32",
@@ -30715,6 +30194,7 @@
     },
     "Tanner Stage": {
      "author_field_name": "Tanner Stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Pubic V/Genitals-Breast V",
@@ -30750,6 +30230,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -30790,6 +30271,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Proliferative",
@@ -30870,6 +30352,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "control",
@@ -31055,6 +30538,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -31265,6 +30749,7 @@
     },
     "Observed_pathology": {
      "author_field_name": "Observed_pathology",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -31305,6 +30790,7 @@
     },
     "Sampled_site_condition": {
      "author_field_name": "Sampled_site_condition",
+     "category": "disease",
      "values": [
       {
        "author_value": "normal",
@@ -31549,28 +31035,9 @@
     "CCR4"
    ],
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Immune_CD4_Th17",
-       "cell_count": 6802,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Immune_CD4_Th17",
-       "cell_count": 6802,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Fallopian Tube",
@@ -31601,6 +31068,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Fallopian Tube Ampulla",
@@ -31691,6 +31159,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Fallopian Tube Ampulla",
@@ -31806,6 +31275,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -31831,6 +31301,7 @@
     },
     "Developmental_stage": {
      "author_field_name": "Developmental_stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Adult",
@@ -31861,6 +31332,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "31",
@@ -32111,6 +31583,7 @@
     },
     "Tanner Stage": {
      "author_field_name": "Tanner Stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Pubic V/Genitals-Breast V",
@@ -32146,6 +31619,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -32176,6 +31650,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Secretory",
@@ -32256,6 +31731,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "control",
@@ -32411,6 +31887,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -32591,6 +32068,7 @@
     },
     "Observed_pathology": {
      "author_field_name": "Observed_pathology",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -32631,6 +32109,7 @@
     },
     "Sampled_site_condition": {
      "author_field_name": "Sampled_site_condition",
+     "category": "disease",
      "values": [
       {
        "author_value": "normal",
@@ -32801,28 +32280,9 @@
    ],
    "comment": "media-4 description: Express Th17 markers, but also markers of both naive and memory T cells, which is consistent with a TSCM phenotype (Wang et al., 2021). Contains a small IL22+ subset. | UNRESOLVED citation(s) ['Wang et al., 2021']: no verified DOI found.",
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Immune_CD4_Th17_SCMlike",
-       "cell_count": 5130,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Immune_CD4_Th17_SCMlike",
-       "cell_count": 5130,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Uterus",
@@ -32858,6 +32318,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Mentrual fluid",
@@ -32963,6 +32424,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Mentrual fluid",
@@ -33093,6 +32555,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -33113,6 +32576,7 @@
     },
     "Developmental_stage": {
      "author_field_name": "Developmental_stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Adult",
@@ -33138,6 +32602,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "27",
@@ -33373,6 +32838,7 @@
     },
     "Tanner Stage": {
      "author_field_name": "Tanner Stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Pubic V/Genitals-Breast V",
@@ -33403,6 +32869,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -33448,6 +32915,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Menstrual",
@@ -33528,6 +32996,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "Hypothyroidism",
@@ -33638,6 +33107,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Hypothyroidism",
@@ -33773,6 +33243,7 @@
     },
     "Observed_pathology": {
      "author_field_name": "Observed_pathology",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -33808,6 +33279,7 @@
     },
     "Sampled_site_condition": {
      "author_field_name": "Sampled_site_condition",
+     "category": "disease",
      "values": [
       {
        "author_value": "normal",
@@ -33967,28 +33439,9 @@
     "RTKN2"
    ],
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Immune_CD4_Treg",
-       "cell_count": 3695,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Immune_CD4_Treg",
-       "cell_count": 3695,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Uterus",
@@ -34024,6 +33477,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Endometrium",
@@ -34114,6 +33568,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Endometrium",
@@ -34214,6 +33669,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -34239,6 +33695,7 @@
     },
     "Developmental_stage": {
      "author_field_name": "Developmental_stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Adult",
@@ -34264,6 +33721,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "35-65",
@@ -34479,6 +33937,7 @@
     },
     "Tanner Stage": {
      "author_field_name": "Tanner Stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Pubic V/Genitals-Breast V",
@@ -34499,6 +33958,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -34539,6 +33999,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Proliferative",
@@ -34619,6 +34080,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "control",
@@ -34709,6 +34171,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -34824,6 +34287,7 @@
     },
     "Observed_pathology": {
      "author_field_name": "Observed_pathology",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -34864,6 +34328,7 @@
     },
     "Sampled_site_condition": {
      "author_field_name": "Sampled_site_condition",
+     "category": "disease",
      "values": [
       {
        "author_value": "normal",
@@ -35031,28 +34496,9 @@
     "FOXP3"
    ],
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Immune_CD4_Treg_Cyc",
-       "cell_count": 114,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Immune_CD4_Treg_Cyc",
-       "cell_count": 114,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Uterus",
@@ -35083,6 +34529,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Endometrium",
@@ -35133,6 +34580,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Endometrium",
@@ -35188,6 +34636,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "unknown",
@@ -35208,6 +34657,7 @@
     },
     "Developmental_stage": {
      "author_field_name": "Developmental_stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Adult",
@@ -35223,6 +34673,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "33",
@@ -35333,6 +34784,7 @@
     },
     "Tanner Stage": {
      "author_field_name": "Tanner Stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Pubic V/Genitals-Breast V",
@@ -35348,6 +34800,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -35363,6 +34816,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Proliferative",
@@ -35428,6 +34882,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "control",
@@ -35468,6 +34923,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -35518,6 +34974,7 @@
     },
     "Observed_pathology": {
      "author_field_name": "Observed_pathology",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -35548,6 +35005,7 @@
     },
     "Sampled_site_condition": {
      "author_field_name": "Sampled_site_condition",
+     "category": "disease",
      "values": [
       {
        "author_value": "normal",
@@ -35643,28 +35101,9 @@
     "SELL"
    ],
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Immune_CD8_NaiveT",
-       "cell_count": 2551,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Immune_CD8_NaiveT",
-       "cell_count": 2551,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Uterus",
@@ -35705,6 +35144,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Mentrual fluid",
@@ -35815,6 +35255,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Mentrual fluid",
@@ -35930,6 +35371,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -35950,6 +35392,7 @@
     },
     "Developmental_stage": {
      "author_field_name": "Developmental_stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Adult",
@@ -35975,6 +35418,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "27",
@@ -36175,6 +35619,7 @@
     },
     "Tanner Stage": {
      "author_field_name": "Tanner Stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Pubic V/Genitals-Breast V",
@@ -36205,6 +35650,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -36255,6 +35701,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Menstrual",
@@ -36340,6 +35787,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "Unknown",
@@ -36425,6 +35873,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Unknown",
@@ -36525,6 +35974,7 @@
     },
     "Observed_pathology": {
      "author_field_name": "Observed_pathology",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -36555,6 +36005,7 @@
     },
     "Sampled_site_condition": {
      "author_field_name": "Sampled_site_condition",
+     "category": "disease",
      "values": [
       {
        "author_value": "Unknown",
@@ -36738,28 +36189,9 @@
    ],
    "comment": "media-4 description: CX3CR1, KLRG1, GZMB, and perforin expression is consistent with a TEMRA phenotype, poised for rapid cytolytic activity (Masopust et al., 2026). Contains a subset that is enriched in menstural fluid and is SELL+ - this might be more central memory-like. | UNRESOLVED citation(s) ['Masopust et al., 2026']: no verified DOI found.",
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Immune_CD8_T_EM",
-       "cell_count": 4022,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Immune_CD8_T_EM",
-       "cell_count": 4022,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Uterus",
@@ -36795,6 +36227,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Endometrium",
@@ -36875,6 +36308,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Mentrual fluid",
@@ -36985,6 +36419,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -37010,6 +36445,7 @@
     },
     "Developmental_stage": {
      "author_field_name": "Developmental_stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Adult",
@@ -37040,6 +36476,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "37",
@@ -37300,6 +36737,7 @@
     },
     "Tanner Stage": {
      "author_field_name": "Tanner Stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Pubic V/Genitals-Breast V",
@@ -37330,6 +36768,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -37355,6 +36794,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Menstrual",
@@ -37435,6 +36875,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "control",
@@ -37565,6 +37006,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -37715,6 +37157,7 @@
     },
     "Observed_pathology": {
      "author_field_name": "Observed_pathology",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -37750,6 +37193,7 @@
     },
     "Sampled_site_condition": {
      "author_field_name": "Sampled_site_condition",
+     "category": "disease",
      "values": [
       {
        "author_value": "normal",
@@ -37915,28 +37359,9 @@
    ],
    "comment": "media-4 description: A portion of this cluster expresses GZMB, but not GZMK.",
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Immune_CD8_T_RM",
-       "cell_count": 15131,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Immune_CD8_T_RM",
-       "cell_count": 15131,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Fallopian Tube",
@@ -37972,6 +37397,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Fallopian Tube Ampulla",
@@ -38062,6 +37488,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Fallopian Tube Ampulla",
@@ -38177,6 +37604,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -38197,6 +37625,7 @@
     },
     "Developmental_stage": {
      "author_field_name": "Developmental_stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Adult",
@@ -38227,6 +37656,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Unknown",
@@ -38462,6 +37892,7 @@
     },
     "Tanner Stage": {
      "author_field_name": "Tanner Stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Pubic V/Genitals-Breast V",
@@ -38497,6 +37928,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -38517,6 +37949,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Unknown",
@@ -38602,6 +38035,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "control",
@@ -38737,6 +38171,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -38897,6 +38332,7 @@
     },
     "Observed_pathology": {
      "author_field_name": "Observed_pathology",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -38937,6 +38373,7 @@
     },
     "Sampled_site_condition": {
      "author_field_name": "Sampled_site_condition",
+     "category": "disease",
      "values": [
       {
        "author_value": "normal",
@@ -39152,28 +38589,9 @@
    ],
    "comment": "media-4 description: Downregulates canonical tissue-resident memory markers relative to CD8_T_RM cluster. Expresses GZMK, but not GZMB.",
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Immune_CD8_T_RM_GZMKhi",
-       "cell_count": 25502,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Immune_CD8_T_RM_GZMKhi",
-       "cell_count": 25502,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Uterus",
@@ -39209,6 +38627,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Endometrium",
@@ -39309,6 +38728,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Endometrium",
@@ -39434,6 +38854,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -39459,6 +38880,7 @@
     },
     "Developmental_stage": {
      "author_field_name": "Developmental_stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Adult",
@@ -39489,6 +38911,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "24",
@@ -39764,6 +39187,7 @@
     },
     "Tanner Stage": {
      "author_field_name": "Tanner Stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Pubic V/Genitals-Breast V",
@@ -39804,6 +39228,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -39864,6 +39289,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Proliferative",
@@ -39949,6 +39375,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "control",
@@ -40129,6 +39556,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -40334,6 +39762,7 @@
     },
     "Observed_pathology": {
      "author_field_name": "Observed_pathology",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -40374,6 +39803,7 @@
     },
     "Sampled_site_condition": {
      "author_field_name": "Sampled_site_condition",
+     "category": "disease",
      "values": [
       {
        "author_value": "normal",
@@ -40649,28 +40079,9 @@
     "CD38"
    ],
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Immune_EarlyMidErythroid",
-       "cell_count": 55,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Immune_EarlyMidErythroid",
-       "cell_count": 55,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Ovary",
@@ -40686,6 +40097,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Gonad_and_extragonadal",
@@ -40716,6 +40128,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Gonad_and_extragonadal",
@@ -40746,6 +40159,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -40761,6 +40175,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "14",
@@ -40879,38 +40294,9 @@
    ],
    "comment": "media-4 description: Lack of GATA1 expression indicates that theses have not yet committed to megakaryocyte/erythroid lineage.",
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Immune_HPC",
-       "cell_count": 211,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Immune_HPC",
-       "cell_count": 211,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA_broad": {
-     "author_field_name": "celltype_HCA_broad",
-     "values": [
-      {
-       "author_value": "Immune_Haematopoietic_progenitor_cells",
-       "cell_count": 211,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Ovary",
@@ -40936,6 +40322,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Gonad_and_extragonadal",
@@ -40971,6 +40358,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Gonad_and_extragonadal",
@@ -41006,6 +40394,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Immune",
@@ -41026,6 +40415,7 @@
     },
     "Developmental_stage": {
      "author_field_name": "Developmental_stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Fetal",
@@ -41041,6 +40431,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -41071,6 +40462,7 @@
     },
     "Tanner Stage": {
      "author_field_name": "Tanner Stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -41086,6 +40478,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "14",
@@ -41181,6 +40574,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -41206,6 +40600,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "control",
@@ -41221,6 +40616,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -41236,6 +40632,7 @@
     },
     "Observed_pathology": {
      "author_field_name": "Observed_pathology",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -41251,6 +40648,7 @@
     },
     "Sampled_site_condition": {
      "author_field_name": "Sampled_site_condition",
+     "category": "disease",
      "values": [
       {
        "author_value": "normal",
@@ -41347,28 +40745,9 @@
     "CA10"
    ],
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Immune_ILC3_NCRhi",
-       "cell_count": 2517,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Immune_ILC3_NCRhi",
-       "cell_count": 2517,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Uterus",
@@ -41409,6 +40788,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Endometrium",
@@ -41529,6 +40909,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Endometrium",
@@ -41659,6 +41040,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -41679,6 +41061,7 @@
     },
     "Developmental_stage": {
      "author_field_name": "Developmental_stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Adult",
@@ -41704,6 +41087,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "31",
@@ -41914,6 +41298,7 @@
     },
     "Tanner Stage": {
      "author_field_name": "Tanner Stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Pubic V/Genitals-Breast V",
@@ -41944,6 +41329,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -42049,6 +41435,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Proliferative Early",
@@ -42129,6 +41516,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "control",
@@ -42214,6 +41602,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -42324,6 +41713,7 @@
     },
     "Observed_pathology": {
      "author_field_name": "Observed_pathology",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -42359,6 +41749,7 @@
     },
     "Sampled_site_condition": {
      "author_field_name": "Sampled_site_condition",
+     "category": "disease",
      "values": [
       {
        "author_value": "normal",
@@ -42574,28 +41965,9 @@
    ],
    "comment": "media-4 description: NCR2 expression is lower compared to ILC3_NCRhi.",
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Immune_ILC3_NCRlo",
-       "cell_count": 321,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Immune_ILC3_NCRlo",
-       "cell_count": 321,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Uterus",
@@ -42626,6 +41998,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Endometrium",
@@ -42691,6 +42064,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Endometrium",
@@ -42761,6 +42135,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -42776,6 +42151,7 @@
     },
     "Developmental_stage": {
      "author_field_name": "Developmental_stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Adult",
@@ -42791,6 +42167,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "65",
@@ -42951,6 +42328,7 @@
     },
     "Tanner Stage": {
      "author_field_name": "Tanner Stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Pubic V/Genitals-Breast V",
@@ -42966,6 +42344,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -43001,6 +42380,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Proliferative",
@@ -43076,6 +42456,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "control",
@@ -43121,6 +42502,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -43181,6 +42563,7 @@
     },
     "Observed_pathology": {
      "author_field_name": "Observed_pathology",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -43221,6 +42604,7 @@
     },
     "Sampled_site_condition": {
      "author_field_name": "Sampled_site_condition",
+     "category": "disease",
      "values": [
       {
        "author_value": "normal",
@@ -43370,28 +42754,9 @@
    ],
    "comment": "media-4 description: IKZF2 expression is lower.",
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Immune_ImmatureB",
-       "cell_count": 387,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Immune_ImmatureB",
-       "cell_count": 387,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Ovary",
@@ -43427,6 +42792,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Gonad_and_extragonadal",
@@ -43512,6 +42878,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Gonad_and_extragonadal",
@@ -43597,6 +42964,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Immune",
@@ -43617,6 +42985,7 @@
     },
     "Developmental_stage": {
      "author_field_name": "Developmental_stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Fetal",
@@ -43637,6 +43006,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -43732,6 +43102,7 @@
     },
     "Tanner Stage": {
      "author_field_name": "Tanner Stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -43752,6 +43123,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "14",
@@ -43822,6 +43194,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -43882,6 +43255,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "control",
@@ -43912,6 +43286,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -43942,6 +43317,7 @@
     },
     "Observed_pathology": {
      "author_field_name": "Observed_pathology",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -43967,6 +43343,7 @@
     },
     "Sampled_site_condition": {
      "author_field_name": "Sampled_site_condition",
+     "category": "disease",
      "values": [
       {
        "author_value": "normal",
@@ -44046,28 +43423,9 @@
    ],
    "comment": "media-4 description: DNTT, RAG1/2 expression is lower. Cycling.",
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Immune_LargePreB",
-       "cell_count": 305,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Immune_LargePreB",
-       "cell_count": 305,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Ovary",
@@ -44098,6 +43456,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Gonad_and_extragonadal",
@@ -44183,6 +43542,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Gonad_and_extragonadal",
@@ -44268,6 +43628,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Immune",
@@ -44283,6 +43644,7 @@
     },
     "Developmental_stage": {
      "author_field_name": "Developmental_stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Fetal",
@@ -44298,6 +43660,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -44323,6 +43686,7 @@
     },
     "Tanner Stage": {
      "author_field_name": "Tanner Stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -44338,6 +43702,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "14",
@@ -44453,6 +43818,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -44556,28 +43922,9 @@
    ],
    "comment": "media-4 description: Compared to EarlyMidErythroid, exhibits lower expression of GATA1, KLF1 and higher expression of BPGM.",
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Immune_LateErythroid",
-       "cell_count": 57,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Immune_LateErythroid",
-       "cell_count": 57,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Ovary",
@@ -44603,6 +43950,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Gonad_and_extragonadal",
@@ -44648,6 +43996,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Gonad_and_extragonadal",
@@ -44693,6 +44042,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Immune",
@@ -44708,6 +44058,7 @@
     },
     "Developmental_stage": {
      "author_field_name": "Developmental_stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Fetal",
@@ -44723,6 +44074,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -44748,6 +44100,7 @@
     },
     "Tanner Stage": {
      "author_field_name": "Tanner Stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -44763,6 +44116,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "14",
@@ -44828,6 +44182,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -44853,6 +44208,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "control",
@@ -44868,6 +44224,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -44969,28 +44326,9 @@
    ],
    "comment": "media-4 description: Two potential states: CA10+, GZMK-, and GZMK+, CA10-. Expresses several tissue-residency markers (ITGAE, ITGA1, CXCR6).",
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Immune_MAIT",
-       "cell_count": 3733,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Immune_MAIT",
-       "cell_count": 3733,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Fallopian Tube",
@@ -45031,6 +44369,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Fallopian Tube",
@@ -45141,6 +44480,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Fallopian Tube",
@@ -45261,6 +44601,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -45286,6 +44627,7 @@
     },
     "Developmental_stage": {
      "author_field_name": "Developmental_stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Adult",
@@ -45311,6 +44653,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "37",
@@ -45541,6 +44884,7 @@
     },
     "Tanner Stage": {
      "author_field_name": "Tanner Stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Pubic V/Genitals-Breast V",
@@ -45571,6 +44915,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -45616,6 +44961,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Unknown",
@@ -45696,6 +45042,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "control",
@@ -45821,6 +45168,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -45971,6 +45319,7 @@
     },
     "Observed_pathology": {
      "author_field_name": "Observed_pathology",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -46006,6 +45355,7 @@
     },
     "Sampled_site_condition": {
      "author_field_name": "Sampled_site_condition",
+     "category": "disease",
      "values": [
       {
        "author_value": "normal",
@@ -46190,28 +45540,9 @@
    ],
    "comment": "media-4 description: A cluster of adult HPCs, which are GATA1+, reside within this cluster, suggesting that they might be transitioning towards a megakaryocyte/erythroid fate.",
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Immune_MEMP",
-       "cell_count": 250,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Immune_MEMP",
-       "cell_count": 250,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Ovary",
@@ -46242,6 +45573,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Gonad_and_extragonadal",
@@ -46312,6 +45644,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Gonad_and_extragonadal",
@@ -46387,6 +45720,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Immune",
@@ -46402,6 +45736,7 @@
     },
     "Developmental_stage": {
      "author_field_name": "Developmental_stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Fetal",
@@ -46417,6 +45752,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -46482,6 +45818,7 @@
     },
     "Tanner Stage": {
      "author_field_name": "Tanner Stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -46497,6 +45834,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "14",
@@ -46607,6 +45945,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -46652,6 +45991,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "control",
@@ -46677,6 +46017,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -46702,6 +46043,7 @@
     },
     "Observed_pathology": {
      "author_field_name": "Observed_pathology",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -46717,6 +46059,7 @@
     },
     "Sampled_site_condition": {
      "author_field_name": "Sampled_site_condition",
+     "category": "disease",
      "values": [
       {
        "author_value": "normal",
@@ -46814,28 +46157,9 @@
     "PTP4A3"
    ],
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Immune_MO_Classical",
-       "cell_count": 13759,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Immune_MO_Classical",
-       "cell_count": 13759,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Uterus",
@@ -46876,6 +46200,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Fallopian Tube",
@@ -47026,6 +46351,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Fallopian Tube",
@@ -47211,6 +46537,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -47236,6 +46563,7 @@
     },
     "Developmental_stage": {
      "author_field_name": "Developmental_stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Adult",
@@ -47261,6 +46589,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "37",
@@ -47526,6 +46855,7 @@
     },
     "Tanner Stage": {
      "author_field_name": "Tanner Stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Pubic V/Genitals-Breast V",
@@ -47556,6 +46886,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -47701,6 +47032,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Unknown",
@@ -47786,6 +47118,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "control",
@@ -47926,6 +47259,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -48091,6 +47425,7 @@
     },
     "Observed_pathology": {
      "author_field_name": "Observed_pathology",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -48131,6 +47466,7 @@
     },
     "Sampled_site_condition": {
      "author_field_name": "Sampled_site_condition",
+     "category": "disease",
      "values": [
       {
        "author_value": "normal",
@@ -48316,28 +47652,9 @@
     "S100A12"
    ],
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Immune_MO_NonClassical",
-       "cell_count": 2122,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Immune_MO_NonClassical",
-       "cell_count": 2122,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Uterus",
@@ -48373,6 +47690,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Mentrual fluid",
@@ -48478,6 +47796,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Mentrual fluid",
@@ -48593,6 +47912,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -48613,6 +47933,7 @@
     },
     "Developmental_stage": {
      "author_field_name": "Developmental_stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Adult",
@@ -48633,6 +47954,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "37",
@@ -48848,6 +48170,7 @@
     },
     "Tanner Stage": {
      "author_field_name": "Tanner Stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Pubic V/Genitals-Breast V",
@@ -48873,6 +48196,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -48928,6 +48252,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Unknown",
@@ -49003,6 +48328,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "control",
@@ -49113,6 +48439,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -49243,6 +48570,7 @@
     },
     "Observed_pathology": {
      "author_field_name": "Observed_pathology",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -49278,6 +48606,7 @@
     },
     "Sampled_site_condition": {
      "author_field_name": "Sampled_site_condition",
+     "category": "disease",
      "values": [
       {
        "author_value": "normal",
@@ -49412,28 +48741,9 @@
     "CD68"
    ],
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Immune_Mac_Cyc",
-       "cell_count": 2560,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Immune_Mac_Cyc",
-       "cell_count": 2560,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Uterus",
@@ -49474,6 +48784,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Endometrium",
@@ -49619,6 +48930,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Endometrium",
@@ -49794,6 +49106,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -49819,6 +49132,7 @@
     },
     "Developmental_stage": {
      "author_field_name": "Developmental_stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Adult",
@@ -49844,6 +49158,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -50079,6 +49394,7 @@
     },
     "Tanner Stage": {
      "author_field_name": "Tanner Stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Pubic V/Genitals-Breast V",
@@ -50109,6 +49425,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -50259,6 +49576,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -50339,6 +49657,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "control",
@@ -50464,6 +49783,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -50614,6 +49934,7 @@
     },
     "Observed_pathology": {
      "author_field_name": "Observed_pathology",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -50654,6 +49975,7 @@
     },
     "Sampled_site_condition": {
      "author_field_name": "Sampled_site_condition",
+     "category": "disease",
      "values": [
       {
        "author_value": "normal",
@@ -50818,28 +50140,9 @@
     "SELENOP"
    ],
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Immune_Mac_LYVE1hi",
-       "cell_count": 16783,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Immune_Mac_LYVE1hi",
-       "cell_count": 16783,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Fallopian Tube",
@@ -50880,6 +50183,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Gonad_and_extragonadal",
@@ -51035,6 +50339,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Gonad_and_extragonadal",
@@ -51225,6 +50530,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -51250,6 +50556,7 @@
     },
     "Developmental_stage": {
      "author_field_name": "Developmental_stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Adult",
@@ -51280,6 +50587,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -51565,6 +50873,7 @@
     },
     "Tanner Stage": {
      "author_field_name": "Tanner Stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Pubic V/Genitals-Breast V",
@@ -51605,6 +50914,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -51755,6 +51065,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -51840,6 +51151,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "control",
@@ -52025,6 +51337,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -52235,6 +51548,7 @@
     },
     "Observed_pathology": {
      "author_field_name": "Observed_pathology",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -52275,6 +51589,7 @@
     },
     "Sampled_site_condition": {
      "author_field_name": "Sampled_site_condition",
+     "category": "disease",
      "values": [
       {
        "author_value": "normal",
@@ -52503,28 +51818,9 @@
    ],
    "comment": "media-4 description: Heterogeneous population lacking specific markers.",
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Immune_Mac_Transitional",
-       "cell_count": 1787,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Immune_Mac_Transitional",
-       "cell_count": 1787,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Uterus",
@@ -52560,6 +51856,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Endometrium",
@@ -52670,6 +51967,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Endometrium",
@@ -52800,6 +52098,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -52820,6 +52119,7 @@
     },
     "Developmental_stage": {
      "author_field_name": "Developmental_stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Adult",
@@ -52840,6 +52140,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -53070,6 +52371,7 @@
     },
     "Tanner Stage": {
      "author_field_name": "Tanner Stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Pubic V/Genitals-Breast V",
@@ -53100,6 +52402,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -53235,6 +52538,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -53315,6 +52619,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "control",
@@ -53435,6 +52740,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -53580,6 +52886,7 @@
     },
     "Observed_pathology": {
      "author_field_name": "Observed_pathology",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -53615,6 +52922,7 @@
     },
     "Sampled_site_condition": {
      "author_field_name": "Sampled_site_condition",
+     "category": "disease",
      "values": [
       {
        "author_value": "normal",
@@ -53787,28 +53095,9 @@
     "KIT"
    ],
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Immune_Mast",
-       "cell_count": 5449,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Immune_Mast",
-       "cell_count": 5449,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Fallopian Tube",
@@ -53844,6 +53133,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Endometrium",
@@ -53959,6 +53249,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Endometrium",
@@ -54094,6 +53385,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -54114,6 +53406,7 @@
     },
     "Developmental_stage": {
      "author_field_name": "Developmental_stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Adult",
@@ -54144,6 +53437,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "30",
@@ -54354,6 +53648,7 @@
     },
     "Tanner Stage": {
      "author_field_name": "Tanner Stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Pubic V/Genitals-Breast V",
@@ -54379,6 +53674,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -54479,6 +53775,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Unknown",
@@ -54554,6 +53851,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "control",
@@ -54634,6 +53932,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -54734,6 +54033,7 @@
     },
     "Observed_pathology": {
      "author_field_name": "Observed_pathology",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -54774,6 +54074,7 @@
     },
     "Sampled_site_condition": {
      "author_field_name": "Sampled_site_condition",
+     "category": "disease",
      "values": [
       {
        "author_value": "normal",
@@ -55033,28 +54334,9 @@
     "IGHD"
    ],
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Immune_MemoryB",
-       "cell_count": 4542,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Immune_MemoryB",
-       "cell_count": 4542,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Uterus",
@@ -55095,6 +54377,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Mentrual fluid",
@@ -55185,6 +54468,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Mentrual fluid",
@@ -55305,6 +54589,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -55325,6 +54610,7 @@
     },
     "Developmental_stage": {
      "author_field_name": "Developmental_stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Adult",
@@ -55350,6 +54636,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "55",
@@ -55575,6 +54862,7 @@
     },
     "Tanner Stage": {
      "author_field_name": "Tanner Stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Pubic V/Genitals-Breast V",
@@ -55605,6 +54893,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -55640,6 +54929,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Menstrual",
@@ -55715,6 +55005,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "control",
@@ -55815,6 +55106,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -55940,6 +55232,7 @@
     },
     "Observed_pathology": {
      "author_field_name": "Observed_pathology",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -55980,6 +55273,7 @@
     },
     "Sampled_site_condition": {
      "author_field_name": "Sampled_site_condition",
+     "category": "disease",
      "values": [
       {
        "author_value": "normal",
@@ -56160,28 +55454,9 @@
    ],
    "comment": "media-4 description: Expresses several tissue-residency markers (ITGAE, ITGA1, CXCR6).",
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Immune_NKT_γδT_Vδ1",
-       "cell_count": 2836,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Immune_NKT_γδT_Vδ1",
-       "cell_count": 2836,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Fallopian Tube",
@@ -56217,6 +55492,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Endometrium",
@@ -56302,6 +55578,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Endometrium",
@@ -56407,6 +55684,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -56432,6 +55710,7 @@
     },
     "Developmental_stage": {
      "author_field_name": "Developmental_stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Adult",
@@ -56462,6 +55741,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "37",
@@ -56707,6 +55987,7 @@
     },
     "Tanner Stage": {
      "author_field_name": "Tanner Stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Pubic V/Genitals-Breast V",
@@ -56737,6 +56018,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -56772,6 +56054,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Unknown",
@@ -56852,6 +56135,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "control",
@@ -56967,6 +56251,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -57102,6 +56387,7 @@
     },
     "Observed_pathology": {
      "author_field_name": "Observed_pathology",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -57137,6 +56423,7 @@
     },
     "Sampled_site_condition": {
      "author_field_name": "Sampled_site_condition",
+     "category": "disease",
      "values": [
       {
        "author_value": "normal",
@@ -57291,28 +56578,9 @@
    ],
    "comment": "media-4 description: CD56 expression is low.",
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Immune_NK_CD16hi",
-       "cell_count": 5175,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Immune_NK_CD16hi",
-       "cell_count": 5175,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Uterus",
@@ -57348,6 +56616,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Endometrium",
@@ -57468,6 +56737,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Endometrium",
@@ -57618,6 +56888,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -57643,6 +56914,7 @@
     },
     "Developmental_stage": {
      "author_field_name": "Developmental_stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Adult",
@@ -57673,6 +56945,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "37",
@@ -57933,6 +57206,7 @@
     },
     "Tanner Stage": {
      "author_field_name": "Tanner Stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Pubic V/Genitals-Breast V",
@@ -57963,6 +57237,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -58053,6 +57328,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Menstrual",
@@ -58138,6 +57414,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "control",
@@ -58288,6 +57565,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -58463,6 +57741,7 @@
     },
     "Observed_pathology": {
      "author_field_name": "Observed_pathology",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -58503,6 +57782,7 @@
     },
     "Sampled_site_condition": {
      "author_field_name": "Sampled_site_condition",
+     "category": "disease",
      "values": [
       {
        "author_value": "normal",
@@ -58672,28 +57952,9 @@
    ],
    "comment": "media-4 description: Both CD56 and CD16 expression are low. High SELL and IL7R expression compared to the other NK subsets suggests this is a more progenitor-like state.",
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Immune_NK_CD56dim_CD16dim_SPTSSBhi",
-       "cell_count": 480,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Immune_NK_CD56dim_CD16dim_SPTSSBhi",
-       "cell_count": 480,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Uterus",
@@ -58724,6 +57985,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Mentrual fluid",
@@ -58779,6 +58041,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Mentrual fluid",
@@ -58844,6 +58107,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -58864,6 +58128,7 @@
     },
     "Developmental_stage": {
      "author_field_name": "Developmental_stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Adult",
@@ -58879,6 +58144,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "27",
@@ -59019,6 +58285,7 @@
     },
     "Tanner Stage": {
      "author_field_name": "Tanner Stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Pubic V/Genitals-Breast V",
@@ -59034,6 +58301,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -59054,6 +58322,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Menstrual",
@@ -59119,6 +58388,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "Hypothyroidism",
@@ -59159,6 +58429,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Hypothyroidism",
@@ -59209,6 +58480,7 @@
     },
     "Observed_pathology": {
      "author_field_name": "Observed_pathology",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -59239,6 +58511,7 @@
     },
     "Sampled_site_condition": {
      "author_field_name": "Sampled_site_condition",
+     "category": "disease",
      "values": [
       {
        "author_value": "normal",
@@ -59326,28 +58599,9 @@
     "CD3D"
    ],
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Immune_NK_Cyc",
-       "cell_count": 3503,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Immune_NK_Cyc",
-       "cell_count": 3503,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Uterus",
@@ -59388,6 +58642,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Endometrium",
@@ -59498,6 +58753,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Endometrium",
@@ -59623,6 +58879,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -59643,6 +58900,7 @@
     },
     "Developmental_stage": {
      "author_field_name": "Developmental_stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Adult",
@@ -59663,6 +58921,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "26",
@@ -59863,6 +59122,7 @@
     },
     "Tanner Stage": {
      "author_field_name": "Tanner Stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Pubic V/Genitals-Breast V",
@@ -59883,6 +59143,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -59993,6 +59254,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Secretory",
@@ -60073,6 +59335,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "control",
@@ -60158,6 +59421,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -60268,6 +59532,7 @@
     },
     "Observed_pathology": {
      "author_field_name": "Observed_pathology",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -60308,6 +59573,7 @@
     },
     "Sampled_site_condition": {
      "author_field_name": "Sampled_site_condition",
+     "category": "disease",
      "values": [
       {
        "author_value": "normal",
@@ -60520,28 +59786,9 @@
    ],
    "comment": "media-4 description: MS4A3, MPO expression are suggestive of NMP. PRTN3, ELANE, and CTSG expression suggest promyelocyte.",
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Immune_NMP_Promyelocytes",
-       "cell_count": 286,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Immune_NMP_Promyelocytes",
-       "cell_count": 286,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Ovary",
@@ -60572,6 +59819,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Gonad_and_extragonadal",
@@ -60652,6 +59900,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Gonad_and_extragonadal",
@@ -60737,6 +59986,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Immune",
@@ -60757,6 +60007,7 @@
     },
     "Developmental_stage": {
      "author_field_name": "Developmental_stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Fetal",
@@ -60777,6 +60028,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -60817,6 +60069,7 @@
     },
     "Tanner Stage": {
      "author_field_name": "Tanner Stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -60837,6 +60090,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "14",
@@ -60952,6 +60206,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -60982,6 +60237,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "control",
@@ -61012,6 +60268,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -61042,6 +60299,7 @@
     },
     "Observed_pathology": {
      "author_field_name": "Observed_pathology",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -61067,6 +60325,7 @@
     },
     "Sampled_site_condition": {
      "author_field_name": "Sampled_site_condition",
+     "category": "disease",
      "values": [
       {
        "author_value": "normal",
@@ -61149,28 +60408,9 @@
     "FCRL1"
    ],
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Immune_NaiveB",
-       "cell_count": 2076,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Immune_NaiveB",
-       "cell_count": 2076,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Uterus",
@@ -61206,6 +60446,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Mentrual fluid",
@@ -61301,6 +60542,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Mentrual fluid",
@@ -61396,6 +60638,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -61416,6 +60659,7 @@
     },
     "Developmental_stage": {
      "author_field_name": "Developmental_stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Adult",
@@ -61441,6 +60685,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "27",
@@ -61641,6 +60886,7 @@
     },
     "Tanner Stage": {
      "author_field_name": "Tanner Stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Pubic V/Genitals-Breast V",
@@ -61676,6 +60922,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -61726,6 +60973,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Menstrual",
@@ -61801,6 +61049,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "Hypothyroidism",
@@ -61886,6 +61135,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Hypothyroidism",
@@ -61991,6 +61241,7 @@
     },
     "Observed_pathology": {
      "author_field_name": "Observed_pathology",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -62026,6 +61277,7 @@
     },
     "Sampled_site_condition": {
      "author_field_name": "Sampled_site_condition",
+     "category": "disease",
      "values": [
       {
        "author_value": "normal",
@@ -62165,28 +61417,9 @@
     "MME"
    ],
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Immune_Neutrophils",
-       "cell_count": 45,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Immune_Neutrophils",
-       "cell_count": 45,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Fallopian Tube",
@@ -62212,6 +61445,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "cervix",
@@ -62257,6 +61491,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "unknown",
@@ -62307,6 +61542,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "35-65",
@@ -62362,6 +61598,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Unknown",
@@ -62397,6 +61634,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "control",
@@ -62417,6 +61655,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -62437,6 +61676,7 @@
     },
     "Observed_pathology": {
      "author_field_name": "Observed_pathology",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -62457,6 +61697,7 @@
     },
     "Sampled_site_condition": {
      "author_field_name": "Sampled_site_condition",
+     "category": "disease",
      "values": [
       {
        "author_value": "normal",
@@ -62529,28 +61770,9 @@
     "IGHA2"
    ],
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Immune_Plasma_κ",
-       "cell_count": 2314,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Immune_Plasma_κ",
-       "cell_count": 2314,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Fallopian Tube",
@@ -62581,6 +61803,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Fallopian Tube Ampulla",
@@ -62656,6 +61879,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Fallopian Tube Ampulla",
@@ -62746,6 +61970,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -62761,6 +61986,7 @@
     },
     "Developmental_stage": {
      "author_field_name": "Developmental_stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Adult",
@@ -62776,6 +62002,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "43",
@@ -62961,6 +62188,7 @@
     },
     "Tanner Stage": {
      "author_field_name": "Tanner Stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Pubic V/Genitals-Breast V",
@@ -62976,6 +62204,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Proliferative",
@@ -63046,6 +62275,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "control",
@@ -63111,6 +62341,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -63196,6 +62427,7 @@
     },
     "Observed_pathology": {
      "author_field_name": "Observed_pathology",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -63231,6 +62463,7 @@
     },
     "Sampled_site_condition": {
      "author_field_name": "Sampled_site_condition",
+     "category": "disease",
      "values": [
       {
        "author_value": "normal",
@@ -63387,28 +62620,9 @@
     "IGHA2"
    ],
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Immune_Plasma_λ",
-       "cell_count": 1782,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Immune_Plasma_λ",
-       "cell_count": 1782,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Fallopian Tube",
@@ -63439,6 +62653,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "cervix",
@@ -63514,6 +62729,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "unknown",
@@ -63604,6 +62820,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -63619,6 +62836,7 @@
     },
     "Developmental_stage": {
      "author_field_name": "Developmental_stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Adult",
@@ -63634,6 +62852,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "35-65",
@@ -63799,6 +63018,7 @@
     },
     "Tanner Stage": {
      "author_field_name": "Tanner Stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Pubic V/Genitals-Breast V",
@@ -63814,6 +63034,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Unknown",
@@ -63869,6 +63090,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "control",
@@ -63929,6 +63151,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -64009,6 +63232,7 @@
     },
     "Observed_pathology": {
      "author_field_name": "Observed_pathology",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -64039,6 +63263,7 @@
     },
     "Sampled_site_condition": {
      "author_field_name": "Sampled_site_condition",
+     "category": "disease",
      "values": [
       {
        "author_value": "normal",
@@ -64178,28 +63403,9 @@
    ],
    "comment": "media-4 description: Contains both early and late pro-B cells.",
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Immune_ProB",
-       "cell_count": 167,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Immune_ProB",
-       "cell_count": 167,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Ovary",
@@ -64225,6 +63431,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Gonad_and_extragonadal",
@@ -64290,6 +63497,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Gonad_and_extragonadal",
@@ -64355,6 +63563,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Immune",
@@ -64375,6 +63584,7 @@
     },
     "Developmental_stage": {
      "author_field_name": "Developmental_stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Fetal",
@@ -64390,6 +63600,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -64425,6 +63636,7 @@
     },
     "Tanner Stage": {
      "author_field_name": "Tanner Stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -64440,6 +63652,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "14",
@@ -64510,6 +63723,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -64600,28 +63814,9 @@
    ],
    "comment": "media-4 description: LEF1 expression is lower.",
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Immune_SmallPreB",
-       "cell_count": 281,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Immune_SmallPreB",
-       "cell_count": 281,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Ovary",
@@ -64647,6 +63842,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Gonad_and_extragonadal",
@@ -64707,6 +63903,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Gonad_and_extragonadal",
@@ -64767,6 +63964,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Immune",
@@ -64782,6 +63980,7 @@
     },
     "Developmental_stage": {
      "author_field_name": "Developmental_stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Fetal",
@@ -64797,6 +63996,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -64822,6 +64022,7 @@
     },
     "Tanner Stage": {
      "author_field_name": "Tanner Stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -64837,6 +64038,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "14",
@@ -64907,6 +64109,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -64999,28 +64202,9 @@
     "CD3D"
    ],
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Immune_T_Cyc",
-       "cell_count": 2208,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Immune_T_Cyc",
-       "cell_count": 2208,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Uterus",
@@ -65061,6 +64245,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Endometrium",
@@ -65171,6 +64356,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Endometrium",
@@ -65306,6 +64492,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -65326,6 +64513,7 @@
     },
     "Developmental_stage": {
      "author_field_name": "Developmental_stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Adult",
@@ -65351,6 +64539,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "33",
@@ -65561,6 +64750,7 @@
     },
     "Tanner Stage": {
      "author_field_name": "Tanner Stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Pubic V/Genitals-Breast V",
@@ -65591,6 +64781,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -65671,6 +64862,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Proliferative",
@@ -65751,6 +64943,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "control",
@@ -65826,6 +65019,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -65926,6 +65120,7 @@
     },
     "Observed_pathology": {
      "author_field_name": "Observed_pathology",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -65966,6 +65161,7 @@
     },
     "Sampled_site_condition": {
      "author_field_name": "Sampled_site_condition",
+     "category": "disease",
      "values": [
       {
        "author_value": "normal",
@@ -66210,28 +65406,9 @@
     "FLT3"
    ],
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Immune_cDC1",
-       "cell_count": 1073,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Immune_cDC1",
-       "cell_count": 1073,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Uterus",
@@ -66267,6 +65444,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Endometrium",
@@ -66382,6 +65560,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Endometrium",
@@ -66502,6 +65681,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -66522,6 +65702,7 @@
     },
     "Developmental_stage": {
      "author_field_name": "Developmental_stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Adult",
@@ -66547,6 +65728,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "37",
@@ -66752,6 +65934,7 @@
     },
     "Tanner Stage": {
      "author_field_name": "Tanner Stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Pubic V/Genitals-Breast V",
@@ -66772,6 +65955,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -66847,6 +66031,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Proliferative",
@@ -66927,6 +66112,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "control",
@@ -67012,6 +66198,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -67117,6 +66304,7 @@
     },
     "Observed_pathology": {
      "author_field_name": "Observed_pathology",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -67152,6 +66340,7 @@
     },
     "Sampled_site_condition": {
      "author_field_name": "Sampled_site_condition",
+     "category": "disease",
      "values": [
       {
        "author_value": "normal",
@@ -67307,28 +66496,9 @@
     "CD207"
    ],
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Immune_cDC2",
-       "cell_count": 3457,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Immune_cDC2",
-       "cell_count": 3457,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Fallopian Tube",
@@ -67369,6 +66539,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Endometrium",
@@ -67514,6 +66685,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Endometrium",
@@ -67684,6 +66856,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -67709,6 +66882,7 @@
     },
     "Developmental_stage": {
      "author_field_name": "Developmental_stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Adult",
@@ -67739,6 +66913,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "37",
@@ -68019,6 +67194,7 @@
     },
     "Tanner Stage": {
      "author_field_name": "Tanner Stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Pubic V/Genitals-Breast V",
@@ -68054,6 +67230,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -68164,6 +67341,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Proliferative",
@@ -68249,6 +67427,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "control",
@@ -68424,6 +67603,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -68624,6 +67804,7 @@
     },
     "Observed_pathology": {
      "author_field_name": "Observed_pathology",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -68664,6 +67845,7 @@
     },
     "Sampled_site_condition": {
      "author_field_name": "Sampled_site_condition",
+     "category": "disease",
      "values": [
       {
        "author_value": "normal",
@@ -68846,28 +68028,9 @@
     "FLT3"
    ],
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Immune_cDC2_CD207hi",
-       "cell_count": 1533,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Immune_cDC2_CD207hi",
-       "cell_count": 1533,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Uterus",
@@ -68908,6 +68071,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Endometrium",
@@ -69018,6 +68182,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Endometrium",
@@ -69123,6 +68288,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -69143,6 +68309,7 @@
     },
     "Developmental_stage": {
      "author_field_name": "Developmental_stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Adult",
@@ -69168,6 +68335,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "37",
@@ -69368,6 +68536,7 @@
     },
     "Tanner Stage": {
      "author_field_name": "Tanner Stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Pubic V/Genitals-Breast V",
@@ -69393,6 +68562,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -69473,6 +68643,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Unknown",
@@ -69558,6 +68729,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "control",
@@ -69643,6 +68815,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -69753,6 +68926,7 @@
     },
     "Observed_pathology": {
      "author_field_name": "Observed_pathology",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -69793,6 +68967,7 @@
     },
     "Sampled_site_condition": {
      "author_field_name": "Sampled_site_condition",
+     "category": "disease",
      "values": [
       {
        "author_value": "normal",
@@ -69943,28 +69118,9 @@
     "10.1038/s41586-020-2134-y"
    ],
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Immune_mregDC",
-       "cell_count": 1577,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Immune_mregDC",
-       "cell_count": 1577,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Uterus",
@@ -69995,6 +69151,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Mentrual fluid",
@@ -70070,6 +69227,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Mentrual fluid",
@@ -70145,6 +69303,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -70165,6 +69324,7 @@
     },
     "Developmental_stage": {
      "author_field_name": "Developmental_stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Adult",
@@ -70185,6 +69345,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "33",
@@ -70380,6 +69541,7 @@
     },
     "Tanner Stage": {
      "author_field_name": "Tanner Stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Pubic V/Genitals-Breast V",
@@ -70400,6 +69562,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -70450,6 +69613,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Menstrual",
@@ -70525,6 +69689,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "Unknown",
@@ -70585,6 +69750,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Unknown",
@@ -70665,6 +69831,7 @@
     },
     "Observed_pathology": {
      "author_field_name": "Observed_pathology",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -70700,6 +69867,7 @@
     },
     "Sampled_site_condition": {
      "author_field_name": "Sampled_site_condition",
+     "category": "disease",
      "values": [
       {
        "author_value": "Unknown",
@@ -70856,28 +70024,9 @@
     "NUPR1"
    ],
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Immune_oLAM",
-       "cell_count": 321,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Immune_oLAM",
-       "cell_count": 321,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Ovary",
@@ -70913,6 +70062,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Ovarian Medulla",
@@ -71008,6 +70158,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Ovarian Medulla",
@@ -71113,6 +70264,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "unknown",
@@ -71133,6 +70285,7 @@
     },
     "Developmental_stage": {
      "author_field_name": "Developmental_stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Adult",
@@ -71153,6 +70306,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "44",
@@ -71303,6 +70457,7 @@
     },
     "Tanner Stage": {
      "author_field_name": "Tanner Stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Pubic V/Genitals-Breast V",
@@ -71328,6 +70483,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -71373,6 +70529,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Unknown",
@@ -71428,6 +70585,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "painful menrohagia",
@@ -71518,6 +70676,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "painful menrohagia",
@@ -71618,6 +70777,7 @@
     },
     "Observed_pathology": {
      "author_field_name": "Observed_pathology",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -71643,6 +70803,7 @@
     },
     "Sampled_site_condition": {
      "author_field_name": "Sampled_site_condition",
+     "category": "disease",
      "values": [
       {
        "author_value": "normal",
@@ -71775,28 +70936,9 @@
     "SIGLEC6"
    ],
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Immune_pDC",
-       "cell_count": 1203,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Immune_pDC",
-       "cell_count": 1203,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Uterus",
@@ -71832,6 +70974,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Endometrium",
@@ -71927,6 +71070,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Endometrium",
@@ -72027,6 +71171,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -72047,6 +71192,7 @@
     },
     "Developmental_stage": {
      "author_field_name": "Developmental_stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Adult",
@@ -72067,6 +71213,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "37",
@@ -72277,6 +71424,7 @@
     },
     "Tanner Stage": {
      "author_field_name": "Tanner Stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Pubic V/Genitals-Breast V",
@@ -72302,6 +71450,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -72367,6 +71516,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Menstrual",
@@ -72442,6 +71592,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "control",
@@ -72532,6 +71683,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -72647,6 +71799,7 @@
     },
     "Observed_pathology": {
      "author_field_name": "Observed_pathology",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -72682,6 +71835,7 @@
     },
     "Sampled_site_condition": {
      "author_field_name": "Sampled_site_condition",
+     "category": "disease",
      "values": [
       {
        "author_value": "normal",
@@ -72862,28 +72016,9 @@
     "10.1038/s41586-025-08982-4"
    ],
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Immune_tolDC",
-       "cell_count": 47,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Immune_tolDC",
-       "cell_count": 47,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Uterus",
@@ -72904,6 +72039,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Endometrium",
@@ -72939,6 +72075,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Endometrium",
@@ -72979,6 +72116,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -72994,6 +72132,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "32",
@@ -73104,6 +72243,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Proliferative",
@@ -73154,6 +72294,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "control",
@@ -73179,6 +72320,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -73219,6 +72361,7 @@
     },
     "Observed_pathology": {
      "author_field_name": "Observed_pathology",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -73249,6 +72392,7 @@
     },
     "Sampled_site_condition": {
      "author_field_name": "Sampled_site_condition",
+     "category": "disease",
      "values": [
       {
        "author_value": "normal",
@@ -73338,28 +72482,9 @@
     "ANPEP"
    ],
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Immune_uMac_Inf",
-       "cell_count": 23069,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Immune_uMac_Inf",
-       "cell_count": 23069,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Uterus",
@@ -73395,6 +72520,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Mentrual fluid",
@@ -73520,6 +72646,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Mentrual fluid",
@@ -73660,6 +72787,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -73680,6 +72808,7 @@
     },
     "Developmental_stage": {
      "author_field_name": "Developmental_stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Adult",
@@ -73705,6 +72834,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "33",
@@ -73935,6 +73065,7 @@
     },
     "Tanner Stage": {
      "author_field_name": "Tanner Stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Pubic V/Genitals-Breast V",
@@ -73970,6 +73101,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -74065,6 +73197,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Menstrual",
@@ -74150,6 +73283,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "Unknown",
@@ -74250,6 +73384,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Unknown",
@@ -74375,6 +73510,7 @@
     },
     "Observed_pathology": {
      "author_field_name": "Observed_pathology",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -74405,6 +73541,7 @@
     },
     "Sampled_site_condition": {
      "author_field_name": "Sampled_site_condition",
+     "category": "disease",
      "values": [
       {
        "author_value": "Unknown",
@@ -74590,28 +73727,9 @@
     "10.1038/s41586-018-0698-6"
    ],
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Immune_uNK1",
-       "cell_count": 3543,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Immune_uNK1",
-       "cell_count": 3543,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Uterus",
@@ -74632,6 +73750,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Endometrium",
@@ -74672,6 +73791,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Endometrium",
@@ -74712,6 +73832,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -74727,6 +73848,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "32",
@@ -74852,6 +73974,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Secretory",
@@ -74917,6 +74040,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "control",
@@ -74977,6 +74101,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -75057,6 +74182,7 @@
     },
     "Observed_pathology": {
      "author_field_name": "Observed_pathology",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -75097,6 +74223,7 @@
     },
     "Sampled_site_condition": {
      "author_field_name": "Sampled_site_condition",
+     "category": "disease",
      "values": [
       {
        "author_value": "normal",
@@ -75218,28 +74345,9 @@
     "10.1038/s41586-018-0698-6"
    ],
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Immune_uNK2",
-       "cell_count": 12245,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Immune_uNK2",
-       "cell_count": 12245,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Uterus",
@@ -75275,6 +74383,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Endometrium",
@@ -75365,6 +74474,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Superficial_Endometrium",
@@ -75465,6 +74575,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -75485,6 +74596,7 @@
     },
     "Developmental_stage": {
      "author_field_name": "Developmental_stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Adult",
@@ -75510,6 +74622,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "31",
@@ -75720,6 +74833,7 @@
     },
     "Tanner Stage": {
      "author_field_name": "Tanner Stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Pubic V/Genitals-Breast V",
@@ -75755,6 +74869,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -75810,6 +74925,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Proliferative Early",
@@ -75895,6 +75011,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "control",
@@ -75995,6 +75112,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -76120,6 +75238,7 @@
     },
     "Observed_pathology": {
      "author_field_name": "Observed_pathology",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -76160,6 +75279,7 @@
     },
     "Sampled_site_condition": {
      "author_field_name": "Sampled_site_condition",
+     "category": "disease",
      "values": [
       {
        "author_value": "normal",
@@ -76354,28 +75474,9 @@
     "10.1038/s41586-018-0698-6"
    ],
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Immune_uNK3",
-       "cell_count": 10688,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Immune_uNK3",
-       "cell_count": 10688,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Uterus",
@@ -76416,6 +75517,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Endometrium",
@@ -76541,6 +75643,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Endometrium",
@@ -76676,6 +75779,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -76701,6 +75805,7 @@
     },
     "Developmental_stage": {
      "author_field_name": "Developmental_stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Adult",
@@ -76731,6 +75836,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "31",
@@ -76991,6 +76097,7 @@
     },
     "Tanner Stage": {
      "author_field_name": "Tanner Stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Pubic V/Genitals-Breast V",
@@ -77026,6 +76133,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -77111,6 +76219,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Proliferative",
@@ -77191,6 +76300,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "control",
@@ -77336,6 +76446,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -77506,6 +76617,7 @@
     },
     "Observed_pathology": {
      "author_field_name": "Observed_pathology",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -77546,6 +76658,7 @@
     },
     "Sampled_site_condition": {
      "author_field_name": "Sampled_site_condition",
+     "category": "disease",
      "values": [
       {
        "author_value": "normal",
@@ -77769,28 +76882,9 @@
     "TENM4"
    ],
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Immune_uftLAM",
-       "cell_count": 2760,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Immune_uftLAM",
-       "cell_count": 2760,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Fallopian Tube",
@@ -77831,6 +76925,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Fallopian Tube Ampulla",
@@ -77971,6 +77066,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Fallopian Tube Ampulla",
@@ -78126,6 +77222,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -78151,6 +77248,7 @@
     },
     "Developmental_stage": {
      "author_field_name": "Developmental_stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Adult",
@@ -78171,6 +77269,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "37",
@@ -78371,6 +77470,7 @@
     },
     "Tanner Stage": {
      "author_field_name": "Tanner Stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Pubic V/Genitals-Breast V",
@@ -78391,6 +77491,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -78511,6 +77612,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Unknown",
@@ -78591,6 +77693,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "control",
@@ -78651,6 +77754,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -78736,6 +77840,7 @@
     },
     "Observed_pathology": {
      "author_field_name": "Observed_pathology",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -78771,6 +77876,7 @@
     },
     "Sampled_site_condition": {
      "author_field_name": "Sampled_site_condition",
+     "category": "disease",
      "values": [
       {
        "author_value": "normal",
@@ -78913,28 +78019,9 @@
    ],
    "comment": "media-4 description: Present only in fetal samples. Lack homing receptors and expresses some tissue-residency markers (ITGAE, CXCR6).",
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Immune_γδT_Vγ9Vδ2",
-       "cell_count": 781,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Immune_γδT_Vγ9Vδ2",
-       "cell_count": 781,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Ovary",
@@ -78970,6 +78057,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Gonad_and_extragonadal",
@@ -79050,6 +78138,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Gonad_and_extragonadal",
@@ -79135,6 +78224,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Immune",
@@ -79155,6 +78245,7 @@
     },
     "Developmental_stage": {
      "author_field_name": "Developmental_stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Fetal",
@@ -79175,6 +78266,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -79305,6 +78397,7 @@
     },
     "Tanner Stage": {
      "author_field_name": "Tanner Stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -79325,6 +78418,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "17",
@@ -79395,6 +78489,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -79460,6 +78555,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "control",
@@ -79490,6 +78586,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -79525,6 +78622,7 @@
     },
     "Observed_pathology": {
      "author_field_name": "Observed_pathology",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -79550,6 +78648,7 @@
     },
     "Sampled_site_condition": {
      "author_field_name": "Sampled_site_condition",
+     "category": "disease",
      "values": [
       {
        "author_value": "normal",
@@ -79671,38 +78770,9 @@
     "C7"
    ],
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Mesen_AdvFibsIntr",
-       "cell_count": 33795,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Mesen_AdvFibsIntr",
-       "cell_count": 33795,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA_broad": {
-     "author_field_name": "celltype_HCA_broad",
-     "values": [
-      {
-       "author_value": "Mesen_AdvFibsIntr",
-       "cell_count": 33795,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Fallopian Tube",
@@ -79728,6 +78798,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Whole_Uterus",
@@ -79798,6 +78869,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Cortex_outer",
@@ -79893,6 +78965,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -79913,6 +78986,7 @@
     },
     "Developmental_stage": {
      "author_field_name": "Developmental_stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Adult",
@@ -79938,6 +79012,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "55",
@@ -80223,6 +79298,7 @@
     },
     "Tanner Stage": {
      "author_field_name": "Tanner Stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Pubic V/Genitals-Breast V",
@@ -80258,6 +79334,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Postmenopausal",
@@ -80353,6 +79430,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "control",
@@ -80528,6 +79606,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -80738,6 +79817,7 @@
     },
     "Observed_pathology": {
      "author_field_name": "Observed_pathology",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -80758,6 +79838,7 @@
     },
     "Sampled_site_condition": {
      "author_field_name": "Sampled_site_condition",
+     "category": "disease",
      "values": [
       {
        "author_value": "normal",
@@ -81224,28 +80305,9 @@
     "SLPI"
    ],
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Mesen_AdvFibs_PI16hi",
-       "cell_count": 3032,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Mesen_AdvFibs_PI16hi",
-       "cell_count": 3032,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Fallopian Tube",
@@ -81271,6 +80333,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Fallopian Tube Ampulla",
@@ -81321,6 +80384,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Fallopian Tube Ampulla",
@@ -81376,6 +80440,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -81391,6 +80456,7 @@
     },
     "Developmental_stage": {
      "author_field_name": "Developmental_stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Adult",
@@ -81406,6 +80472,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "61",
@@ -81521,6 +80588,7 @@
     },
     "Tanner Stage": {
      "author_field_name": "Tanner Stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Pubic V/Genitals-Breast V",
@@ -81536,6 +80604,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Postmenopausal",
@@ -81586,6 +80655,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "control",
@@ -81601,6 +80671,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -81721,28 +80792,9 @@
     "C7"
    ],
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Mesen_AdvFibs_PI16low",
-       "cell_count": 18360,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Mesen_AdvFibs_PI16low",
-       "cell_count": 18360,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Fallopian Tube",
@@ -81768,6 +80820,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Fallopian Tube Isthmus",
@@ -81828,6 +80881,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Fallopian Tube Isthmus",
@@ -81913,6 +80967,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -81928,6 +80983,7 @@
     },
     "Developmental_stage": {
      "author_field_name": "Developmental_stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Adult",
@@ -81948,6 +81004,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Unknown",
@@ -82173,6 +81230,7 @@
     },
     "Tanner Stage": {
      "author_field_name": "Tanner Stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Pubic V/Genitals-Breast V",
@@ -82208,6 +81266,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Postmenopausal",
@@ -82293,6 +81352,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "control",
@@ -82388,6 +81448,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -82488,6 +81549,7 @@
     },
     "Observed_pathology": {
      "author_field_name": "Observed_pathology",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -82508,6 +81570,7 @@
     },
     "Sampled_site_condition": {
      "author_field_name": "Sampled_site_condition",
+     "category": "disease",
      "values": [
       {
        "author_value": "normal",
@@ -82719,28 +81782,9 @@
    "cell_ontology_term_id": "CL:0000499",
    "cell_ontology_term": "stromal cell",
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Mesen_CervixFib_Fetal",
-       "cell_count": 11916,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA_broad": {
-     "author_field_name": "celltype_HCA_broad",
-     "values": [
-      {
-       "author_value": "Mesen_CervixFib",
-       "cell_count": 11916,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Reproductive tract",
@@ -82756,6 +81800,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "uterus, cervix",
@@ -82821,6 +81866,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "uterus, cervix",
@@ -82886,6 +81932,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -82901,6 +81948,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "12",
@@ -83225,38 +82273,9 @@
    ],
    "comment": "Minted generic leaf for celltype_HCA_fine='Mesen_CervixFibs' (452 cells). The master L1-L4 nomenclature terminates at L3 'Cervix stroma' with no finer label, so these author-labelled cells — pericytes/etc. the annotators did NOT assign to a finer subtype — had no leaf of their own; the parent node is retained as a pure supertype. cell_label inherited from the supertype nomenclature.",
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Mesen_CervixFibs",
-       "cell_count": 452,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Mesen_CervixFibs",
-       "cell_count": 452,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA_broad": {
-     "author_field_name": "celltype_HCA_broad",
-     "values": [
-      {
-       "author_value": "Mesen_CervixFibs",
-       "cell_count": 452,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Cervix",
@@ -83272,6 +82291,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "cervix",
@@ -83287,6 +82307,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "unknown",
@@ -83302,6 +82323,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "35-65",
@@ -83317,6 +82339,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Unknown",
@@ -83332,6 +82355,7 @@
     },
     "Observed_pathology": {
      "author_field_name": "Observed_pathology",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not_applicable",
@@ -83357,28 +82381,9 @@
    "cell_ontology_term_id": "CL:0000192",
    "cell_ontology_term": "smooth muscle cell",
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Mesen_CervixVaginaSMCs_Fetal",
-       "cell_count": 11569,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA_broad": {
-     "author_field_name": "celltype_HCA_broad",
-     "values": [
-      {
-       "author_value": "Mesen_CervixVaginaSMCs",
-       "cell_count": 11569,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Reproductive tract",
@@ -83394,6 +82399,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "cervix, vagina",
@@ -83459,6 +82465,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Cervix, vagina",
@@ -83524,6 +82531,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -83539,6 +82547,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "19",
@@ -83917,28 +82926,9 @@
     "PRR16"
    ],
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Mesen_CorpusCavernosumFib_Fetal",
-       "cell_count": 9472,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA_broad": {
-     "author_field_name": "celltype_HCA_broad",
-     "values": [
-      {
-       "author_value": "Mesen_CorpusCavernosumFib",
-       "cell_count": 9472,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Whole_tract",
@@ -83969,6 +82959,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Whole_tract",
@@ -83999,6 +82990,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -84009,6 +83001,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "7.8",
@@ -84205,28 +83198,9 @@
     "SALL1"
    ],
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Mesen_CorpusSpongiosumFib_Fetal",
-       "cell_count": 10169,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA_broad": {
-     "author_field_name": "celltype_HCA_broad",
-     "values": [
-      {
-       "author_value": "Mesen_CorpusSpongiosumFib",
-       "cell_count": 10169,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Reproductive tract",
@@ -84242,6 +83216,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "lower tract",
@@ -84297,6 +83272,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "lower tract",
@@ -84352,6 +83328,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -84362,6 +83339,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "9",
@@ -84645,28 +83623,9 @@
    "cell_ontology_term_id": "CL:0002255",
    "cell_ontology_term": "stromal cell of endometrium",
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Mesen_EndoStromalFib_Menopause",
-       "cell_count": 2855,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Mesen_EndoStromalFib_Menopause",
-       "cell_count": 2855,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Whole_Uterus",
@@ -84692,6 +83651,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Endometrium",
@@ -84722,6 +83682,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -84737,6 +83698,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "53",
@@ -84867,6 +83829,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Postmenopausal",
@@ -84942,6 +83905,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "control",
@@ -84977,6 +83941,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -85047,6 +84012,7 @@
     },
     "Observed_pathology": {
      "author_field_name": "Observed_pathology",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -85072,6 +84038,7 @@
     },
     "Sampled_site_condition": {
      "author_field_name": "Sampled_site_condition",
+     "category": "disease",
      "values": [
       {
        "author_value": "normal",
@@ -85275,28 +84242,9 @@
     "F13A1"
    ],
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Mesen_EndoStromalFib_MenstrualEutopic",
-       "cell_count": 13034,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Mesen_EndoStromalFib_MenstrualEutopic",
-       "cell_count": 13034,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Endometrium",
@@ -85322,6 +84270,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Endometrium",
@@ -85347,6 +84296,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "unknown",
@@ -85362,6 +84312,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "42",
@@ -85497,6 +84448,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Menstrual",
@@ -85587,6 +84539,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "control",
@@ -85622,6 +84575,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -85687,6 +84641,7 @@
     },
     "Observed_pathology": {
      "author_field_name": "Observed_pathology",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -85707,6 +84662,7 @@
     },
     "Sampled_site_condition": {
      "author_field_name": "Sampled_site_condition",
+     "category": "disease",
      "values": [
       {
        "author_value": "normal",
@@ -85858,28 +84814,9 @@
     "F13A1"
    ],
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Mesen_EndoStromalFib_MenstrualFluid",
-       "cell_count": 27092,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Mesen_EndoStromalFib_MenstrualFluid",
-       "cell_count": 27092,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Mentrual fluid",
@@ -85900,6 +84837,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Mentrual fluid",
@@ -85920,6 +84858,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -85935,6 +84874,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "32",
@@ -86055,6 +84995,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Menstrual",
@@ -86115,6 +85056,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "Unknown",
@@ -86165,6 +85107,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Unknown",
@@ -86240,6 +85183,7 @@
     },
     "Observed_pathology": {
      "author_field_name": "Observed_pathology",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -86265,6 +85209,7 @@
     },
     "Sampled_site_condition": {
      "author_field_name": "Sampled_site_condition",
+     "category": "disease",
      "values": [
       {
        "author_value": "Unknown",
@@ -86402,28 +85347,9 @@
     "INHBA"
    ],
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Mesen_EndoStromalFib_Prolif",
-       "cell_count": 164476,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Mesen_EndoStromalFib_Prolif",
-       "cell_count": 164476,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Endometrium",
@@ -86449,6 +85375,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Endometrium",
@@ -86479,6 +85406,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -86494,6 +85422,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "35",
@@ -86634,6 +85563,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Proliferative",
@@ -86729,6 +85659,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "control",
@@ -86784,6 +85715,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -86874,6 +85806,7 @@
     },
     "Observed_pathology": {
      "author_field_name": "Observed_pathology",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -86909,6 +85842,7 @@
     },
     "Sampled_site_condition": {
      "author_field_name": "Sampled_site_condition",
+     "category": "disease",
      "values": [
       {
        "author_value": "normal",
@@ -87326,28 +86260,9 @@
     "INHBA"
    ],
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Mesen_EndoStromalFib_Prolif_Cyc",
-       "cell_count": 32491,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Mesen_EndoStromalFib_Prolif_Cyc",
-       "cell_count": 32491,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Endometrium",
@@ -87373,6 +86288,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Endometrium",
@@ -87398,6 +86314,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -87413,6 +86330,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "37",
@@ -87548,6 +86466,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Proliferative",
@@ -87638,6 +86557,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "control",
@@ -87683,6 +86603,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -87763,6 +86684,7 @@
     },
     "Observed_pathology": {
      "author_field_name": "Observed_pathology",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -87793,6 +86715,7 @@
     },
     "Sampled_site_condition": {
      "author_field_name": "Sampled_site_condition",
+     "category": "disease",
      "values": [
       {
        "author_value": "normal",
@@ -88054,28 +86977,9 @@
     "INHBA"
    ],
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Mesen_EndoStromalFib_eSec",
-       "cell_count": 17251,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Mesen_EndoStromalFib_eSec",
-       "cell_count": 17251,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Endometrium",
@@ -88101,6 +87005,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Endometrium",
@@ -88126,6 +87031,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -88141,6 +87047,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "37",
@@ -88271,6 +87178,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Secretory",
@@ -88361,6 +87269,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "control",
@@ -88411,6 +87320,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -88496,6 +87406,7 @@
     },
     "Observed_pathology": {
      "author_field_name": "Observed_pathology",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -88526,6 +87437,7 @@
     },
     "Sampled_site_condition": {
      "author_field_name": "Sampled_site_condition",
+     "category": "disease",
      "values": [
       {
        "author_value": "normal",
@@ -88788,28 +87700,9 @@
     "MMP11"
    ],
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Mesen_EndoStromalFib_lSec",
-       "cell_count": 36137,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Mesen_EndoStromalFib_lSec",
-       "cell_count": 36137,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Endometrium",
@@ -88835,6 +87728,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Endometrium",
@@ -88860,6 +87754,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -88875,6 +87770,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "43",
@@ -89010,6 +87906,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Secretory",
@@ -89095,6 +87992,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "control",
@@ -89155,6 +88053,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -89250,6 +88149,7 @@
     },
     "Observed_pathology": {
      "author_field_name": "Observed_pathology",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -89285,6 +88185,7 @@
     },
     "Sampled_site_condition": {
      "author_field_name": "Sampled_site_condition",
+     "category": "disease",
      "values": [
       {
        "author_value": "normal",
@@ -89624,28 +88525,9 @@
     "MMP11"
    ],
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Mesen_EndoStromalFib_mSec",
-       "cell_count": 103861,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Mesen_EndoStromalFib_mSec",
-       "cell_count": 103861,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Endometrium",
@@ -89671,6 +88553,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Endometrium",
@@ -89701,6 +88584,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -89716,6 +88600,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "38",
@@ -89861,6 +88746,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Secretory Mid",
@@ -89956,6 +88842,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "control",
@@ -90016,6 +88903,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -90111,6 +88999,7 @@
     },
     "Observed_pathology": {
      "author_field_name": "Observed_pathology",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -90146,6 +89035,7 @@
     },
     "Sampled_site_condition": {
      "author_field_name": "Sampled_site_condition",
+     "category": "disease",
      "values": [
       {
        "author_value": "normal",
@@ -90514,28 +89404,9 @@
    "cell_ontology_term": "stromal cell of endometrium",
    "comment": "media-4 description: Heterogeneous population;depends on the hormonal treatment",
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Mesen_EndoStromalFib_nEMC",
-       "cell_count": 48007,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Mesen_EndoStromalFib_nEMC",
-       "cell_count": 48007,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Endometrium",
@@ -90561,6 +89432,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Endometrium",
@@ -90591,6 +89463,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "unknown",
@@ -90606,6 +89479,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "29",
@@ -90751,6 +89625,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Hormones",
@@ -90846,6 +89721,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "control",
@@ -90901,6 +89777,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -90991,6 +89868,7 @@
     },
     "Observed_pathology": {
      "author_field_name": "Observed_pathology",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -91026,6 +89904,7 @@
     },
     "Sampled_site_condition": {
      "author_field_name": "Sampled_site_condition",
+     "category": "disease",
      "values": [
       {
        "author_value": "normal",
@@ -91341,28 +90220,9 @@
    ],
    "comment": "media-4 description: Heterogeneous population;depends on the hormonal treatment",
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Mesen_EndoStromalFib_nEMC_Cyc",
-       "cell_count": 12895,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Mesen_EndoStromalFib_nEMC_Cyc",
-       "cell_count": 12895,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Endometrium",
@@ -91388,6 +90248,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Endometrium",
@@ -91413,6 +90274,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "unknown",
@@ -91428,6 +90290,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "23",
@@ -91553,6 +90416,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Hormones",
@@ -91643,6 +90507,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "control",
@@ -91683,6 +90548,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -91758,6 +90624,7 @@
     },
     "Observed_pathology": {
      "author_field_name": "Observed_pathology",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -91788,6 +90655,7 @@
     },
     "Sampled_site_condition": {
      "author_field_name": "Sampled_site_condition",
+     "category": "disease",
      "values": [
       {
        "author_value": "normal",
@@ -91986,28 +90854,9 @@
    ],
    "comment": "media-4 description: Heterogeneous population;depends on the hormonal treatment",
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Mesen_EndoStromalFib_nEMC_Sec",
-       "cell_count": 50283,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Mesen_EndoStromalFib_nEMC_Sec",
-       "cell_count": 50283,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Endometrium",
@@ -92033,6 +90882,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Endometrium",
@@ -92058,6 +90908,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "unknown",
@@ -92073,6 +90924,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "32",
@@ -92208,6 +91060,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Hormones",
@@ -92303,6 +91156,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "control",
@@ -92358,6 +91212,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -92448,6 +91303,7 @@
     },
     "Observed_pathology": {
      "author_field_name": "Observed_pathology",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -92483,6 +91339,7 @@
     },
     "Sampled_site_condition": {
      "author_field_name": "Sampled_site_condition",
+     "category": "disease",
      "values": [
       {
        "author_value": "normal",
@@ -92789,28 +91646,9 @@
     "PLAC1"
    ],
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Mesen_EpoophronFib_Fetal",
-       "cell_count": 13877,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA_broad": {
-     "author_field_name": "celltype_HCA_broad",
-     "values": [
-      {
-       "author_value": "Mesen_EpoophronFib",
-       "cell_count": 13877,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Ovary",
@@ -92831,6 +91669,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Gonad_and_extragonadal",
@@ -92911,6 +91750,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Gonad_and_extragonadal",
@@ -92991,6 +91831,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -93011,6 +91852,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -93026,6 +91868,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "16",
@@ -93535,28 +92378,9 @@
     "CD36"
    ],
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Mesen_FallopianFib_Fetal",
-       "cell_count": 41092,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA_broad": {
-     "author_field_name": "celltype_HCA_broad",
-     "values": [
-      {
-       "author_value": "Mesen_FallopianFib",
-       "cell_count": 41092,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Reproductive tract",
@@ -93577,6 +92401,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Fallopian Tube",
@@ -93657,6 +92482,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Fallopian Tube",
@@ -93737,6 +92563,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -93757,6 +92584,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -93772,6 +92600,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "12",
@@ -94380,38 +93209,9 @@
    ],
    "comment": "Minted generic leaf for celltype_HCA_fine='Mesen_FallopianFibs' (64649 cells). The master L1-L4 nomenclature terminates at L3 'Fallopian tube stroma' with no finer label, so these author-labelled cells — pericytes/etc. the annotators did NOT assign to a finer subtype — had no leaf of their own; the parent node is retained as a pure supertype. cell_label inherited from the supertype nomenclature.",
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Mesen_FallopianFibs",
-       "cell_count": 64649,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Mesen_FallopianFibs",
-       "cell_count": 64649,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA_broad": {
-     "author_field_name": "celltype_HCA_broad",
-     "values": [
-      {
-       "author_value": "Mesen_FallopianFibs",
-       "cell_count": 64649,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Fallopian Tube Fimbria",
@@ -94437,6 +93237,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Fallopian Tube Fimbria",
@@ -94472,6 +93273,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "43",
@@ -94562,6 +93364,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Postmenopausal",
@@ -94732,28 +93535,9 @@
     "PTGER3"
    ],
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Mesen_FallopianLig_Fetal",
-       "cell_count": 18265,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA_broad": {
-     "author_field_name": "celltype_HCA_broad",
-     "values": [
-      {
-       "author_value": "Mesen_FallopianLig",
-       "cell_count": 18265,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Reproductive tract",
@@ -94774,6 +93558,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Fallopian Tube",
@@ -94854,6 +93639,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Fallopian Tube",
@@ -94934,6 +93720,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -94954,6 +93741,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -94969,6 +93757,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "12",
@@ -95463,28 +94252,9 @@
    "cell_ontology_term_id": "CL:0000192",
    "cell_ontology_term": "smooth muscle cell",
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Mesen_FallopianSMCs_Fetal",
-       "cell_count": 8413,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA_broad": {
-     "author_field_name": "celltype_HCA_broad",
-     "values": [
-      {
-       "author_value": "Mesen_FallopianSMCs",
-       "cell_count": 8413,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Reproductive tract",
@@ -95500,6 +94270,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Fallopian Tube",
@@ -95560,6 +94331,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Fallopian Tube",
@@ -95620,6 +94392,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -95635,6 +94408,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "21",
@@ -95948,28 +94722,9 @@
     "DLX5"
    ],
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Mesen_GlansFib_Fetal",
-       "cell_count": 5416,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA_broad": {
-     "author_field_name": "celltype_HCA_broad",
-     "values": [
-      {
-       "author_value": "Mesen_GlansFib",
-       "cell_count": 5416,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "lower tract",
@@ -95995,6 +94750,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "lower tract",
@@ -96020,6 +94776,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -96030,6 +94787,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "9",
@@ -96204,28 +94962,9 @@
    "cell_ontology_term_id": "CL:0000057",
    "cell_ontology_term": "fibroblast",
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Mesen_LabiaFib_Fetal",
-       "cell_count": 1794,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA_broad": {
-     "author_field_name": "celltype_HCA_broad",
-     "values": [
-      {
-       "author_value": "Mesen_LabiaFib",
-       "cell_count": 1794,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "uterus, cervix, vagina",
@@ -96256,6 +94995,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "uterus, cervix, vagina",
@@ -96286,6 +95026,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -96296,6 +95037,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "15",
@@ -96430,28 +95172,9 @@
    "cell_ontology_term_id": "CL:0000057",
    "cell_ontology_term": "fibroblast",
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Mesen_LabioScrotalSwelling_Fetal",
-       "cell_count": 6830,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA_broad": {
-     "author_field_name": "celltype_HCA_broad",
-     "values": [
-      {
-       "author_value": "Mesen_LabioScrotalSwelling",
-       "cell_count": 6830,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Reproductive tract",
@@ -96472,6 +95195,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "external genitalia",
@@ -96522,6 +95246,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "External genitalia",
@@ -96572,6 +95297,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -96587,6 +95313,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "9",
@@ -96876,28 +95603,9 @@
    "cell_ontology_term_id": "CL:0000057",
    "cell_ontology_term": "fibroblast",
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Mesen_MesonephricFibs_Fetal",
-       "cell_count": 28521,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA_broad": {
-     "author_field_name": "celltype_HCA_broad",
-     "values": [
-      {
-       "author_value": "Mesen_MesonephricFibs",
-       "cell_count": 28521,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Reproductive tract",
@@ -96918,6 +95626,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Gonad_and_extragonadal",
@@ -96988,6 +95697,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Gonad_and_extragonadal",
@@ -97058,6 +95768,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -97078,6 +95789,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -97093,6 +95805,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "9",
@@ -97588,28 +96301,9 @@
     "CNTN1"
    ],
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Mesen_MullerianFib",
-       "cell_count": 2471,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA_broad": {
-     "author_field_name": "celltype_HCA_broad",
-     "values": [
-      {
-       "author_value": "Mesen_MullerianFib",
-       "cell_count": 2471,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Mesonephros",
@@ -97630,6 +96324,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Extragonadal",
@@ -97685,6 +96380,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Extragonadal",
@@ -97740,6 +96436,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -97760,6 +96457,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "8.6",
@@ -98070,18 +96768,9 @@
     "IL17B"
    ],
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Mesen_OvarianFibs_Fetal",
-       "cell_count": 32133,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Ovary",
@@ -98102,6 +96791,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Gonad_and_extragonadal",
@@ -98182,6 +96872,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Gonad_and_extragonadal",
@@ -98262,6 +96953,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -98282,6 +96974,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -98297,6 +96990,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "16",
@@ -98964,28 +97658,9 @@
     "LAMB1"
    ],
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Mesen_OvarianFibs_InncorMedulla",
-       "cell_count": 125985,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Mesen_OvarianFibs_InncorMedulla",
-       "cell_count": 125985,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Ovarian Cortex",
@@ -99016,6 +97691,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Cortex_outer",
@@ -99056,6 +97732,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "unknown",
@@ -99076,6 +97753,7 @@
     },
     "Developmental_stage": {
      "author_field_name": "Developmental_stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "paediatric",
@@ -99101,6 +97779,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "46",
@@ -99261,6 +97940,7 @@
     },
     "Tanner Stage": {
      "author_field_name": "Tanner Stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Pubic V/Genitals-Breast V",
@@ -99296,6 +97976,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Unknown",
@@ -99321,6 +98002,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "endometrial hyperplasia",
@@ -99486,6 +98168,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "endometrial hyperplasia",
@@ -99856,28 +98539,9 @@
     "LAMB1"
    ],
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Mesen_OvarianFibs_Medulla_SMCsLike",
-       "cell_count": 13705,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Mesen_OvarianFibs_Medulla_SMCsLike",
-       "cell_count": 13705,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Ovarian Cortex",
@@ -99908,6 +98572,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Cortex_outer",
@@ -99948,6 +98613,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "unknown",
@@ -99968,6 +98634,7 @@
     },
     "Developmental_stage": {
      "author_field_name": "Developmental_stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Adult",
@@ -99993,6 +98660,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "15",
@@ -100148,6 +98816,7 @@
     },
     "Tanner Stage": {
      "author_field_name": "Tanner Stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Pubic V/Genitals-Breast V",
@@ -100183,6 +98852,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Unknown",
@@ -100208,6 +98878,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "control",
@@ -100363,6 +99034,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -100641,28 +99313,9 @@
     "PROK1"
    ],
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Mesen_OvarianFibs_Outcor",
-       "cell_count": 21434,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Mesen_OvarianFibs_Outcor",
-       "cell_count": 21434,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Ovarian Cortex",
@@ -100693,6 +99346,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Cortex_outer",
@@ -100733,6 +99387,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "unknown",
@@ -100753,6 +99408,7 @@
     },
     "Developmental_stage": {
      "author_field_name": "Developmental_stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "pubertal",
@@ -100778,6 +99434,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "15",
@@ -100938,6 +99595,7 @@
     },
     "Tanner Stage": {
      "author_field_name": "Tanner Stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Unknown",
@@ -100973,6 +99631,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Unknown",
@@ -100998,6 +99657,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "Undiagnosed immunodeficiency",
@@ -101163,6 +99823,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Undiagnosed immunodeficiency",
@@ -101470,28 +100131,9 @@
     "TMEM100"
    ],
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Mesen_OvarianFibs_Perifol",
-       "cell_count": 44411,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Mesen_OvarianFibs_Perifol",
-       "cell_count": 44411,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Ovarian Cortex",
@@ -101522,6 +100164,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Cortex_outer",
@@ -101567,6 +100210,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "unknown",
@@ -101587,6 +100231,7 @@
     },
     "Developmental_stage": {
      "author_field_name": "Developmental_stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "paediatric",
@@ -101612,6 +100257,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "2",
@@ -101772,6 +100418,7 @@
     },
     "Tanner Stage": {
      "author_field_name": "Tanner Stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Pubic I/Genitals-Breast I",
@@ -101807,6 +100454,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Paediatric",
@@ -101832,6 +100480,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "Sickle Cell Disease",
@@ -101997,6 +100646,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Sickle Cell Disease",
@@ -102342,28 +100992,9 @@
    ],
    "comment": "Minted generic leaf for celltype_HCA_fine='Mesen_Pericyte' (38904 cells). The master L1-L4 nomenclature terminates at L3 'Pericytes' with no finer label, so these author-labelled cells — pericytes/etc. the annotators did NOT assign to a finer subtype — had no leaf of their own; the parent node is retained as a pure supertype. cell_label inherited from the supertype nomenclature.",
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Mesen_Pericyte",
-       "cell_count": 38904,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Mesen_Pericyte",
-       "cell_count": 38904,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "celltype_HCA_broad": {
      "author_field_name": "celltype_HCA_broad",
+     "category": "cross_cutting_cell_type",
      "values": [
       {
        "author_value": "Mesen_Pericyte",
@@ -102379,6 +101010,7 @@
     },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Uterus",
@@ -102409,6 +101041,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Endometrium",
@@ -102484,6 +101117,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Endometrium",
@@ -102589,6 +101223,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -102609,6 +101244,7 @@
     },
     "Developmental_stage": {
      "author_field_name": "Developmental_stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Adult",
@@ -102634,6 +101270,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "23",
@@ -102929,6 +101566,7 @@
     },
     "Tanner Stage": {
      "author_field_name": "Tanner Stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Pubic V/Genitals-Breast V",
@@ -102964,6 +101602,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Postmenopausal",
@@ -103074,6 +101713,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "control",
@@ -103264,6 +101904,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -103489,6 +102130,7 @@
     },
     "Observed_pathology": {
      "author_field_name": "Observed_pathology",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -103529,6 +102171,7 @@
     },
     "Sampled_site_condition": {
      "author_field_name": "Sampled_site_condition",
+     "category": "disease",
      "values": [
       {
        "author_value": "normal",
@@ -104017,28 +102660,9 @@
     "MKI67"
    ],
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Mesen_Pericyte_Cyc",
-       "cell_count": 4522,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Mesen_Pericyte_Cyc",
-       "cell_count": 4522,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Uterus",
@@ -104069,6 +102693,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Endometrium",
@@ -104144,6 +102769,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Endometrium",
@@ -104229,6 +102855,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "unknown",
@@ -104249,6 +102876,7 @@
     },
     "Developmental_stage": {
      "author_field_name": "Developmental_stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Adult",
@@ -104274,6 +102902,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "31",
@@ -104524,6 +103153,7 @@
     },
     "Tanner Stage": {
      "author_field_name": "Tanner Stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Pubic V/Genitals-Breast V",
@@ -104559,6 +103189,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Proliferative",
@@ -104664,6 +103295,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "control",
@@ -104784,6 +103416,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -104939,6 +103572,7 @@
     },
     "Observed_pathology": {
      "author_field_name": "Observed_pathology",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -104979,6 +103613,7 @@
     },
     "Sampled_site_condition": {
      "author_field_name": "Sampled_site_condition",
+     "category": "disease",
      "values": [
       {
        "author_value": "normal",
@@ -105271,28 +103906,9 @@
    ],
    "comment": "Minted generic leaf for celltype_HCA_fine='Mesen_Pericyte_EndoStromalLike' (10229 cells). The master L1-L4 nomenclature terminates at L3 'Endometrial pericyte-stromal-likes' with no finer label, so these author-labelled cells — pericytes/etc. the annotators did NOT assign to a finer subtype — had no leaf of their own; the parent node is retained as a pure supertype. cell_label inherited from the supertype nomenclature.",
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Mesen_Pericyte_EndoStromalLike",
-       "cell_count": 10229,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Mesen_Pericyte_EndoStromalLike",
-       "cell_count": 10229,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Endometrium",
@@ -105318,6 +103934,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Endometrium",
@@ -105348,6 +103965,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -105363,6 +103981,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "33",
@@ -105508,6 +104127,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Proliferative",
@@ -105603,6 +104223,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "endometriosis",
@@ -105653,6 +104274,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -105738,6 +104360,7 @@
     },
     "Observed_pathology": {
      "author_field_name": "Observed_pathology",
+     "category": "disease",
      "values": [
       {
        "author_value": "endometriosis",
@@ -105773,6 +104396,7 @@
     },
     "Sampled_site_condition": {
      "author_field_name": "Sampled_site_condition",
+     "category": "disease",
      "values": [
       {
        "author_value": "normal",
@@ -106062,28 +104686,9 @@
     "IL11"
    ],
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Mesen_Pericyte_EndoStromalLike_MenstrualFluid",
-       "cell_count": 1272,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Mesen_Pericyte_EndoStromalLike_MenstrualFluid",
-       "cell_count": 1272,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Mentrual fluid",
@@ -106104,6 +104709,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Mentrual fluid",
@@ -106129,6 +104735,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -106144,6 +104751,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "32",
@@ -106184,6 +104792,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Menstrual",
@@ -106204,6 +104813,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "Unknown",
@@ -106234,6 +104844,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Unknown",
@@ -106264,6 +104875,7 @@
     },
     "Observed_pathology": {
      "author_field_name": "Observed_pathology",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -106279,6 +104891,7 @@
     },
     "Sampled_site_condition": {
      "author_field_name": "Sampled_site_condition",
+     "category": "disease",
      "values": [
       {
        "author_value": "Unknown",
@@ -106317,28 +104930,9 @@
     "HMCN2"
    ],
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Mesen_Pericyte_SMCsIntr",
-       "cell_count": 8167,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Mesen_Pericyte_SMCsIntr",
-       "cell_count": 8167,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Uterus",
@@ -106369,6 +104963,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Whole_Uterus",
@@ -106444,6 +105039,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Endometrium",
@@ -106544,6 +105140,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -106564,6 +105161,7 @@
     },
     "Developmental_stage": {
      "author_field_name": "Developmental_stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Adult",
@@ -106584,6 +105182,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "53",
@@ -106854,6 +105453,7 @@
     },
     "Tanner Stage": {
      "author_field_name": "Tanner Stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Pubic V/Genitals-Breast V",
@@ -106884,6 +105484,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Postmenopausal",
@@ -106984,6 +105585,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "control",
@@ -107084,6 +105686,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -107219,6 +105822,7 @@
     },
     "Observed_pathology": {
      "author_field_name": "Observed_pathology",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -107244,6 +105848,7 @@
     },
     "Sampled_site_condition": {
      "author_field_name": "Sampled_site_condition",
+     "category": "disease",
      "values": [
       {
        "author_value": "normal",
@@ -107555,28 +106160,9 @@
     "SHOX2"
    ],
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Mesen_Prepuce_Fetal",
-       "cell_count": 2243,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA_broad": {
-     "author_field_name": "celltype_HCA_broad",
-     "values": [
-      {
-       "author_value": "Mesen_Prepuce",
-       "cell_count": 2243,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "lower tract",
@@ -107607,6 +106193,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "lower tract",
@@ -107637,6 +106224,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -107647,6 +106235,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "9",
@@ -107826,28 +106415,9 @@
    "cell_ontology_term_id": "CL:4052012",
    "cell_ontology_term": "interna theca cell",
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Mesen_Theca_Atretic",
-       "cell_count": 3239,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Mesen_Theca_Atretic",
-       "cell_count": 3239,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Follicle",
@@ -107873,6 +106443,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Antral_follicle",
@@ -107903,6 +106474,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "unknown",
@@ -107923,6 +106495,7 @@
     },
     "Developmental_stage": {
      "author_field_name": "Developmental_stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Adult",
@@ -107948,6 +106521,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "31",
@@ -108063,6 +106637,7 @@
     },
     "Tanner Stage": {
      "author_field_name": "Tanner Stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Pubic V/Genitals-Breast V",
@@ -108098,6 +106673,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Unknown",
@@ -108123,6 +106699,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "Stroke",
@@ -108233,6 +106810,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Stroke",
@@ -108430,28 +107008,9 @@
     "MKI67"
    ],
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Mesen_Theca_Interna_Cyc",
-       "cell_count": 9366,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Mesen_Theca_Interna_Cyc",
-       "cell_count": 9366,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Follicle",
@@ -108477,6 +107036,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Antral_follicle",
@@ -108522,6 +107082,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "unknown",
@@ -108542,6 +107103,7 @@
     },
     "Developmental_stage": {
      "author_field_name": "Developmental_stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Adult",
@@ -108562,6 +107124,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "31",
@@ -108677,6 +107240,7 @@
     },
     "Tanner Stage": {
      "author_field_name": "Tanner Stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Pubic V/Genitals-Breast V",
@@ -108707,6 +107271,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Unknown",
@@ -108727,6 +107292,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "Stroke",
@@ -108832,6 +107398,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Stroke",
@@ -109104,28 +107671,9 @@
     "LHCGR"
    ],
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Mesen_Theca_Interna_Perifol",
-       "cell_count": 5148,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Mesen_Theca_Interna_Perifol",
-       "cell_count": 5148,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Ovarian Cortex",
@@ -109151,6 +107699,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Cortex_outer",
@@ -109186,6 +107735,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "unknown",
@@ -109206,6 +107756,7 @@
     },
     "Developmental_stage": {
      "author_field_name": "Developmental_stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Adult",
@@ -109231,6 +107782,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "31",
@@ -109351,6 +107903,7 @@
     },
     "Tanner Stage": {
      "author_field_name": "Tanner Stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Pubic V/Genitals-Breast V",
@@ -109386,6 +107939,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Unknown",
@@ -109406,6 +107960,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "Stroke",
@@ -109516,6 +108071,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Stroke",
@@ -109768,28 +108324,9 @@
     "PIEZO2"
    ],
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Mesen_Theca_Interna_Steroid",
-       "cell_count": 8428,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Mesen_Theca_Interna_Steroid",
-       "cell_count": 8428,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Follicle",
@@ -109815,6 +108352,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Cortex_outer",
@@ -109855,6 +108393,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "unknown",
@@ -109875,6 +108414,7 @@
     },
     "Developmental_stage": {
      "author_field_name": "Developmental_stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Adult",
@@ -109900,6 +108440,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "31",
@@ -110040,6 +108581,7 @@
     },
     "Tanner Stage": {
      "author_field_name": "Tanner Stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Pubic V/Genitals-Breast V",
@@ -110075,6 +108617,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Unknown",
@@ -110100,6 +108643,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "Stroke",
@@ -110245,6 +108789,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Stroke",
@@ -110534,18 +109079,9 @@
     "FENDRR"
    ],
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Mesen_UGSFib_Lower",
-       "cell_count": 6277,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Reproductive tract",
@@ -110566,6 +109102,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Whole_tract",
@@ -110626,6 +109163,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Whole_tract",
@@ -110686,6 +109224,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -110706,6 +109245,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "7.4",
@@ -111053,18 +109593,9 @@
     "TNC"
    ],
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Mesen_UGSFib_Upper",
-       "cell_count": 11402,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Reproductive tract",
@@ -111085,6 +109616,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Gonad_and_extragonadal",
@@ -111165,6 +109697,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Gonad_and_extragonadal",
@@ -111245,6 +109778,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -111265,6 +109799,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "8.6",
@@ -111735,28 +110270,9 @@
    "cell_ontology_term_id": "CL:0000057",
    "cell_ontology_term": "fibroblast",
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Mesen_UterusFibs_Fetal",
-       "cell_count": 29462,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA_broad": {
-     "author_field_name": "celltype_HCA_broad",
-     "values": [
-      {
-       "author_value": "Mesen_UterusFibs",
-       "cell_count": 29462,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Reproductive tract",
@@ -111777,6 +110293,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Fallopian Tube",
@@ -111857,6 +110374,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Fallopian Tube",
@@ -111937,6 +110455,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -111957,6 +110476,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "12",
@@ -112398,28 +110918,9 @@
     "PTGER3"
    ],
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Mesen_UterusLig_Fetal",
-       "cell_count": 12364,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA_broad": {
-     "author_field_name": "celltype_HCA_broad",
-     "values": [
-      {
-       "author_value": "Mesen_UterusLig",
-       "cell_count": 12364,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Reproductive tract",
@@ -112440,6 +110941,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "uterus",
@@ -112520,6 +111022,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "uterus",
@@ -112600,6 +111103,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -112620,6 +111124,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "20",
@@ -113077,28 +111582,9 @@
    "cell_ontology_term_id": "CL:0000192",
    "cell_ontology_term": "smooth muscle cell",
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Mesen_UterusSMCs_Fetal",
-       "cell_count": 7550,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA_broad": {
-     "author_field_name": "celltype_HCA_broad",
-     "values": [
-      {
-       "author_value": "Mesen_UterusSMCs",
-       "cell_count": 7550,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Reproductive tract",
@@ -113114,6 +111600,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "uterus",
@@ -113169,6 +111656,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "uterus",
@@ -113224,6 +111712,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "20",
@@ -113476,28 +111965,9 @@
     "GAP43"
    ],
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Mesen_VaginaFib_Lower_Fetal",
-       "cell_count": 645,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA_broad": {
-     "author_field_name": "celltype_HCA_broad",
-     "values": [
-      {
-       "author_value": "Mesen_VaginaFib",
-       "cell_count": 645,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Ovary",
@@ -113513,6 +111983,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Gonad_and_extragonadal",
@@ -113548,6 +112019,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Gonad_and_extragonadal",
@@ -113583,6 +112055,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not_immune",
@@ -113603,6 +112076,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "7.5",
@@ -113798,28 +112272,9 @@
    ],
    "comment": "Minted generic leaf for celltype_HCA_fine='Mesen_VaginaFibs' (1463 cells). The master L1-L4 nomenclature terminates at L3 'Vagina stroma' with no finer label, so these author-labelled cells — pericytes/etc. the annotators did NOT assign to a finer subtype — had no leaf of their own; the parent node is retained as a pure supertype. cell_label inherited from the supertype nomenclature.",
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Mesen_VaginaFibs",
-       "cell_count": 1463,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Mesen_VaginaFibs",
-       "cell_count": 1463,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Vagina",
@@ -113835,6 +112290,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Vagina",
@@ -113850,6 +112306,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Vagina",
@@ -113865,6 +112322,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "55",
@@ -113895,6 +112353,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Postmenopausal",
@@ -113910,6 +112369,7 @@
     },
     "Observed_pathology": {
      "author_field_name": "Observed_pathology",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -113939,18 +112399,9 @@
     "FENDRR"
    ],
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Mesen_VaginaFibs_Upper_Fetal",
-       "cell_count": 7925,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Reproductive tract",
@@ -113966,6 +112417,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Vagina",
@@ -114041,6 +112493,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Vagina",
@@ -114116,6 +112569,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -114126,6 +112580,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "13",
@@ -114409,28 +112864,9 @@
    "cell_ontology_term_id": "CL:0000192",
    "cell_ontology_term": "smooth muscle cell",
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Mesen_VaginaSMCs_Lower_Fetal",
-       "cell_count": 1311,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA_broad": {
-     "author_field_name": "celltype_HCA_broad",
-     "values": [
-      {
-       "author_value": "Mesen_VaginaSMCs",
-       "cell_count": 1311,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Reproductive tract",
@@ -114446,6 +112882,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Vagina",
@@ -114486,6 +112923,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Vagina",
@@ -114526,6 +112964,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "19",
@@ -114686,28 +113125,9 @@
     "MT1M"
    ],
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Mesen_vSMCs_largeArt",
-       "cell_count": 33678,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Mesen_vSMCs_largeArt",
-       "cell_count": 33678,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Fallopian Tube",
@@ -114733,6 +113153,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Myometrium",
@@ -114803,6 +113224,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Myometrium",
@@ -114898,6 +113320,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -114918,6 +113341,7 @@
     },
     "Developmental_stage": {
      "author_field_name": "Developmental_stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Adult",
@@ -114943,6 +113367,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "55",
@@ -115198,6 +113623,7 @@
     },
     "Tanner Stage": {
      "author_field_name": "Tanner Stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Pubic V/Genitals-Breast V",
@@ -115233,6 +113659,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Postmenopausal",
@@ -115318,6 +113745,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "control",
@@ -115443,6 +113871,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -115598,6 +114027,7 @@
     },
     "Observed_pathology": {
      "author_field_name": "Observed_pathology",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -115618,6 +114048,7 @@
     },
     "Sampled_site_condition": {
      "author_field_name": "Sampled_site_condition",
+     "category": "disease",
      "values": [
       {
        "author_value": "normal",
@@ -115905,28 +114336,9 @@
     "NET1"
    ],
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Mesen_vSMCs_medArt",
-       "cell_count": 51141,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Mesen_vSMCs_medArt",
-       "cell_count": 51141,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Ovary",
@@ -115957,6 +114369,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Ovarian Cortex",
@@ -116032,6 +114445,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Cortex_outer",
@@ -116132,6 +114546,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -116152,6 +114567,7 @@
     },
     "Developmental_stage": {
      "author_field_name": "Developmental_stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Adult",
@@ -116177,6 +114593,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "28",
@@ -116472,6 +114889,7 @@
     },
     "Tanner Stage": {
      "author_field_name": "Tanner Stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Pubic V/Genitals-Breast V",
@@ -116507,6 +114925,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Unknown",
@@ -116607,6 +115026,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "control",
@@ -116787,6 +115207,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -117002,6 +115423,7 @@
     },
     "Observed_pathology": {
      "author_field_name": "Observed_pathology",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -117037,6 +115459,7 @@
     },
     "Sampled_site_condition": {
      "author_field_name": "Sampled_site_condition",
+     "category": "disease",
      "values": [
       {
        "author_value": "normal",
@@ -117384,38 +115807,9 @@
     "PAX3"
    ],
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Neural_Melanocyte_Fetal",
-       "cell_count": 88,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Neural_Melanocyte_Fetal",
-       "cell_count": 88,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA_broad": {
-     "author_field_name": "celltype_HCA_broad",
-     "values": [
-      {
-       "author_value": "Neural_Melanocyte",
-       "cell_count": 88,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "external genitalia",
@@ -117446,6 +115840,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "External genitalia",
@@ -117476,6 +115871,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -117486,6 +115882,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "15",
@@ -117560,28 +115957,9 @@
     "MKI67"
    ],
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Neural_Schwann_Cyc",
-       "cell_count": 2401,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Neural_Schwann_Cyc",
-       "cell_count": 2401,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Reproductive tract",
@@ -117602,6 +115980,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Whole_tract",
@@ -117692,6 +116071,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Whole_tract",
@@ -117782,6 +116162,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -117802,6 +116183,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "5.6",
@@ -118054,28 +116436,9 @@
     "SMOC1"
    ],
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Neural_Schwann_Fetal",
-       "cell_count": 5801,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Neural_Schwann_Fetal",
-       "cell_count": 5801,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Reproductive tract",
@@ -118096,6 +116459,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Vagina",
@@ -118181,6 +116545,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Vagina",
@@ -118266,6 +116631,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -118286,6 +116652,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "19",
@@ -118488,28 +116855,9 @@
     "POU3F1"
    ],
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Neural_Schwann_Immature",
-       "cell_count": 35,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Neural_Schwann_Immature",
-       "cell_count": 35,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "external genitalia",
@@ -118545,6 +116893,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "External genitalia",
@@ -118580,6 +116929,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -118590,6 +116940,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "12",
@@ -118663,28 +117014,9 @@
     "SMOC1"
    ],
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Neural_Schwann_Precursor",
-       "cell_count": 847,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Neural_Schwann_Precursor",
-       "cell_count": 847,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Reproductive tract",
@@ -118700,6 +117032,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "external genitalia",
@@ -118745,6 +117078,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "External genitalia",
@@ -118790,6 +117124,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -118800,6 +117135,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "14",
@@ -118922,28 +117258,9 @@
     "GJC3"
    ],
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Neural_Schwann_myelinating",
-       "cell_count": 22,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Neural_Schwann_myelinating",
-       "cell_count": 22,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Ovary",
@@ -118969,6 +117286,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Ovarian Cortex",
@@ -119009,6 +117327,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Cortex_outer",
@@ -119059,6 +117378,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -119074,6 +117394,7 @@
     },
     "Developmental_stage": {
      "author_field_name": "Developmental_stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Adult",
@@ -119094,6 +117415,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "5",
@@ -119164,6 +117486,7 @@
     },
     "Tanner Stage": {
      "author_field_name": "Tanner Stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Pubic V/Genitals-Breast V",
@@ -119179,6 +117502,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Paediatric",
@@ -119209,6 +117533,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "control",
@@ -119234,6 +117559,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -119279,28 +117605,9 @@
    "cell_ontology_term_id": "CL:0011103",
    "cell_ontology_term": "sympathetic neuron",
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Neural_SympatheticNeurons_Immature",
-       "cell_count": 4469,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Neural_SympatheticNeurons_Immature",
-       "cell_count": 4469,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Reproductive tract",
@@ -119321,6 +117628,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Whole_tract",
@@ -119401,6 +117709,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Whole_tract",
@@ -119481,6 +117790,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -119501,6 +117811,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "6.2",
@@ -119755,28 +118066,9 @@
     "MKI67"
    ],
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Neural_SympatheticNeurons_Immature_Cyc",
-       "cell_count": 394,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Neural_SympatheticNeurons_Immature_Cyc",
-       "cell_count": 394,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Reproductive tract",
@@ -119797,6 +118089,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Whole_tract",
@@ -119867,6 +118160,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Whole_tract",
@@ -119937,6 +118231,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -119957,6 +118252,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "11",
@@ -120122,28 +118418,9 @@
     "HMX1"
    ],
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Neural_SympatheticNeurons_Noradrenergic",
-       "cell_count": 246,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Neural_SympatheticNeurons_Noradrenergic",
-       "cell_count": 246,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Reproductive tract",
@@ -120159,6 +118436,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Whole_tract",
@@ -120209,6 +118487,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Whole_tract",
@@ -120259,6 +118538,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -120279,6 +118559,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "7.4",
@@ -120385,48 +118666,9 @@
    "parent_cell_set_accession": "HCArepro:L2:0058",
    "n_cells": 55187,
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Mesen_AdvFibsIntr",
-       "cell_count": 33795,
-       "cell_ratio": 0.6124
-      },
-      {
-       "author_value": "Mesen_AdvFibs_PI16low",
-       "cell_count": 18360,
-       "cell_ratio": 0.3327
-      },
-      {
-       "author_value": "Mesen_AdvFibs_PI16hi",
-       "cell_count": 3032,
-       "cell_ratio": 0.0549
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Mesen_AdvFibsIntr",
-       "cell_count": 33795,
-       "cell_ratio": 0.6124
-      },
-      {
-       "author_value": "Mesen_AdvFibs_PI16low",
-       "cell_count": 18360,
-       "cell_ratio": 0.3327
-      },
-      {
-       "author_value": "Mesen_AdvFibs_PI16hi",
-       "cell_count": 3032,
-       "cell_ratio": 0.0549
-      }
-     ]
-    },
     "celltype_HCA_broad": {
      "author_field_name": "celltype_HCA_broad",
+     "category": "cross_cutting_cell_type",
      "values": [
       {
        "author_value": "Mesen_AdvFibsIntr",
@@ -120442,6 +118684,7 @@
     },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Fallopian Tube",
@@ -120467,6 +118710,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Fallopian Tube Isthmus",
@@ -120537,6 +118781,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Fallopian Tube Isthmus",
@@ -120632,6 +118877,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -120652,6 +118898,7 @@
     },
     "Developmental_stage": {
      "author_field_name": "Developmental_stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Adult",
@@ -120677,6 +118924,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "55",
@@ -120962,6 +119210,7 @@
     },
     "Tanner Stage": {
      "author_field_name": "Tanner Stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Pubic V/Genitals-Breast V",
@@ -120997,6 +119246,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Postmenopausal",
@@ -121092,6 +119342,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "control",
@@ -121267,6 +119518,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -121477,6 +119729,7 @@
     },
     "Observed_pathology": {
      "author_field_name": "Observed_pathology",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -121497,6 +119750,7 @@
     },
     "Sampled_site_condition": {
      "author_field_name": "Sampled_site_condition",
+     "category": "disease",
      "values": [
       {
        "author_value": "normal",
@@ -121990,108 +120244,9 @@
     "B cells"
    ],
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Immune_MemoryB",
-       "cell_count": 4542,
-       "cell_ratio": 0.3832
-      },
-      {
-       "author_value": "Immune_Plasma_κ",
-       "cell_count": 2314,
-       "cell_ratio": 0.1952
-      },
-      {
-       "author_value": "Immune_NaiveB",
-       "cell_count": 2076,
-       "cell_ratio": 0.1751
-      },
-      {
-       "author_value": "Immune_Plasma_λ",
-       "cell_count": 1782,
-       "cell_ratio": 0.1503
-      },
-      {
-       "author_value": "Immune_ImmatureB",
-       "cell_count": 387,
-       "cell_ratio": 0.0326
-      },
-      {
-       "author_value": "Immune_LargePreB",
-       "cell_count": 305,
-       "cell_ratio": 0.0257
-      },
-      {
-       "author_value": "Immune_SmallPreB",
-       "cell_count": 281,
-       "cell_ratio": 0.0237
-      },
-      {
-       "author_value": "Immune_ProB",
-       "cell_count": 167,
-       "cell_ratio": 0.0141
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Immune_MemoryB",
-       "cell_count": 4542,
-       "cell_ratio": 0.3832
-      },
-      {
-       "author_value": "Immune_Plasma_κ",
-       "cell_count": 2314,
-       "cell_ratio": 0.1952
-      },
-      {
-       "author_value": "Immune_NaiveB",
-       "cell_count": 2076,
-       "cell_ratio": 0.1751
-      },
-      {
-       "author_value": "Immune_Plasma_λ",
-       "cell_count": 1782,
-       "cell_ratio": 0.1503
-      },
-      {
-       "author_value": "Immune_ImmatureB",
-       "cell_count": 387,
-       "cell_ratio": 0.0326
-      },
-      {
-       "author_value": "Immune_LargePreB",
-       "cell_count": 305,
-       "cell_ratio": 0.0257
-      },
-      {
-       "author_value": "Immune_SmallPreB",
-       "cell_count": 281,
-       "cell_ratio": 0.0237
-      },
-      {
-       "author_value": "Immune_ProB",
-       "cell_count": 167,
-       "cell_ratio": 0.0141
-      }
-     ]
-    },
-    "celltype_HCA_broad": {
-     "author_field_name": "celltype_HCA_broad",
-     "values": [
-      {
-       "author_value": "Immune_B_cells",
-       "cell_count": 11854,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Uterus",
@@ -122132,6 +120287,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Mentrual fluid",
@@ -122267,6 +120423,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Mentrual fluid",
@@ -122432,6 +120589,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -122457,6 +120615,7 @@
     },
     "Developmental_stage": {
      "author_field_name": "Developmental_stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Adult",
@@ -122482,6 +120641,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "27",
@@ -122732,6 +120892,7 @@
     },
     "Tanner Stage": {
      "author_field_name": "Tanner Stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Pubic V/Genitals-Breast V",
@@ -122767,6 +120928,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -122892,6 +121054,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Menstrual",
@@ -122977,6 +121140,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "control",
@@ -123112,6 +121276,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -123272,6 +121437,7 @@
     },
     "Observed_pathology": {
      "author_field_name": "Observed_pathology",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -123312,6 +121478,7 @@
     },
     "Sampled_site_condition": {
      "author_field_name": "Sampled_site_condition",
+     "category": "disease",
      "values": [
       {
        "author_value": "normal",
@@ -123533,28 +121700,9 @@
    "parent_cell_set_accession": "HCArepro:L2:0045",
    "n_cells": 11569,
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Mesen_CervixVaginaSMCs_Fetal",
-       "cell_count": 11569,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA_broad": {
-     "author_field_name": "celltype_HCA_broad",
-     "values": [
-      {
-       "author_value": "Mesen_CervixVaginaSMCs",
-       "cell_count": 11569,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Reproductive tract",
@@ -123570,6 +121718,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "cervix, vagina",
@@ -123635,6 +121784,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Cervix, vagina",
@@ -123700,6 +121850,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -123715,6 +121866,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "19",
@@ -124104,6 +122256,7 @@
    "composition": {
     "celltype_HCA_fine": {
      "author_field_name": "celltype_HCA_fine",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Epi_CervixMucinous",
@@ -124114,36 +122267,12 @@
        "author_value": "Epi_CervixMucinous_Secretory",
        "cell_count": 287,
        "cell_ratio": 0.1989
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Epi_CervixMucinous",
-       "cell_count": 1156,
-       "cell_ratio": 0.8011
-      },
-      {
-       "author_value": "Epi_CervixMucinous_Secretory",
-       "cell_count": 287,
-       "cell_ratio": 0.1989
-      }
-     ]
-    },
-    "celltype_HCA_broad": {
-     "author_field_name": "celltype_HCA_broad",
-     "values": [
-      {
-       "author_value": "Epi_CervixMucinous",
-       "cell_count": 1443,
-       "cell_ratio": 1.0
       }
      ]
     },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Cervix",
@@ -124159,6 +122288,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "cervix",
@@ -124174,6 +122304,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "unknown",
@@ -124189,6 +122320,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "35-65",
@@ -124204,6 +122336,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Unknown",
@@ -124219,6 +122352,7 @@
     },
     "Observed_pathology": {
      "author_field_name": "Observed_pathology",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not_applicable",
@@ -124245,48 +122379,9 @@
    "cell_ontology_term": "epithelial cell of cervix",
    "comment": "Supertype/internal node. Its un-subtyped members were split into minted generic leaf/leaves (see children with 'Minted generic leaf' comments). n_cells is the full subtree.",
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Epi_CervixSquamous",
-       "cell_count": 1138,
-       "cell_ratio": 0.7356
-      },
-      {
-       "author_value": "Epi_CervixSquamous_Cyc",
-       "cell_count": 409,
-       "cell_ratio": 0.2644
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Epi_CervixSquamous",
-       "cell_count": 1138,
-       "cell_ratio": 0.7356
-      },
-      {
-       "author_value": "Epi_CervixSquamous_Cyc",
-       "cell_count": 409,
-       "cell_ratio": 0.2644
-      }
-     ]
-    },
-    "celltype_HCA_broad": {
-     "author_field_name": "celltype_HCA_broad",
-     "values": [
-      {
-       "author_value": "Epi_CervixSquamous",
-       "cell_count": 1547,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Cervix",
@@ -124307,6 +122402,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "cervix",
@@ -124327,6 +122423,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "unknown",
@@ -124352,6 +122449,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -124367,6 +122465,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "35-65",
@@ -124427,6 +122526,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Unknown",
@@ -124472,6 +122572,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "control",
@@ -124487,6 +122588,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -124512,6 +122614,7 @@
     },
     "Observed_pathology": {
      "author_field_name": "Observed_pathology",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not_applicable",
@@ -124532,6 +122635,7 @@
     },
     "Sampled_site_condition": {
      "author_field_name": "Sampled_site_condition",
+     "category": "disease",
      "values": [
       {
        "author_value": "normal",
@@ -124558,53 +122662,9 @@
    "cell_ontology_term": "stromal cell",
    "comment": "Supertype/internal node. Its un-subtyped members were split into minted generic leaf/leaves (see children with 'Minted generic leaf' comments). n_cells is the full subtree.",
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Mesen_CervixFib_Fetal",
-       "cell_count": 11916,
-       "cell_ratio": 0.9635
-      },
-      {
-       "author_value": "Mesen_CervixFibs",
-       "cell_count": 452,
-       "cell_ratio": 0.0365
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "unknown",
-       "cell_count": 11916,
-       "cell_ratio": 0.9635
-      },
-      {
-       "author_value": "Mesen_CervixFibs",
-       "cell_count": 452,
-       "cell_ratio": 0.0365
-      }
-     ]
-    },
-    "celltype_HCA_broad": {
-     "author_field_name": "celltype_HCA_broad",
-     "values": [
-      {
-       "author_value": "Mesen_CervixFib",
-       "cell_count": 11916,
-       "cell_ratio": 0.9635
-      },
-      {
-       "author_value": "Mesen_CervixFibs",
-       "cell_count": 452,
-       "cell_ratio": 0.0365
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Reproductive tract",
@@ -124630,6 +122690,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "uterus, cervix",
@@ -124700,6 +122761,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "uterus, cervix",
@@ -124770,6 +122832,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -124785,6 +122848,7 @@
     },
     "Developmental_stage": {
      "author_field_name": "Developmental_stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Fetal",
@@ -124800,6 +122864,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -124820,6 +122885,7 @@
     },
     "Tanner Stage": {
      "author_field_name": "Tanner Stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -124835,6 +122901,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "12",
@@ -124915,6 +122982,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -124935,6 +123003,7 @@
     },
     "Observed_pathology": {
      "author_field_name": "Observed_pathology",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -125187,58 +123256,9 @@
     "Immune_Conventional_DC"
    ],
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Immune_cDC2",
-       "cell_count": 3457,
-       "cell_ratio": 0.5702
-      },
-      {
-       "author_value": "Immune_cDC2_CD207hi",
-       "cell_count": 1533,
-       "cell_ratio": 0.2528
-      },
-      {
-       "author_value": "Immune_cDC1",
-       "cell_count": 1073,
-       "cell_ratio": 0.177
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Immune_cDC2",
-       "cell_count": 3457,
-       "cell_ratio": 0.5702
-      },
-      {
-       "author_value": "Immune_cDC2_CD207hi",
-       "cell_count": 1533,
-       "cell_ratio": 0.2528
-      },
-      {
-       "author_value": "Immune_cDC1",
-       "cell_count": 1073,
-       "cell_ratio": 0.177
-      }
-     ]
-    },
-    "celltype_HCA_broad": {
-     "author_field_name": "celltype_HCA_broad",
-     "values": [
-      {
-       "author_value": "Immune_Conventional_DC",
-       "cell_count": 6063,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Uterus",
@@ -125279,6 +123299,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Endometrium",
@@ -125429,6 +123450,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Endometrium",
@@ -125609,6 +123631,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -125634,6 +123657,7 @@
     },
     "Developmental_stage": {
      "author_field_name": "Developmental_stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Adult",
@@ -125664,6 +123688,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "37",
@@ -125944,6 +123969,7 @@
     },
     "Tanner Stage": {
      "author_field_name": "Tanner Stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Pubic V/Genitals-Breast V",
@@ -125979,6 +124005,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -126094,6 +124121,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Proliferative",
@@ -126179,6 +124207,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "control",
@@ -126354,6 +124383,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -126554,6 +124584,7 @@
     },
     "Observed_pathology": {
      "author_field_name": "Observed_pathology",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -126594,6 +124625,7 @@
     },
     "Sampled_site_condition": {
      "author_field_name": "Sampled_site_condition",
+     "category": "disease",
      "values": [
       {
        "author_value": "normal",
@@ -126807,28 +124839,9 @@
    "parent_cell_set_accession": "HCArepro:L2:0005",
    "n_cells": 9472,
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Mesen_CorpusCavernosumFib_Fetal",
-       "cell_count": 9472,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA_broad": {
-     "author_field_name": "celltype_HCA_broad",
-     "values": [
-      {
-       "author_value": "Mesen_CorpusCavernosumFib",
-       "cell_count": 9472,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Whole_tract",
@@ -126859,6 +124872,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Whole_tract",
@@ -126889,6 +124903,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -126899,6 +124914,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "7.8",
@@ -127089,28 +125105,9 @@
    "parent_cell_set_accession": "HCArepro:L2:0005",
    "n_cells": 10169,
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Mesen_CorpusSpongiosumFib_Fetal",
-       "cell_count": 10169,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA_broad": {
-     "author_field_name": "celltype_HCA_broad",
-     "values": [
-      {
-       "author_value": "Mesen_CorpusSpongiosumFib",
-       "cell_count": 10169,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Reproductive tract",
@@ -127126,6 +125123,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "lower tract",
@@ -127181,6 +125179,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "lower tract",
@@ -127236,6 +125235,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -127246,6 +125246,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "9",
@@ -127538,28 +125539,9 @@
    ],
    "comment": "Minted generic leaf for celltype_HCA_fine='Endo_cap' (21199 cells). The master L1-L4 nomenclature terminates at L2 'Capillary endothelial' with no finer label, so these author-labelled cells — pericytes/etc. the annotators did NOT assign to a finer subtype — had no leaf of their own; the parent node is retained as a pure supertype. cell_label inherited from the supertype nomenclature.",
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Endo_cap",
-       "cell_count": 21199,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Endo_cap",
-       "cell_count": 21199,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Ovary",
@@ -127600,6 +125582,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Ovarian Cortex",
@@ -127750,6 +125733,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Cortex_outer",
@@ -127930,6 +125914,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -127960,6 +125945,7 @@
     },
     "Developmental_stage": {
      "author_field_name": "Developmental_stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Adult",
@@ -127990,6 +125976,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -128295,6 +126282,7 @@
     },
     "Tanner Stage": {
      "author_field_name": "Tanner Stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Pubic V/Genitals-Breast V",
@@ -128335,6 +126323,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -128480,6 +126469,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -128590,6 +126580,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "control",
@@ -128780,6 +126771,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -129005,6 +126997,7 @@
     },
     "Observed_pathology": {
      "author_field_name": "Observed_pathology",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -129045,6 +127038,7 @@
     },
     "Sampled_site_condition": {
      "author_field_name": "Sampled_site_condition",
+     "category": "disease",
      "values": [
       {
        "author_value": "normal",
@@ -129347,28 +127341,9 @@
     "CDK1"
    ],
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Endo_cap_cycl",
-       "cell_count": 5081,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Endo_cap_cycl",
-       "cell_count": 5081,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Uterus",
@@ -129409,6 +127384,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Endometrium",
@@ -129549,6 +127525,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Endometrium",
@@ -129704,6 +127681,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -129734,6 +127712,7 @@
     },
     "Developmental_stage": {
      "author_field_name": "Developmental_stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Adult",
@@ -129759,6 +127738,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -129979,6 +127959,7 @@
     },
     "Tanner Stage": {
      "author_field_name": "Tanner Stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Pubic V/Genitals-Breast V",
@@ -130009,6 +127990,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -130154,6 +128136,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -130259,6 +128242,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "control",
@@ -130354,6 +128338,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -130484,6 +128469,7 @@
     },
     "Observed_pathology": {
      "author_field_name": "Observed_pathology",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -130524,6 +128510,7 @@
     },
     "Sampled_site_condition": {
      "author_field_name": "Sampled_site_condition",
+     "category": "disease",
      "values": [
       {
        "author_value": "normal",
@@ -130769,18 +128756,9 @@
     "EHD3"
    ],
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Endo_cap_kidney",
-       "cell_count": 548,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Ovary",
@@ -130801,6 +128779,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Gonad_and_extragonadal",
@@ -130861,6 +128840,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Gonad_and_extragonadal",
@@ -130921,6 +128901,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -130941,6 +128922,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "6.5",
@@ -131121,28 +129103,9 @@
     "PGF"
    ],
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Endo_cap_tip",
-       "cell_count": 3614,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Endo_cap_tip",
-       "cell_count": 3614,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Ovary",
@@ -131183,6 +129146,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Endometrium",
@@ -131328,6 +129292,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Cortex_outer",
@@ -131488,6 +129453,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "unknown",
@@ -131518,6 +129484,7 @@
     },
     "Developmental_stage": {
      "author_field_name": "Developmental_stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Adult",
@@ -131548,6 +129515,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -131823,6 +129791,7 @@
     },
     "Tanner Stage": {
      "author_field_name": "Tanner Stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Pubic V/Genitals-Breast V",
@@ -131863,6 +129832,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -132003,6 +129973,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Unknown",
@@ -132118,6 +130089,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "control",
@@ -132308,6 +130280,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -132533,6 +130506,7 @@
     },
     "Observed_pathology": {
      "author_field_name": "Observed_pathology",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -132573,6 +130547,7 @@
     },
     "Sampled_site_condition": {
      "author_field_name": "Sampled_site_condition",
+     "category": "disease",
      "values": [
       {
        "author_value": "normal",
@@ -132811,28 +130786,9 @@
     "OSBPL1A"
    ],
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Endo_ven_hev",
-       "cell_count": 11495,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Endo_ven_hev",
-       "cell_count": 11495,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Uterus",
@@ -132863,6 +130819,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Endometrium",
@@ -132943,6 +130900,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Endometrium",
@@ -133043,6 +131001,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -133063,6 +131022,7 @@
     },
     "Developmental_stage": {
      "author_field_name": "Developmental_stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Adult",
@@ -133088,6 +131048,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "30",
@@ -133353,6 +131314,7 @@
     },
     "Tanner Stage": {
      "author_field_name": "Tanner Stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Pubic V/Genitals-Breast V",
@@ -133388,6 +131350,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Secretory Mid",
@@ -133498,6 +131461,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "control",
@@ -133663,6 +131627,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -133863,6 +131828,7 @@
     },
     "Observed_pathology": {
      "author_field_name": "Observed_pathology",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -133903,6 +131869,7 @@
     },
     "Sampled_site_condition": {
      "author_field_name": "Sampled_site_condition",
+     "category": "disease",
      "values": [
       {
        "author_value": "normal",
@@ -134135,48 +132102,9 @@
    "cell_ontology_term": "glandular epithelial cell of endometrium",
    "comment": "Supertype/internal node. Its un-subtyped members were split into minted generic leaf/leaves (see children with 'Minted generic leaf' comments). n_cells is the full subtree.",
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Epi_EndoGlandBas_WIF1",
-       "cell_count": 1694,
-       "cell_ratio": 0.6937
-      },
-      {
-       "author_value": "Epi_EndoGlandBas",
-       "cell_count": 748,
-       "cell_ratio": 0.3063
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Epi_EndoGlandBas_WIF1",
-       "cell_count": 1694,
-       "cell_ratio": 0.6937
-      },
-      {
-       "author_value": "Epi_EndoGlandBas",
-       "cell_count": 748,
-       "cell_ratio": 0.3063
-      }
-     ]
-    },
-    "celltype_HCA_broad": {
-     "author_field_name": "celltype_HCA_broad",
-     "values": [
-      {
-       "author_value": "Epi_EndoGlandBas",
-       "cell_count": 2442,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Endometrium",
@@ -134202,6 +132130,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Endometrium",
@@ -134232,6 +132161,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -134247,6 +132177,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "24",
@@ -134377,6 +132308,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Proliferative Late",
@@ -134467,6 +132399,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "control",
@@ -134502,6 +132435,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -134567,6 +132501,7 @@
     },
     "Observed_pathology": {
      "author_field_name": "Observed_pathology",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -134592,6 +132527,7 @@
     },
     "Sampled_site_condition": {
      "author_field_name": "Sampled_site_condition",
+     "category": "disease",
      "values": [
       {
        "author_value": "normal",
@@ -134751,38 +132687,9 @@
    "n_cells": 7258,
    "comment": "Object data-quality artifact: the h5ad carries two celltype_HCA_fine labels for the same cell type — 'Endo_cap_APCDD1' and 'Endo_cap_APCDD1+' (trailing '+'). Merged here to one leaf via label normalisation; flag to authors.",
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Endo_cap_APCDD1",
-       "cell_count": 4691,
-       "cell_ratio": 0.6463
-      },
-      {
-       "author_value": "Endo_cap_APCDD1+",
-       "cell_count": 2567,
-       "cell_ratio": 0.3537
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Endo_cap_APCDD1",
-       "cell_count": 4691,
-       "cell_ratio": 0.6463
-      },
-      {
-       "author_value": "unknown",
-       "cell_count": 2567,
-       "cell_ratio": 0.3537
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Uterus",
@@ -134808,6 +132715,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Endometrium",
@@ -134923,6 +132831,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Endometrium",
@@ -135048,6 +132957,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -135078,6 +132988,7 @@
     },
     "Developmental_stage": {
      "author_field_name": "Developmental_stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Adult",
@@ -135108,6 +133019,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -135338,6 +133250,7 @@
     },
     "Tanner Stage": {
      "author_field_name": "Tanner Stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Pubic V/Genitals-Breast V",
@@ -135373,6 +133286,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -135453,6 +133367,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -135563,6 +133478,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "control",
@@ -135703,6 +133619,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -135878,6 +133795,7 @@
     },
     "Observed_pathology": {
      "author_field_name": "Observed_pathology",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -135913,6 +133831,7 @@
     },
     "Sampled_site_condition": {
      "author_field_name": "Sampled_site_condition",
+     "category": "disease",
      "values": [
       {
        "author_value": "normal",
@@ -136110,58 +134029,9 @@
    ],
    "comment": "Marker origin: media-4 broad code 'Epi_EndoCil' (supertype-level).",
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Epi_EndoCil_Diff",
-       "cell_count": 8903,
-       "cell_ratio": 0.7487
-      },
-      {
-       "author_value": "Epi_EndoCil_Cyc",
-       "cell_count": 1975,
-       "cell_ratio": 0.1661
-      },
-      {
-       "author_value": "Epi_EndoCil_eProf",
-       "cell_count": 1014,
-       "cell_ratio": 0.0853
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Epi_EndoCil_Diff",
-       "cell_count": 8903,
-       "cell_ratio": 0.7487
-      },
-      {
-       "author_value": "Epi_EndoCil_Cyc",
-       "cell_count": 1975,
-       "cell_ratio": 0.1661
-      },
-      {
-       "author_value": "Epi_EndoCil_eProf",
-       "cell_count": 1014,
-       "cell_ratio": 0.0853
-      }
-     ]
-    },
-    "celltype_HCA_broad": {
-     "author_field_name": "celltype_HCA_broad",
-     "values": [
-      {
-       "author_value": "Epi_EndoCil",
-       "cell_count": 11892,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Endometrium",
@@ -136187,6 +134057,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Endometrium",
@@ -136212,6 +134083,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -136227,6 +134099,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "18-34",
@@ -136372,6 +134245,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Proliferative",
@@ -136467,6 +134341,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "control",
@@ -136517,6 +134392,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -136602,6 +134478,7 @@
     },
     "Observed_pathology": {
      "author_field_name": "Observed_pathology",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -136637,6 +134514,7 @@
     },
     "Sampled_site_condition": {
      "author_field_name": "Sampled_site_condition",
+     "category": "disease",
      "values": [
       {
        "author_value": "normal",
@@ -136934,98 +134812,9 @@
    ],
    "comment": "Marker origin: media-4 broad code 'Epi_EndoGlandFun' (supertype-level).",
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Epi_EndoGlandFun_mSec",
-       "cell_count": 25233,
-       "cell_ratio": 0.2598
-      },
-      {
-       "author_value": "Epi_EndoGlandFun_Prof",
-       "cell_count": 23099,
-       "cell_ratio": 0.2378
-      },
-      {
-       "author_value": "Epi_EndoGlandFun_emSec",
-       "cell_count": 18366,
-       "cell_ratio": 0.1891
-      },
-      {
-       "author_value": "Epi_EndoGlandFun_Prof_Cyc",
-       "cell_count": 12815,
-       "cell_ratio": 0.1319
-      },
-      {
-       "author_value": "Epi_EndoGlandFun_lProf",
-       "cell_count": 11900,
-       "cell_ratio": 0.1225
-      },
-      {
-       "author_value": "Epi_EndoGlandFun_Menstr",
-       "cell_count": 4248,
-       "cell_ratio": 0.0437
-      },
-      {
-       "author_value": "Epi_EndoGlandFun_lSec",
-       "cell_count": 1467,
-       "cell_ratio": 0.0151
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Epi_EndoGlandFun_mSec",
-       "cell_count": 25233,
-       "cell_ratio": 0.2598
-      },
-      {
-       "author_value": "Epi_EndoGlandFun_Prof",
-       "cell_count": 23099,
-       "cell_ratio": 0.2378
-      },
-      {
-       "author_value": "Epi_EndoGlandFun_emSec",
-       "cell_count": 18366,
-       "cell_ratio": 0.1891
-      },
-      {
-       "author_value": "Epi_EndoGlandFun_Prof_Cyc",
-       "cell_count": 12815,
-       "cell_ratio": 0.1319
-      },
-      {
-       "author_value": "Epi_EndoGlandFun_lProf",
-       "cell_count": 11900,
-       "cell_ratio": 0.1225
-      },
-      {
-       "author_value": "Epi_EndoGlandFun_Menstr",
-       "cell_count": 4248,
-       "cell_ratio": 0.0437
-      },
-      {
-       "author_value": "Epi_EndoGlandFun_lSec",
-       "cell_count": 1467,
-       "cell_ratio": 0.0151
-      }
-     ]
-    },
-    "celltype_HCA_broad": {
-     "author_field_name": "celltype_HCA_broad",
-     "values": [
-      {
-       "author_value": "Epi_EndoGlandFun",
-       "cell_count": 97128,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Endometrium",
@@ -137051,6 +134840,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Superficial_Endometrium",
@@ -137076,6 +134866,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -137091,6 +134882,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "18-34",
@@ -137231,6 +135023,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Secretory Mid",
@@ -137326,6 +135119,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "control",
@@ -137386,6 +135180,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -137481,6 +135276,7 @@
     },
     "Observed_pathology": {
      "author_field_name": "Observed_pathology",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -137516,6 +135312,7 @@
     },
     "Sampled_site_condition": {
      "author_field_name": "Sampled_site_condition",
+     "category": "disease",
      "values": [
       {
        "author_value": "normal",
@@ -137913,138 +135710,9 @@
    ],
    "comment": "Marker origin: media-4 broad code 'Mesen_EndoStromalFib' (supertype-level).",
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Mesen_EndoStromalFib_Prolif",
-       "cell_count": 164476,
-       "cell_ratio": 0.3235
-      },
-      {
-       "author_value": "Mesen_EndoStromalFib_mSec",
-       "cell_count": 103861,
-       "cell_ratio": 0.2043
-      },
-      {
-       "author_value": "Mesen_EndoStromalFib_nEMC_Sec",
-       "cell_count": 50283,
-       "cell_ratio": 0.0989
-      },
-      {
-       "author_value": "Mesen_EndoStromalFib_nEMC",
-       "cell_count": 48007,
-       "cell_ratio": 0.0944
-      },
-      {
-       "author_value": "Mesen_EndoStromalFib_lSec",
-       "cell_count": 36137,
-       "cell_ratio": 0.0711
-      },
-      {
-       "author_value": "Mesen_EndoStromalFib_Prolif_Cyc",
-       "cell_count": 32491,
-       "cell_ratio": 0.0639
-      },
-      {
-       "author_value": "Mesen_EndoStromalFib_MenstrualFluid",
-       "cell_count": 27092,
-       "cell_ratio": 0.0533
-      },
-      {
-       "author_value": "Mesen_EndoStromalFib_eSec",
-       "cell_count": 17251,
-       "cell_ratio": 0.0339
-      },
-      {
-       "author_value": "Mesen_EndoStromalFib_MenstrualEutopic",
-       "cell_count": 13034,
-       "cell_ratio": 0.0256
-      },
-      {
-       "author_value": "Mesen_EndoStromalFib_nEMC_Cyc",
-       "cell_count": 12895,
-       "cell_ratio": 0.0254
-      },
-      {
-       "author_value": "Mesen_EndoStromalFib_Menopause",
-       "cell_count": 2855,
-       "cell_ratio": 0.0056
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Mesen_EndoStromalFib_Prolif",
-       "cell_count": 164476,
-       "cell_ratio": 0.3235
-      },
-      {
-       "author_value": "Mesen_EndoStromalFib_mSec",
-       "cell_count": 103861,
-       "cell_ratio": 0.2043
-      },
-      {
-       "author_value": "Mesen_EndoStromalFib_nEMC_Sec",
-       "cell_count": 50283,
-       "cell_ratio": 0.0989
-      },
-      {
-       "author_value": "Mesen_EndoStromalFib_nEMC",
-       "cell_count": 48007,
-       "cell_ratio": 0.0944
-      },
-      {
-       "author_value": "Mesen_EndoStromalFib_lSec",
-       "cell_count": 36137,
-       "cell_ratio": 0.0711
-      },
-      {
-       "author_value": "Mesen_EndoStromalFib_Prolif_Cyc",
-       "cell_count": 32491,
-       "cell_ratio": 0.0639
-      },
-      {
-       "author_value": "Mesen_EndoStromalFib_MenstrualFluid",
-       "cell_count": 27092,
-       "cell_ratio": 0.0533
-      },
-      {
-       "author_value": "Mesen_EndoStromalFib_eSec",
-       "cell_count": 17251,
-       "cell_ratio": 0.0339
-      },
-      {
-       "author_value": "Mesen_EndoStromalFib_MenstrualEutopic",
-       "cell_count": 13034,
-       "cell_ratio": 0.0256
-      },
-      {
-       "author_value": "Mesen_EndoStromalFib_nEMC_Cyc",
-       "cell_count": 12895,
-       "cell_ratio": 0.0254
-      },
-      {
-       "author_value": "Mesen_EndoStromalFib_Menopause",
-       "cell_count": 2855,
-       "cell_ratio": 0.0056
-      }
-     ]
-    },
-    "celltype_HCA_broad": {
-     "author_field_name": "celltype_HCA_broad",
-     "values": [
-      {
-       "author_value": "Mesen_EndoStromalFib",
-       "cell_count": 508382,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Endometrium",
@@ -138070,6 +135738,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Endometrium",
@@ -138100,6 +135769,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -138115,6 +135785,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "32",
@@ -138260,6 +135931,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Proliferative",
@@ -138355,6 +136027,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "control",
@@ -138415,6 +136088,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -138510,6 +136184,7 @@
     },
     "Observed_pathology": {
      "author_field_name": "Observed_pathology",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -138545,6 +136220,7 @@
     },
     "Sampled_site_condition": {
      "author_field_name": "Sampled_site_condition",
+     "category": "disease",
      "values": [
       {
        "author_value": "normal",
@@ -139022,38 +136698,9 @@
    "parent_cell_set_accession": "HCArepro:L2:0012",
    "n_cells": 18196,
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Epi_EndoGland_nEMC",
-       "cell_count": 18196,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Epi_EndoGland_nEMC",
-       "cell_count": 18196,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA_broad": {
-     "author_field_name": "celltype_HCA_broad",
-     "values": [
-      {
-       "author_value": "Epi_EndoGland",
-       "cell_count": 18196,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Endometrium",
@@ -139079,6 +136726,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Superficial_Endometrium",
@@ -139104,6 +136752,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -139119,6 +136768,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "22",
@@ -139264,6 +136914,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Hormones",
@@ -139359,6 +137010,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "endometriosis",
@@ -139414,6 +137066,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -139504,6 +137157,7 @@
     },
     "Observed_pathology": {
      "author_field_name": "Observed_pathology",
+     "category": "disease",
      "values": [
       {
        "author_value": "endometriosis",
@@ -139539,6 +137193,7 @@
     },
     "Sampled_site_condition": {
      "author_field_name": "Sampled_site_condition",
+     "category": "disease",
      "values": [
       {
        "author_value": "endometriosis",
@@ -139773,58 +137428,9 @@
    ],
    "comment": "Marker origin: media-4 broad code 'Epi_EndoGlandLum' (supertype-level).",
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Epi_EndoGlandLum_mSec",
-       "cell_count": 12046,
-       "cell_ratio": 0.554
-      },
-      {
-       "author_value": "Epi_EndoGlandLum_Prof",
-       "cell_count": 9672,
-       "cell_ratio": 0.4449
-      },
-      {
-       "author_value": "Epi_EndoGlandLum_eSec",
-       "cell_count": 24,
-       "cell_ratio": 0.0011
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Epi_EndoGlandLum_mSec",
-       "cell_count": 12046,
-       "cell_ratio": 0.554
-      },
-      {
-       "author_value": "Epi_EndoGlandLum_Prof",
-       "cell_count": 9672,
-       "cell_ratio": 0.4449
-      },
-      {
-       "author_value": "Epi_EndoGlandLum_eSec",
-       "cell_count": 24,
-       "cell_ratio": 0.0011
-      }
-     ]
-    },
-    "celltype_HCA_broad": {
-     "author_field_name": "celltype_HCA_broad",
-     "values": [
-      {
-       "author_value": "Epi_EndoGlandLum",
-       "cell_count": 21742,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Endometrium",
@@ -139850,6 +137456,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Superficial_Endometrium",
@@ -139875,6 +137482,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -139890,6 +137498,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "18-34",
@@ -140030,6 +137639,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Secretory Early-Mid",
@@ -140125,6 +137735,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "control",
@@ -140175,6 +137786,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -140260,6 +137872,7 @@
     },
     "Observed_pathology": {
      "author_field_name": "Observed_pathology",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -140290,6 +137903,7 @@
     },
     "Sampled_site_condition": {
      "author_field_name": "Sampled_site_condition",
+     "category": "disease",
      "values": [
       {
        "author_value": "normal",
@@ -140624,38 +138238,9 @@
    ],
    "comment": "Supertype/internal node. Its un-subtyped members were split into minted generic leaf/leaves (see children with 'Minted generic leaf' comments). n_cells is the full subtree.",
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Mesen_Pericyte_EndoStromalLike",
-       "cell_count": 10229,
-       "cell_ratio": 0.8894
-      },
-      {
-       "author_value": "Mesen_Pericyte_EndoStromalLike_MenstrualFluid",
-       "cell_count": 1272,
-       "cell_ratio": 0.1106
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Mesen_Pericyte_EndoStromalLike",
-       "cell_count": 10229,
-       "cell_ratio": 0.8894
-      },
-      {
-       "author_value": "Mesen_Pericyte_EndoStromalLike_MenstrualFluid",
-       "cell_count": 1272,
-       "cell_ratio": 0.1106
-      }
-     ]
-    },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Endometrium",
@@ -140681,6 +138266,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Endometrium",
@@ -140711,6 +138297,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -140726,6 +138313,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "32",
@@ -140871,6 +138459,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Proliferative",
@@ -140966,6 +138555,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "endometriosis",
@@ -141021,6 +138611,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -141111,6 +138702,7 @@
     },
     "Observed_pathology": {
      "author_field_name": "Observed_pathology",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -141146,6 +138738,7 @@
     },
     "Sampled_site_condition": {
      "author_field_name": "Sampled_site_condition",
+     "category": "disease",
      "values": [
       {
        "author_value": "endometriosis",
@@ -141436,38 +139029,9 @@
     "EMX2"
    ],
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Epi_EctocervixVaginaSquamous",
-       "cell_count": 646,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Epi_EctocervixVaginaSquamous",
-       "cell_count": 646,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA_broad": {
-     "author_field_name": "celltype_HCA_broad",
-     "values": [
-      {
-       "author_value": "Epi_EctocervixVaginaSquamous",
-       "cell_count": 646,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Cervix",
@@ -141483,6 +139047,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "cervix",
@@ -141498,6 +139063,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "unknown",
@@ -141513,6 +139079,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "35-65",
@@ -141533,6 +139100,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Unknown",
@@ -141548,6 +139116,7 @@
     },
     "Observed_pathology": {
      "author_field_name": "Observed_pathology",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not_applicable",
@@ -141585,38 +139154,9 @@
     "WT1"
    ],
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Epi_EndoMucinous",
-       "cell_count": 2110,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Epi_EndoMucinous",
-       "cell_count": 2110,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA_broad": {
-     "author_field_name": "celltype_HCA_broad",
-     "values": [
-      {
-       "author_value": "Epi_EndoMucinous",
-       "cell_count": 2110,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Endometrium",
@@ -141642,6 +139182,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Superficial_Endometrium",
@@ -141667,6 +139208,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -141682,6 +139224,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "26",
@@ -141817,6 +139360,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Proliferative",
@@ -141907,6 +139451,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "control",
@@ -141937,6 +139482,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -142002,6 +139548,7 @@
     },
     "Observed_pathology": {
      "author_field_name": "Observed_pathology",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -142027,6 +139574,7 @@
     },
     "Sampled_site_condition": {
      "author_field_name": "Sampled_site_condition",
+     "category": "disease",
      "values": [
       {
        "author_value": "normal",
@@ -142212,28 +139760,9 @@
     "SOX17"
    ],
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Epi_Mullerian_Undiff",
-       "cell_count": 3605,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA_broad": {
-     "author_field_name": "celltype_HCA_broad",
-     "values": [
-      {
-       "author_value": "Epi_Mullerian",
-       "cell_count": 3605,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Reproductive tract",
@@ -142254,6 +139783,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Gonad_and_extragonadal",
@@ -142344,6 +139874,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Gonad_and_extragonadal",
@@ -142434,6 +139965,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -142454,6 +139986,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "8.6",
@@ -142768,38 +140301,9 @@
     "FOXJ1"
    ],
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Epi_OvarianInclCil",
-       "cell_count": 20,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Epi_OvarianInclCil",
-       "cell_count": 20,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA_broad": {
-     "author_field_name": "celltype_HCA_broad",
-     "values": [
-      {
-       "author_value": "Epi_OvarianInclCil",
-       "cell_count": 20,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Whole_Ovary",
@@ -142820,6 +140324,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Whole_Ovary_left",
@@ -142845,6 +140350,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -142860,6 +140366,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "26",
@@ -142885,6 +140392,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Unknown",
@@ -142900,6 +140408,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "control",
@@ -142920,6 +140429,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -142959,38 +140469,9 @@
    ],
    "comment": "media-4 description: Some are WNT7A;suggesting endometrial origin;while others are OVPG1 suggesting fallopian tube origin",
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Epi_OvarianInclSec",
-       "cell_count": 202,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Epi_OvarianInclSec",
-       "cell_count": 202,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA_broad": {
-     "author_field_name": "celltype_HCA_broad",
-     "values": [
-      {
-       "author_value": "Epi_OvarianInclSec",
-       "cell_count": 202,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Whole_Ovary",
@@ -143016,6 +140497,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Whole_Ovary_right",
@@ -143051,6 +140533,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -143066,6 +140549,7 @@
     },
     "Developmental_stage": {
      "author_field_name": "Developmental_stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Adult",
@@ -143081,6 +140565,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "56",
@@ -143116,6 +140601,7 @@
     },
     "Tanner Stage": {
      "author_field_name": "Tanner Stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Pubic V/Genitals-Breast V",
@@ -143131,6 +140617,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Postmenopausal",
@@ -143151,6 +140638,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "control",
@@ -143176,6 +140664,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -143228,38 +140717,9 @@
     "DSG3"
    ],
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Epi_ParatubalIncl_squamous",
-       "cell_count": 922,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Epi_ParatubalIncl_squamous",
-       "cell_count": 922,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA_broad": {
-     "author_field_name": "celltype_HCA_broad",
-     "values": [
-      {
-       "author_value": "Epi_ParatubalIncl",
-       "cell_count": 922,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Fallopian Tube Fimbria",
@@ -143285,6 +140745,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Fallopian Tube Fimbria",
@@ -143310,6 +140771,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "62",
@@ -143365,6 +140827,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Postmenopausal",
@@ -143435,28 +140898,9 @@
     "SHH"
    ],
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Epi_UGS_Undiff",
-       "cell_count": 3302,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA_broad": {
-     "author_field_name": "celltype_HCA_broad",
-     "values": [
-      {
-       "author_value": "Epi_UGS",
-       "cell_count": 3302,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Reproductive tract",
@@ -143472,6 +140916,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Vagina",
@@ -143532,6 +140977,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Vagina",
@@ -143592,6 +141038,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -143602,6 +141049,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "12",
@@ -143848,28 +141296,9 @@
    "parent_cell_set_accession": "HCArepro:L2:0005",
    "n_cells": 13877,
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Mesen_EpoophronFib_Fetal",
-       "cell_count": 13877,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA_broad": {
-     "author_field_name": "celltype_HCA_broad",
-     "values": [
-      {
-       "author_value": "Mesen_EpoophronFib",
-       "cell_count": 13877,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Ovary",
@@ -143890,6 +141319,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Gonad_and_extragonadal",
@@ -143970,6 +141400,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Gonad_and_extragonadal",
@@ -144050,6 +141481,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -144070,6 +141502,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -144085,6 +141518,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "16",
@@ -144591,48 +142025,9 @@
     "Immune_Erythroid"
    ],
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Immune_LateErythroid",
-       "cell_count": 57,
-       "cell_ratio": 0.5089
-      },
-      {
-       "author_value": "Immune_EarlyMidErythroid",
-       "cell_count": 55,
-       "cell_ratio": 0.4911
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Immune_LateErythroid",
-       "cell_count": 57,
-       "cell_ratio": 0.5089
-      },
-      {
-       "author_value": "Immune_EarlyMidErythroid",
-       "cell_count": 55,
-       "cell_ratio": 0.4911
-      }
-     ]
-    },
-    "celltype_HCA_broad": {
-     "author_field_name": "celltype_HCA_broad",
-     "values": [
-      {
-       "author_value": "Immune_Erythroid",
-       "cell_count": 112,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Ovary",
@@ -144658,6 +142053,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Gonad_and_extragonadal",
@@ -144713,6 +142109,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Gonad_and_extragonadal",
@@ -144768,6 +142165,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Immune",
@@ -144783,6 +142181,7 @@
     },
     "Developmental_stage": {
      "author_field_name": "Developmental_stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Fetal",
@@ -144798,6 +142197,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -144823,6 +142223,7 @@
     },
     "Tanner Stage": {
      "author_field_name": "Tanner Stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -144838,6 +142239,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "14",
@@ -144933,6 +142335,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -144958,6 +142361,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "control",
@@ -144973,6 +142377,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -145081,68 +142486,9 @@
    ],
    "comment": "Marker origin: media-4 broad code 'Epi_FallopianCil' (supertype-level).",
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Epi_FallopianCil_Diff",
-       "cell_count": 12869,
-       "cell_ratio": 0.8942
-      },
-      {
-       "author_value": "Epi_FallopianCil_Cyc",
-       "cell_count": 547,
-       "cell_ratio": 0.038
-      },
-      {
-       "author_value": "Epi_FallopianCil_Fetal",
-       "cell_count": 516,
-       "cell_ratio": 0.0359
-      },
-      {
-       "author_value": "Epi_FallopianCil_Early",
-       "cell_count": 460,
-       "cell_ratio": 0.032
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Epi_FallopianCil_Diff",
-       "cell_count": 12869,
-       "cell_ratio": 0.8942
-      },
-      {
-       "author_value": "Epi_FallopianCil_Cyc",
-       "cell_count": 547,
-       "cell_ratio": 0.038
-      },
-      {
-       "author_value": "unknown",
-       "cell_count": 516,
-       "cell_ratio": 0.0359
-      },
-      {
-       "author_value": "Epi_FallopianCil_Early",
-       "cell_count": 460,
-       "cell_ratio": 0.032
-      }
-     ]
-    },
-    "celltype_HCA_broad": {
-     "author_field_name": "celltype_HCA_broad",
-     "values": [
-      {
-       "author_value": "Epi_FallopianCil",
-       "cell_count": 14392,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Fallopian Tube",
@@ -145163,6 +142509,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Fallopian Tube Fimbria",
@@ -145218,6 +142565,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Fallopian Tube Fimbria",
@@ -145283,6 +142631,7 @@
     },
     "Developmental_stage": {
      "author_field_name": "Developmental_stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Adult",
@@ -145298,6 +142647,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Unknown",
@@ -145393,6 +142743,7 @@
     },
     "Tanner Stage": {
      "author_field_name": "Tanner Stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Pubic V/Genitals-Breast V",
@@ -145408,6 +142759,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -145458,6 +142810,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Unknown",
@@ -145643,63 +142996,9 @@
    ],
    "comment": "Marker origin: media-4 broad code 'Epi_FallopianSec' (supertype-level).",
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Epi_FallopianSec_OVGP1hi_EstrInd",
-       "cell_count": 17601,
-       "cell_ratio": 0.3995
-      },
-      {
-       "author_value": "Epi_FallopianSec_OVGP1lo",
-       "cell_count": 13587,
-       "cell_ratio": 0.3084
-      },
-      {
-       "author_value": "Epi_FallopianSec_Fetal",
-       "cell_count": 12310,
-       "cell_ratio": 0.2794
-      },
-      {
-       "author_value": "Epi_FallopianSec_Cyc",
-       "cell_count": 560,
-       "cell_ratio": 0.0127
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "unknown",
-       "cell_count": 29911,
-       "cell_ratio": 0.6789
-      },
-      {
-       "author_value": "Epi_FallopianSec_OVGP1lo",
-       "cell_count": 13587,
-       "cell_ratio": 0.3084
-      },
-      {
-       "author_value": "Epi_FallopianSec_Cyc",
-       "cell_count": 560,
-       "cell_ratio": 0.0127
-      }
-     ]
-    },
-    "celltype_HCA_broad": {
-     "author_field_name": "celltype_HCA_broad",
-     "values": [
-      {
-       "author_value": "Epi_FallopianSec",
-       "cell_count": 44058,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Fallopian Tube",
@@ -145725,6 +143024,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Fallopian Tube Ampulla",
@@ -145800,6 +143100,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Fallopian Tube Ampulla",
@@ -145885,6 +143186,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -145905,6 +143207,7 @@
     },
     "Developmental_stage": {
      "author_field_name": "Developmental_stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Adult",
@@ -145920,6 +143223,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -146020,6 +143324,7 @@
     },
     "Tanner Stage": {
      "author_field_name": "Tanner Stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Pubic V/Genitals-Breast V",
@@ -146035,6 +143340,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -146155,6 +143461,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Unknown",
@@ -146493,28 +143800,9 @@
    "parent_cell_set_accession": "HCArepro:L2:0045",
    "n_cells": 8413,
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Mesen_FallopianSMCs_Fetal",
-       "cell_count": 8413,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA_broad": {
-     "author_field_name": "celltype_HCA_broad",
-     "values": [
-      {
-       "author_value": "Mesen_FallopianSMCs",
-       "cell_count": 8413,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Reproductive tract",
@@ -146530,6 +143818,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Fallopian Tube",
@@ -146590,6 +143879,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Fallopian Tube",
@@ -146650,6 +143940,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -146665,6 +143956,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "21",
@@ -146972,28 +144264,9 @@
    "parent_cell_set_accession": "HCArepro:L2:0161",
    "n_cells": 18265,
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Mesen_FallopianLig_Fetal",
-       "cell_count": 18265,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA_broad": {
-     "author_field_name": "celltype_HCA_broad",
-     "values": [
-      {
-       "author_value": "Mesen_FallopianLig",
-       "cell_count": 18265,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Reproductive tract",
@@ -147014,6 +144287,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Fallopian Tube",
@@ -147094,6 +144368,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Fallopian Tube",
@@ -147174,6 +144449,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -147194,6 +144470,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -147209,6 +144486,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "12",
@@ -147704,53 +144982,9 @@
    "cell_ontology_term": "stromal cell",
    "comment": "Supertype/internal node. Its un-subtyped members were split into minted generic leaf/leaves (see children with 'Minted generic leaf' comments). n_cells is the full subtree.",
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Mesen_FallopianFibs",
-       "cell_count": 64649,
-       "cell_ratio": 0.6114
-      },
-      {
-       "author_value": "Mesen_FallopianFib_Fetal",
-       "cell_count": 41092,
-       "cell_ratio": 0.3886
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Mesen_FallopianFibs",
-       "cell_count": 64649,
-       "cell_ratio": 0.6114
-      },
-      {
-       "author_value": "unknown",
-       "cell_count": 41092,
-       "cell_ratio": 0.3886
-      }
-     ]
-    },
-    "celltype_HCA_broad": {
-     "author_field_name": "celltype_HCA_broad",
-     "values": [
-      {
-       "author_value": "Mesen_FallopianFibs",
-       "cell_count": 64649,
-       "cell_ratio": 0.6114
-      },
-      {
-       "author_value": "Mesen_FallopianFib",
-       "cell_count": 41092,
-       "cell_ratio": 0.3886
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Fallopian Tube",
@@ -147776,6 +145010,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Fallopian Tube Fimbria",
@@ -147871,6 +145106,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Fallopian Tube Fimbria",
@@ -147976,6 +145212,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -147996,6 +145233,7 @@
     },
     "Developmental_stage": {
      "author_field_name": "Developmental_stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Adult",
@@ -148011,6 +145249,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -148111,6 +145350,7 @@
     },
     "Tanner Stage": {
      "author_field_name": "Tanner Stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Pubic V/Genitals-Breast V",
@@ -148126,6 +145366,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -148266,6 +145507,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -148884,38 +146126,9 @@
    "parent_cell_set_accession": "HCArepro:L2:0143",
    "n_cells": 88,
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Neural_Melanocyte_Fetal",
-       "cell_count": 88,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Neural_Melanocyte_Fetal",
-       "cell_count": 88,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA_broad": {
-     "author_field_name": "celltype_HCA_broad",
-     "values": [
-      {
-       "author_value": "Neural_Melanocyte",
-       "cell_count": 88,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "external genitalia",
@@ -148946,6 +146159,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "External genitalia",
@@ -148976,6 +146190,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -148986,6 +146201,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "15",
@@ -149052,28 +146268,9 @@
    "parent_cell_set_accession": "HCArepro:L2:0001",
    "n_cells": 1482,
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Epi_GenitalSurf_Fetal",
-       "cell_count": 1482,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA_broad": {
-     "author_field_name": "celltype_HCA_broad",
-     "values": [
-      {
-       "author_value": "Epi_GenitalSurf",
-       "cell_count": 1482,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "uterus, cervix, vagina",
@@ -149124,6 +146321,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "uterus, cervix, vagina",
@@ -149174,6 +146372,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -149184,6 +146383,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "15",
@@ -149364,18 +146564,9 @@
     "GDF9"
    ],
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Germcell_Oogonia_meiotic",
-       "cell_count": 1622,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Ovary",
@@ -149391,6 +146582,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Gonad_and_extragonadal",
@@ -149411,6 +146603,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Gonad_and_extragonadal",
@@ -149431,6 +146624,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -149451,6 +146645,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -149466,6 +146661,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "17",
@@ -149620,18 +146816,9 @@
     "SYCP1"
    ],
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Germcell_Oogonia_premeiotic",
-       "cell_count": 3142,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Ovary",
@@ -149647,6 +146834,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Gonad_and_extragonadal",
@@ -149672,6 +146860,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Gonad_and_extragonadal",
@@ -149697,6 +146886,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -149717,6 +146907,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -149732,6 +146923,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "17",
@@ -149860,28 +147052,9 @@
     "MKI67"
    ],
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Germcell_PGC_Cyc",
-       "cell_count": 2592,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA_broad": {
-     "author_field_name": "celltype_HCA_broad",
-     "values": [
-      {
-       "author_value": "Germcell_PGC",
-       "cell_count": 2592,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Ovary",
@@ -149897,6 +147070,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Gonad",
@@ -149927,6 +147101,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Gonad",
@@ -149957,6 +147132,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -149977,6 +147153,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -149992,6 +147169,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "9",
@@ -150159,28 +147337,9 @@
    ],
    "comment": "Minted generic leaf for celltype_HCA_fine='Germcell_PGCs' (6862 cells). The master L1-L4 nomenclature terminates at L2 'Primordial germ cell' with no finer label, so these author-labelled cells — pericytes/etc. the annotators did NOT assign to a finer subtype — had no leaf of their own; the parent node is retained as a pure supertype. cell_label inherited from the supertype nomenclature.",
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Germcell_PGCs",
-       "cell_count": 6862,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA_broad": {
-     "author_field_name": "celltype_HCA_broad",
-     "values": [
-      {
-       "author_value": "Germcell_PGCs",
-       "cell_count": 6862,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Ovary",
@@ -150196,6 +147355,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Gonad",
@@ -150221,6 +147381,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Gonad",
@@ -150246,6 +147407,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -150266,6 +147428,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -150281,6 +147444,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "9",
@@ -150447,28 +147611,9 @@
    "parent_cell_set_accession": "HCArepro:L2:0005",
    "n_cells": 5416,
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Mesen_GlansFib_Fetal",
-       "cell_count": 5416,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA_broad": {
-     "author_field_name": "celltype_HCA_broad",
-     "values": [
-      {
-       "author_value": "Mesen_GlansFib",
-       "cell_count": 5416,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "lower tract",
@@ -150494,6 +147639,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "lower tract",
@@ -150519,6 +147665,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -150529,6 +147676,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "9",
@@ -150715,28 +147863,9 @@
    ],
    "comment": "media-4 description: Expresses SRY in males (in males XY)",
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Gonadal_SupportingUndiff",
-       "cell_count": 16769,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA_broad": {
-     "author_field_name": "celltype_HCA_broad",
-     "values": [
-      {
-       "author_value": "Gonadal_SupportingUndiff",
-       "cell_count": 16769,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Ovary",
@@ -150757,6 +147886,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Gonad",
@@ -150797,6 +147927,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Gonad",
@@ -150837,6 +147968,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -150857,6 +147989,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "6",
@@ -151277,28 +148410,9 @@
     "LHX2"
    ],
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Gonadal_preGranulosa-CEderived",
-       "cell_count": 23076,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA_broad": {
-     "author_field_name": "celltype_HCA_broad",
-     "values": [
-      {
-       "author_value": "Gonadal_preGranulosa-CEderived",
-       "cell_count": 23076,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Ovary",
@@ -151314,6 +148428,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Gonad_and_extragonadal",
@@ -151344,6 +148459,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Gonad_and_extragonadal",
@@ -151374,6 +148490,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -151394,6 +148511,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -151409,6 +148527,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "10",
@@ -151892,58 +149011,9 @@
     "Immune_Granulocytes"
    ],
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Immune_Mast",
-       "cell_count": 5449,
-       "cell_ratio": 0.9846
-      },
-      {
-       "author_value": "Immune_Neutrophils",
-       "cell_count": 45,
-       "cell_ratio": 0.0081
-      },
-      {
-       "author_value": "Immune_BasoEosino",
-       "cell_count": 40,
-       "cell_ratio": 0.0072
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Immune_Mast",
-       "cell_count": 5449,
-       "cell_ratio": 0.9846
-      },
-      {
-       "author_value": "Immune_Neutrophils",
-       "cell_count": 45,
-       "cell_ratio": 0.0081
-      },
-      {
-       "author_value": "Immune_BasoEosino",
-       "cell_count": 40,
-       "cell_ratio": 0.0072
-      }
-     ]
-    },
-    "celltype_HCA_broad": {
-     "author_field_name": "celltype_HCA_broad",
-     "values": [
-      {
-       "author_value": "Immune_Granulocytes",
-       "cell_count": 5534,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Fallopian Tube",
@@ -151979,6 +149049,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Endometrium",
@@ -152094,6 +149165,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Endometrium",
@@ -152229,6 +149301,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -152249,6 +149322,7 @@
     },
     "Developmental_stage": {
      "author_field_name": "Developmental_stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Adult",
@@ -152279,6 +149353,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "30",
@@ -152489,6 +149564,7 @@
     },
     "Tanner Stage": {
      "author_field_name": "Tanner Stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Pubic V/Genitals-Breast V",
@@ -152514,6 +149590,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -152614,6 +149691,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Unknown",
@@ -152689,6 +149767,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "control",
@@ -152769,6 +149848,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -152869,6 +149949,7 @@
     },
     "Observed_pathology": {
      "author_field_name": "Observed_pathology",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -152909,6 +149990,7 @@
     },
     "Sampled_site_condition": {
      "author_field_name": "Sampled_site_condition",
+     "category": "disease",
      "values": [
       {
        "author_value": "normal",
@@ -153174,68 +150256,9 @@
    ],
    "comment": "Marker origin: media-4 broad code 'Granulosa_AMHpos' (supertype-level).",
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Granulosa_AMHpos_Steroidogenic",
-       "cell_count": 15814,
-       "cell_ratio": 0.492
-      },
-      {
-       "author_value": "Granulosa_AMHpos_Cyc",
-       "cell_count": 8927,
-       "cell_ratio": 0.2777
-      },
-      {
-       "author_value": "Granulosa_AMHpos_Atretic",
-       "cell_count": 5440,
-       "cell_ratio": 0.1692
-      },
-      {
-       "author_value": "Granulosa_AMHpos_nonSteroidogenic_early",
-       "cell_count": 1267,
-       "cell_ratio": 0.0394
-      },
-      {
-       "author_value": "Granulosa_AMHpos_nonSteroidogenic",
-       "cell_count": 694,
-       "cell_ratio": 0.0216
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "unknown",
-       "cell_count": 17775,
-       "cell_ratio": 0.553
-      },
-      {
-       "author_value": "Granulosa_AMHpos_Cyc",
-       "cell_count": 8927,
-       "cell_ratio": 0.2777
-      },
-      {
-       "author_value": "Granulosa_AMHpos_Atretic",
-       "cell_count": 5440,
-       "cell_ratio": 0.1692
-      }
-     ]
-    },
-    "celltype_HCA_broad": {
-     "author_field_name": "celltype_HCA_broad",
-     "values": [
-      {
-       "author_value": "Granulosa_AMHpos",
-       "cell_count": 32142,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Ovarian Cortex",
@@ -153261,6 +150284,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Follicle_Inner_cortex",
@@ -153306,6 +150330,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "unknown",
@@ -153326,6 +150351,7 @@
     },
     "Developmental_stage": {
      "author_field_name": "Developmental_stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "paediatric",
@@ -153351,6 +150377,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "2",
@@ -153486,6 +150513,7 @@
     },
     "Tanner Stage": {
      "author_field_name": "Tanner Stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Pubic I/Genitals-Breast I",
@@ -153521,6 +150549,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Paediatric",
@@ -153541,6 +150570,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "Sickle Cell Disease",
@@ -153696,6 +150726,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Sickle Cell Disease",
@@ -153981,43 +151012,9 @@
    "parent_cell_set_accession": "HCArepro:L2:0035",
    "n_cells": 12532,
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Granulosa_AMHneg_Squamous",
-       "cell_count": 5644,
-       "cell_ratio": 0.4504
-      },
-      {
-       "author_value": "Granulosa_sq_Fetal",
-       "cell_count": 3928,
-       "cell_ratio": 0.3134
-      },
-      {
-       "author_value": "Granulosa_AMHneg_Atretic",
-       "cell_count": 2960,
-       "cell_ratio": 0.2362
-      }
-     ]
-    },
-    "celltype_HCA_broad": {
-     "author_field_name": "celltype_HCA_broad",
-     "values": [
-      {
-       "author_value": "Granulosa_AMHneg",
-       "cell_count": 8604,
-       "cell_ratio": 0.6866
-      },
-      {
-       "author_value": "Granulosa_sq",
-       "cell_count": 3928,
-       "cell_ratio": 0.3134
-      }
-     ]
-    },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Ovarian Cortex",
@@ -154053,6 +151050,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Cortex_outer",
@@ -154108,6 +151106,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "unknown",
@@ -154138,6 +151137,7 @@
     },
     "Developmental_stage": {
      "author_field_name": "Developmental_stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "paediatric",
@@ -154168,6 +151168,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "5",
@@ -154303,6 +151304,7 @@
     },
     "Tanner Stage": {
      "author_field_name": "Tanner Stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Pubic I/Genitals-Breast I",
@@ -154343,6 +151345,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -154413,6 +151416,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Paediatric",
@@ -154438,6 +151442,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "control",
@@ -154588,6 +151593,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -154980,38 +151986,9 @@
    "parent_cell_set_accession": "HCArepro:L2:0212",
    "n_cells": 211,
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Immune_HPC",
-       "cell_count": 211,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Immune_HPC",
-       "cell_count": 211,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA_broad": {
-     "author_field_name": "celltype_HCA_broad",
-     "values": [
-      {
-       "author_value": "Immune_Haematopoietic_progenitor_cells",
-       "cell_count": 211,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Ovary",
@@ -155037,6 +152014,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Gonad_and_extragonadal",
@@ -155072,6 +152050,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Gonad_and_extragonadal",
@@ -155107,6 +152086,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Immune",
@@ -155127,6 +152107,7 @@
     },
     "Developmental_stage": {
      "author_field_name": "Developmental_stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Fetal",
@@ -155142,6 +152123,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -155172,6 +152154,7 @@
     },
     "Tanner Stage": {
      "author_field_name": "Tanner Stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -155187,6 +152170,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "14",
@@ -155282,6 +152266,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -155307,6 +152292,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "control",
@@ -155322,6 +152308,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -155337,6 +152324,7 @@
     },
     "Observed_pathology": {
      "author_field_name": "Observed_pathology",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -155352,6 +152340,7 @@
     },
     "Sampled_site_condition": {
      "author_field_name": "Sampled_site_condition",
+     "category": "disease",
      "values": [
       {
        "author_value": "normal",
@@ -155436,48 +152425,9 @@
     "Immune_ILC"
    ],
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Immune_ILC3_NCRhi",
-       "cell_count": 2517,
-       "cell_ratio": 0.8869
-      },
-      {
-       "author_value": "Immune_ILC3_NCRlo",
-       "cell_count": 321,
-       "cell_ratio": 0.1131
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Immune_ILC3_NCRhi",
-       "cell_count": 2517,
-       "cell_ratio": 0.8869
-      },
-      {
-       "author_value": "Immune_ILC3_NCRlo",
-       "cell_count": 321,
-       "cell_ratio": 0.1131
-      }
-     ]
-    },
-    "celltype_HCA_broad": {
-     "author_field_name": "celltype_HCA_broad",
-     "values": [
-      {
-       "author_value": "Immune_ILC",
-       "cell_count": 2838,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Uterus",
@@ -155518,6 +152468,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Endometrium",
@@ -155638,6 +152589,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Endometrium",
@@ -155768,6 +152720,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -155788,6 +152741,7 @@
     },
     "Developmental_stage": {
      "author_field_name": "Developmental_stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Adult",
@@ -155813,6 +152767,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "31",
@@ -156028,6 +152983,7 @@
     },
     "Tanner Stage": {
      "author_field_name": "Tanner Stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Pubic V/Genitals-Breast V",
@@ -156058,6 +153014,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -156178,6 +153135,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Proliferative Early",
@@ -156258,6 +153216,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "control",
@@ -156348,6 +153307,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -156463,6 +153423,7 @@
     },
     "Observed_pathology": {
      "author_field_name": "Observed_pathology",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -156503,6 +153464,7 @@
     },
     "Sampled_site_condition": {
      "author_field_name": "Sampled_site_condition",
+     "category": "disease",
      "values": [
       {
        "author_value": "normal",
@@ -156736,38 +153698,9 @@
     "PRSS57"
    ],
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Immune_MegaPlat",
-       "cell_count": 177,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Immune_MegaPlat",
-       "cell_count": 177,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA_broad": {
-     "author_field_name": "celltype_HCA_broad",
-     "values": [
-      {
-       "author_value": "Immune_Megakaryocytes/platelets",
-       "cell_count": 177,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Ovary",
@@ -156793,6 +153726,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Gonad_and_extragonadal",
@@ -156863,6 +153797,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Gonad_and_extragonadal",
@@ -156933,6 +153868,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -156953,6 +153889,7 @@
     },
     "Developmental_stage": {
      "author_field_name": "Developmental_stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Fetal",
@@ -156968,6 +153905,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -156983,6 +153921,7 @@
     },
     "Tanner Stage": {
      "author_field_name": "Tanner Stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -156998,6 +153937,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "14",
@@ -157133,6 +154073,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -157198,28 +154139,9 @@
    "parent_cell_set_accession": "HCArepro:L2:0005",
    "n_cells": 1794,
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Mesen_LabiaFib_Fetal",
-       "cell_count": 1794,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA_broad": {
-     "author_field_name": "celltype_HCA_broad",
-     "values": [
-      {
-       "author_value": "Mesen_LabiaFib",
-       "cell_count": 1794,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "uterus, cervix, vagina",
@@ -157250,6 +154172,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "uterus, cervix, vagina",
@@ -157280,6 +154203,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -157290,6 +154214,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "15",
@@ -157422,28 +154347,9 @@
    "parent_cell_set_accession": "HCArepro:L2:0005",
    "n_cells": 6830,
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Mesen_LabioScrotalSwelling_Fetal",
-       "cell_count": 6830,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA_broad": {
-     "author_field_name": "celltype_HCA_broad",
-     "values": [
-      {
-       "author_value": "Mesen_LabioScrotalSwelling",
-       "cell_count": 6830,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Reproductive tract",
@@ -157464,6 +154370,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "external genitalia",
@@ -157514,6 +154421,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "External genitalia",
@@ -157564,6 +154472,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -157579,6 +154488,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "9",
@@ -157869,88 +154779,9 @@
     "Immune_Macrophages"
    ],
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Immune_uMac_Inf",
-       "cell_count": 23069,
-       "cell_ratio": 0.4879
-      },
-      {
-       "author_value": "Immune_Mac_LYVE1hi",
-       "cell_count": 16783,
-       "cell_ratio": 0.355
-      },
-      {
-       "author_value": "Immune_uftLAM",
-       "cell_count": 2760,
-       "cell_ratio": 0.0584
-      },
-      {
-       "author_value": "Immune_Mac_Cyc",
-       "cell_count": 2560,
-       "cell_ratio": 0.0541
-      },
-      {
-       "author_value": "Immune_Mac_Transitional",
-       "cell_count": 1787,
-       "cell_ratio": 0.0378
-      },
-      {
-       "author_value": "Immune_oLAM",
-       "cell_count": 321,
-       "cell_ratio": 0.0068
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Immune_uMac_Inf",
-       "cell_count": 23069,
-       "cell_ratio": 0.4879
-      },
-      {
-       "author_value": "Immune_Mac_LYVE1hi",
-       "cell_count": 16783,
-       "cell_ratio": 0.355
-      },
-      {
-       "author_value": "Immune_uftLAM",
-       "cell_count": 2760,
-       "cell_ratio": 0.0584
-      },
-      {
-       "author_value": "Immune_Mac_Cyc",
-       "cell_count": 2560,
-       "cell_ratio": 0.0541
-      },
-      {
-       "author_value": "Immune_Mac_Transitional",
-       "cell_count": 1787,
-       "cell_ratio": 0.0378
-      },
-      {
-       "author_value": "Immune_oLAM",
-       "cell_count": 321,
-       "cell_ratio": 0.0068
-      }
-     ]
-    },
-    "celltype_HCA_broad": {
-     "author_field_name": "celltype_HCA_broad",
-     "values": [
-      {
-       "author_value": "Immune_Macrophages",
-       "cell_count": 47280,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Uterus",
@@ -157991,6 +154822,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Mentrual fluid",
@@ -158146,6 +154978,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Mentrual fluid",
@@ -158336,6 +155169,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -158366,6 +155200,7 @@
     },
     "Developmental_stage": {
      "author_field_name": "Developmental_stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Adult",
@@ -158396,6 +155231,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "33",
@@ -158681,6 +155517,7 @@
     },
     "Tanner Stage": {
      "author_field_name": "Tanner Stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Pubic V/Genitals-Breast V",
@@ -158721,6 +155558,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -158871,6 +155709,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Menstrual",
@@ -158956,6 +155795,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "control",
@@ -159141,6 +155981,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -159351,6 +156192,7 @@
     },
     "Observed_pathology": {
      "author_field_name": "Observed_pathology",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -159391,6 +156233,7 @@
     },
     "Sampled_site_condition": {
      "author_field_name": "Sampled_site_condition",
+     "category": "disease",
      "values": [
       {
        "author_value": "normal",
@@ -159621,28 +156464,9 @@
    ],
    "comment": "Minted generic leaf for celltype_HCA_fine='Mesen_AdvFibs' (19 cells). The master L1-L4 nomenclature terminates at L2 'Adventitial fibroblasts' with no finer label, so these author-labelled cells — pericytes/etc. the annotators did NOT assign to a finer subtype — had no leaf of their own; the parent node is retained as a pure supertype. cell_label inherited from the supertype nomenclature.",
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Mesen_AdvFibs",
-       "cell_count": 19,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Mesen_AdvFibs",
-       "cell_count": 19,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Endometrium",
@@ -159658,6 +156482,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Endometrium",
@@ -159678,6 +156503,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -159693,6 +156519,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "23",
@@ -159743,6 +156570,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Secretory Early-Mid",
@@ -159778,6 +156606,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "control",
@@ -159798,6 +156627,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -159833,6 +156663,7 @@
     },
     "Observed_pathology": {
      "author_field_name": "Observed_pathology",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -159853,6 +156684,7 @@
     },
     "Sampled_site_condition": {
      "author_field_name": "Sampled_site_condition",
+     "category": "disease",
      "values": [
       {
        "author_value": "normal",
@@ -159940,38 +156772,9 @@
     "MMP3"
    ],
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Mesen_EndoGlandBas",
-       "cell_count": 535,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Mesen_EndoGlandBas",
-       "cell_count": 535,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA_broad": {
-     "author_field_name": "celltype_HCA_broad",
-     "values": [
-      {
-       "author_value": "Mesen_EndoGlandBas",
-       "cell_count": 535,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Myometrium",
@@ -159992,6 +156795,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Myometrium",
@@ -160012,6 +156816,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -160027,6 +156832,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "31",
@@ -160072,6 +156878,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Proliferative",
@@ -160112,6 +156919,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "control",
@@ -160127,6 +156935,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -160152,6 +156961,7 @@
     },
     "Observed_pathology": {
      "author_field_name": "Observed_pathology",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -160167,6 +156977,7 @@
     },
     "Sampled_site_condition": {
      "author_field_name": "Sampled_site_condition",
+     "category": "disease",
      "values": [
       {
        "author_value": "normal",
@@ -160270,28 +157081,9 @@
     "IL17B"
    ],
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Mesen_GonadalFibs_Undiff",
-       "cell_count": 26055,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA_broad": {
-     "author_field_name": "celltype_HCA_broad",
-     "values": [
-      {
-       "author_value": "Mesen_GonadalFibs",
-       "cell_count": 26055,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Ovary",
@@ -160312,6 +157104,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Gonad_and_extragonadal",
@@ -160397,6 +157190,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Gonad_and_extragonadal",
@@ -160482,6 +157276,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -160502,6 +157297,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -160517,6 +157313,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "6",
@@ -161289,28 +158086,9 @@
     "DPT"
    ],
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Mesen_OvarianFibs_AdvLike",
-       "cell_count": 507,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Mesen_OvarianFibs_AdvLike",
-       "cell_count": 507,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Whole_Ovary",
@@ -161341,6 +158119,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Whole_Ovary_right",
@@ -161376,6 +158155,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -161391,6 +158171,7 @@
     },
     "Developmental_stage": {
      "author_field_name": "Developmental_stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Adult",
@@ -161416,6 +158197,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "26",
@@ -161531,6 +158313,7 @@
     },
     "Tanner Stage": {
      "author_field_name": "Tanner Stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Pubic V/Genitals-Breast V",
@@ -161566,6 +158349,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Unknown",
@@ -161591,6 +158375,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "control",
@@ -161706,6 +158491,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -161901,38 +158687,9 @@
     "RGS5"
    ],
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Mesen_OvarianInclFibs",
-       "cell_count": 96,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Mesen_OvarianInclFibs",
-       "cell_count": 96,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA_broad": {
-     "author_field_name": "celltype_HCA_broad",
-     "values": [
-      {
-       "author_value": "Mesen_OvarianInclFibs",
-       "cell_count": 96,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Whole_Ovary",
@@ -161958,6 +158715,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Cortex_outer",
@@ -161988,6 +158746,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -162003,6 +158762,7 @@
     },
     "Developmental_stage": {
      "author_field_name": "Developmental_stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Adult",
@@ -162023,6 +158783,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "40",
@@ -162098,6 +158859,7 @@
     },
     "Tanner Stage": {
      "author_field_name": "Tanner Stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Pubic V/Genitals-Breast V",
@@ -162113,6 +158875,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Unknown",
@@ -162128,6 +158891,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "control",
@@ -162168,6 +158932,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -162268,28 +159033,9 @@
     "PDGFRA"
    ],
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Mesen_PV_Fetal",
-       "cell_count": 28897,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA_broad": {
-     "author_field_name": "celltype_HCA_broad",
-     "values": [
-      {
-       "author_value": "Mesen_PV",
-       "cell_count": 28897,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Reproductive tract",
@@ -162310,6 +159056,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Gonad_and_extragonadal",
@@ -162395,6 +159142,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Gonad_and_extragonadal",
@@ -162480,6 +159228,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -162500,6 +159249,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -162515,6 +159265,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "21",
@@ -163276,28 +160027,9 @@
     "STEAP4"
    ],
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Mesen_Pericyte_EndoSpiralArt",
-       "cell_count": 6617,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Mesen_Pericyte_EndoSpiralArt",
-       "cell_count": 6617,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Uterus",
@@ -163328,6 +160060,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Endometrium",
@@ -163403,6 +160136,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Endometrium",
@@ -163493,6 +160227,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -163513,6 +160248,7 @@
     },
     "Developmental_stage": {
      "author_field_name": "Developmental_stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Adult",
@@ -163538,6 +160274,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "29",
@@ -163788,6 +160525,7 @@
     },
     "Tanner Stage": {
      "author_field_name": "Tanner Stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Pubic V/Genitals-Breast V",
@@ -163823,6 +160561,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Secretory Mid",
@@ -163928,6 +160667,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "control",
@@ -164078,6 +160818,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -164263,6 +161004,7 @@
     },
     "Observed_pathology": {
      "author_field_name": "Observed_pathology",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -164303,6 +161045,7 @@
     },
     "Sampled_site_condition": {
      "author_field_name": "Sampled_site_condition",
+     "category": "disease",
      "values": [
       {
        "author_value": "normal",
@@ -164500,38 +161243,9 @@
     "CNN1"
    ],
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Mesen_SMCs",
-       "cell_count": 41488,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Mesen_SMCs",
-       "cell_count": 41488,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA_broad": {
-     "author_field_name": "celltype_HCA_broad",
-     "values": [
-      {
-       "author_value": "Mesen_SMCs",
-       "cell_count": 41488,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Uterus",
@@ -164557,6 +161271,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Whole_Uterus",
@@ -164622,6 +161337,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Endometrium",
@@ -164712,6 +161428,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -164732,6 +161449,7 @@
     },
     "Developmental_stage": {
      "author_field_name": "Developmental_stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Adult",
@@ -164752,6 +161470,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "23",
@@ -164992,6 +161711,7 @@
     },
     "Tanner Stage": {
      "author_field_name": "Tanner Stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Pubic V/Genitals-Breast V",
@@ -165027,6 +161747,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Postmenopausal",
@@ -165122,6 +161843,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "control",
@@ -165242,6 +161964,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -165392,6 +162115,7 @@
     },
     "Observed_pathology": {
      "author_field_name": "Observed_pathology",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -165417,6 +162141,7 @@
     },
     "Sampled_site_condition": {
      "author_field_name": "Sampled_site_condition",
+     "category": "disease",
      "values": [
       {
        "author_value": "normal",
@@ -165864,28 +162589,9 @@
     "ANPEP"
    ],
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Mesen_Theca_Externa",
-       "cell_count": 30089,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Mesen_Theca_Externa",
-       "cell_count": 30089,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Ovarian Cortex",
@@ -165916,6 +162622,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Cortex_outer",
@@ -165966,6 +162673,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "unknown",
@@ -165986,6 +162694,7 @@
     },
     "Developmental_stage": {
      "author_field_name": "Developmental_stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Adult",
@@ -166011,6 +162720,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "10",
@@ -166156,6 +162866,7 @@
     },
     "Tanner Stage": {
      "author_field_name": "Tanner Stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Pubic V/Genitals-Breast V",
@@ -166191,6 +162902,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Unknown",
@@ -166216,6 +162928,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "ERCC6L2-associated inherited bone marrow failure syndrome",
@@ -166366,6 +163079,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "ERCC6L2-associated inherited bone marrow failure syndrome",
@@ -166675,28 +163389,9 @@
     "PTGER3"
    ],
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Mesen_UGSLig",
-       "cell_count": 2661,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA_broad": {
-     "author_field_name": "celltype_HCA_broad",
-     "values": [
-      {
-       "author_value": "Mesen_UGSLig",
-       "cell_count": 2661,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Reproductive tract",
@@ -166712,6 +163407,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Whole_tract",
@@ -166767,6 +163463,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Whole_tract",
@@ -166822,6 +163519,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -166837,6 +163535,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "5.6",
@@ -167083,28 +163782,9 @@
    "cell_ontology_term_id": "CL:0000192",
    "cell_ontology_term": "smooth muscle cell",
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Mesen_UGSSMCs",
-       "cell_count": 383,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA_broad": {
-     "author_field_name": "celltype_HCA_broad",
-     "values": [
-      {
-       "author_value": "Mesen_UGSSMCs",
-       "cell_count": 383,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Reproductive tract",
@@ -167120,6 +163800,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "uterus, cervix, vagina",
@@ -167165,6 +163846,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "uterus, cervix, vagina",
@@ -167210,6 +163892,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -167225,6 +163908,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "13",
@@ -167386,38 +164070,9 @@
     "RGS5"
    ],
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Mesen_UterotubalJunctionFibs",
-       "cell_count": 150,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Mesen_UterotubalJunctionFibs",
-       "cell_count": 150,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA_broad": {
-     "author_field_name": "celltype_HCA_broad",
-     "values": [
-      {
-       "author_value": "Mesen_UterotubalJunctionFibs",
-       "cell_count": 150,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Fallopian Tube Isthmus",
@@ -167443,6 +164098,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Fallopian Tube Isthmus",
@@ -167468,6 +164124,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "65",
@@ -167518,6 +164175,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Postmenopausal",
@@ -167588,28 +164246,9 @@
     "GATA2"
    ],
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Meso_GonadalCoelEpi",
-       "cell_count": 2840,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA_broad": {
-     "author_field_name": "celltype_HCA_broad",
-     "values": [
-      {
-       "author_value": "Meso_GonadalCoelEpi",
-       "cell_count": 2840,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Ovary",
@@ -167630,6 +164269,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Gonad_and_extragonadal",
@@ -167695,6 +164335,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Gonad_and_extragonadal",
@@ -167760,6 +164401,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -167780,6 +164422,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -167795,6 +164438,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "8.6",
@@ -168187,28 +164831,9 @@
     "GATA2"
    ],
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Meso_OSE",
-       "cell_count": 841,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Meso_OSE",
-       "cell_count": 841,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Follicle",
@@ -168234,6 +164859,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Antral_follicle",
@@ -168269,6 +164895,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "unknown",
@@ -168284,6 +164911,7 @@
     },
     "Developmental_stage": {
      "author_field_name": "Developmental_stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Adult",
@@ -168309,6 +164937,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "31",
@@ -168399,6 +165028,7 @@
     },
     "Tanner Stage": {
      "author_field_name": "Tanner Stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Pubic V/Genitals-Breast V",
@@ -168429,6 +165059,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Unknown",
@@ -168449,6 +165080,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "Stroke",
@@ -168509,6 +165141,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Stroke",
@@ -168613,18 +165246,9 @@
     "GATA2"
    ],
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Meso_OSE_Fetal",
-       "cell_count": 23115,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Ovary",
@@ -168645,6 +165269,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Gonad",
@@ -168715,6 +165340,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Gonad",
@@ -168785,6 +165411,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -168805,6 +165432,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -168820,6 +165448,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "10",
@@ -169381,28 +166010,9 @@
     "PAX8"
    ],
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Meso_ParamesoCoelEpi",
-       "cell_count": 8490,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA_broad": {
-     "author_field_name": "celltype_HCA_broad",
-     "values": [
-      {
-       "author_value": "Meso_ParamesoCoelEpi",
-       "cell_count": 8490,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Reproductive tract",
@@ -169423,6 +166033,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Gonad_and_extragonadal",
@@ -169498,6 +166109,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Gonad_and_extragonadal",
@@ -169573,6 +166185,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -169593,6 +166206,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -169608,6 +166222,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "6.6",
@@ -170030,28 +166645,9 @@
     "PAX8"
    ],
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Meso_Peritoneal_Fetal",
-       "cell_count": 4720,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA_broad": {
-     "author_field_name": "celltype_HCA_broad",
-     "values": [
-      {
-       "author_value": "Meso_Peritoneal",
-       "cell_count": 4720,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Ovary",
@@ -170072,6 +166668,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Gonad_and_extragonadal",
@@ -170127,6 +166724,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Gonad_and_extragonadal",
@@ -170182,6 +166780,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -170202,6 +166801,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "6.5",
@@ -170588,38 +167188,9 @@
     "PAX8"
    ],
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Meso_serosa",
-       "cell_count": 453,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Meso_serosa",
-       "cell_count": 453,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA_broad": {
-     "author_field_name": "celltype_HCA_broad",
-     "values": [
-      {
-       "author_value": "Meso_serosa",
-       "cell_count": 453,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Fallopian Tube",
@@ -170635,6 +167206,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Fallopian Tube Ampulla",
@@ -170680,6 +167252,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Fallopian Tube Ampulla",
@@ -170735,6 +167308,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -170750,6 +167324,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "61",
@@ -170840,6 +167415,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Postmenopausal",
@@ -170890,6 +167466,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "control",
@@ -170910,6 +167487,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -170930,6 +167508,7 @@
     },
     "Observed_pathology": {
      "author_field_name": "Observed_pathology",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -170945,6 +167524,7 @@
     },
     "Sampled_site_condition": {
      "author_field_name": "Sampled_site_condition",
+     "category": "disease",
      "values": [
       {
        "author_value": "normal",
@@ -171059,28 +167639,9 @@
     "HTR2B"
    ],
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Mesen_MesonephricFibs_Fetal",
-       "cell_count": 28521,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA_broad": {
-     "author_field_name": "celltype_HCA_broad",
-     "values": [
-      {
-       "author_value": "Mesen_MesonephricFibs",
-       "cell_count": 28521,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Reproductive tract",
@@ -171101,6 +167662,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Gonad_and_extragonadal",
@@ -171171,6 +167733,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Gonad_and_extragonadal",
@@ -171241,6 +167804,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -171261,6 +167825,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -171276,6 +167841,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "9",
@@ -171765,28 +168331,9 @@
    "parent_cell_set_accession": "HCArepro:L2:0012",
    "n_cells": 7359,
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Epi_MesonephricTub_Fetal",
-       "cell_count": 7359,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA_broad": {
-     "author_field_name": "celltype_HCA_broad",
-     "values": [
-      {
-       "author_value": "Epi_MesonephricTub",
-       "cell_count": 7359,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Reproductive tract",
@@ -171807,6 +168354,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Whole_tract",
@@ -171887,6 +168435,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Whole_tract",
@@ -171967,6 +168516,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -171987,6 +168537,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "5.6",
@@ -172431,48 +168982,9 @@
     "Immune_Monocytes"
    ],
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Immune_MO_Classical",
-       "cell_count": 13759,
-       "cell_ratio": 0.8664
-      },
-      {
-       "author_value": "Immune_MO_NonClassical",
-       "cell_count": 2122,
-       "cell_ratio": 0.1336
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Immune_MO_Classical",
-       "cell_count": 13759,
-       "cell_ratio": 0.8664
-      },
-      {
-       "author_value": "Immune_MO_NonClassical",
-       "cell_count": 2122,
-       "cell_ratio": 0.1336
-      }
-     ]
-    },
-    "celltype_HCA_broad": {
-     "author_field_name": "celltype_HCA_broad",
-     "values": [
-      {
-       "author_value": "Immune_Monocytes",
-       "cell_count": 15881,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Uterus",
@@ -172513,6 +169025,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Fallopian Tube",
@@ -172663,6 +169176,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Fallopian Tube",
@@ -172848,6 +169362,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -172873,6 +169388,7 @@
     },
     "Developmental_stage": {
      "author_field_name": "Developmental_stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Adult",
@@ -172898,6 +169414,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "37",
@@ -173168,6 +169685,7 @@
     },
     "Tanner Stage": {
      "author_field_name": "Tanner Stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Pubic V/Genitals-Breast V",
@@ -173198,6 +169716,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -173343,6 +169862,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Unknown",
@@ -173428,6 +169948,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "control",
@@ -173568,6 +170089,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -173733,6 +170255,7 @@
     },
     "Observed_pathology": {
      "author_field_name": "Observed_pathology",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -173773,6 +170296,7 @@
     },
     "Sampled_site_condition": {
      "author_field_name": "Sampled_site_condition",
+     "category": "disease",
      "values": [
       {
        "author_value": "normal",
@@ -173954,28 +170478,9 @@
    "parent_cell_set_accession": "HCArepro:L2:0005",
    "n_cells": 2471,
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Mesen_MullerianFib",
-       "cell_count": 2471,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA_broad": {
-     "author_field_name": "celltype_HCA_broad",
-     "values": [
-      {
-       "author_value": "Mesen_MullerianFib",
-       "cell_count": 2471,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Mesonephros",
@@ -173996,6 +170501,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Extragonadal",
@@ -174051,6 +170557,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Extragonadal",
@@ -174106,6 +170613,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -174126,6 +170634,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "8.6",
@@ -174425,48 +170934,9 @@
     "Immune_Myeloid_progenitors"
    ],
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Immune_NMP_Promyelocytes",
-       "cell_count": 286,
-       "cell_ratio": 0.5336
-      },
-      {
-       "author_value": "Immune_MEMP",
-       "cell_count": 250,
-       "cell_ratio": 0.4664
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Immune_NMP_Promyelocytes",
-       "cell_count": 286,
-       "cell_ratio": 0.5336
-      },
-      {
-       "author_value": "Immune_MEMP",
-       "cell_count": 250,
-       "cell_ratio": 0.4664
-      }
-     ]
-    },
-    "celltype_HCA_broad": {
-     "author_field_name": "celltype_HCA_broad",
-     "values": [
-      {
-       "author_value": "Immune_Myeloid_progenitors",
-       "cell_count": 536,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Ovary",
@@ -174502,6 +170972,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Gonad_and_extragonadal",
@@ -174602,6 +171073,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Gonad_and_extragonadal",
@@ -174712,6 +171184,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Immune",
@@ -174732,6 +171205,7 @@
     },
     "Developmental_stage": {
      "author_field_name": "Developmental_stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Fetal",
@@ -174752,6 +171226,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -174842,6 +171317,7 @@
     },
     "Tanner Stage": {
      "author_field_name": "Tanner Stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -174862,6 +171338,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "14",
@@ -174987,6 +171464,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -175037,6 +171515,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "control",
@@ -175077,6 +171556,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -175122,6 +171602,7 @@
     },
     "Observed_pathology": {
      "author_field_name": "Observed_pathology",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -175147,6 +171628,7 @@
     },
     "Sampled_site_condition": {
      "author_field_name": "Sampled_site_condition",
+     "category": "disease",
      "values": [
       {
        "author_value": "normal",
@@ -175261,88 +171743,9 @@
     "NK cells"
    ],
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Immune_uNK2",
-       "cell_count": 12245,
-       "cell_ratio": 0.3436
-      },
-      {
-       "author_value": "Immune_uNK3",
-       "cell_count": 10688,
-       "cell_ratio": 0.2999
-      },
-      {
-       "author_value": "Immune_NK_CD16hi",
-       "cell_count": 5175,
-       "cell_ratio": 0.1452
-      },
-      {
-       "author_value": "Immune_uNK1",
-       "cell_count": 3543,
-       "cell_ratio": 0.0994
-      },
-      {
-       "author_value": "Immune_NK_Cyc",
-       "cell_count": 3503,
-       "cell_ratio": 0.0983
-      },
-      {
-       "author_value": "Immune_NK_CD56dim_CD16dim_SPTSSBhi",
-       "cell_count": 480,
-       "cell_ratio": 0.0135
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Immune_uNK2",
-       "cell_count": 12245,
-       "cell_ratio": 0.3436
-      },
-      {
-       "author_value": "Immune_uNK3",
-       "cell_count": 10688,
-       "cell_ratio": 0.2999
-      },
-      {
-       "author_value": "Immune_NK_CD16hi",
-       "cell_count": 5175,
-       "cell_ratio": 0.1452
-      },
-      {
-       "author_value": "Immune_uNK1",
-       "cell_count": 3543,
-       "cell_ratio": 0.0994
-      },
-      {
-       "author_value": "Immune_NK_Cyc",
-       "cell_count": 3503,
-       "cell_ratio": 0.0983
-      },
-      {
-       "author_value": "Immune_NK_CD56dim_CD16dim_SPTSSBhi",
-       "cell_count": 480,
-       "cell_ratio": 0.0135
-      }
-     ]
-    },
-    "celltype_HCA_broad": {
-     "author_field_name": "celltype_HCA_broad",
-     "values": [
-      {
-       "author_value": "Immune_NK_cells",
-       "cell_count": 35634,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Uterus",
@@ -175383,6 +171786,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Endometrium",
@@ -175528,6 +171932,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Endometrium",
@@ -175708,6 +172113,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -175733,6 +172139,7 @@
     },
     "Developmental_stage": {
      "author_field_name": "Developmental_stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Adult",
@@ -175763,6 +172170,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "32",
@@ -176048,6 +172456,7 @@
     },
     "Tanner Stage": {
      "author_field_name": "Tanner Stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Pubic V/Genitals-Breast V",
@@ -176088,6 +172497,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -176203,6 +172613,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Proliferative",
@@ -176288,6 +172699,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "control",
@@ -176463,6 +172875,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -176663,6 +173076,7 @@
     },
     "Observed_pathology": {
      "author_field_name": "Observed_pathology",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -176703,6 +173117,7 @@
     },
     "Sampled_site_condition": {
      "author_field_name": "Sampled_site_condition",
+     "category": "disease",
      "values": [
       {
        "author_value": "normal",
@@ -176980,28 +173395,9 @@
    ],
    "comment": "Minted generic leaf for celltype_HCA_fine='Neural_Schwann' (781 cells). The master L1-L4 nomenclature terminates at L2 'Glials' with no finer label, so these author-labelled cells — pericytes/etc. the annotators did NOT assign to a finer subtype — had no leaf of their own; the parent node is retained as a pure supertype. cell_label inherited from the supertype nomenclature.",
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Neural_Schwann",
-       "cell_count": 781,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Neural_Schwann",
-       "cell_count": 781,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Ovary",
@@ -177027,6 +173423,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Ovarian Cortex",
@@ -177092,6 +173489,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Cortex_outer",
@@ -177182,6 +173580,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "unknown",
@@ -177202,6 +173601,7 @@
     },
     "Developmental_stage": {
      "author_field_name": "Developmental_stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "paediatric",
@@ -177227,6 +173627,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "7",
@@ -177462,6 +173863,7 @@
     },
     "Tanner Stage": {
      "author_field_name": "Tanner Stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Pubic V/Genitals-Breast V",
@@ -177497,6 +173899,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Paediatric",
@@ -177567,6 +173970,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "control",
@@ -177707,6 +174111,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -177852,6 +174257,7 @@
     },
     "Observed_pathology": {
      "author_field_name": "Observed_pathology",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -177867,6 +174273,7 @@
     },
     "Sampled_site_condition": {
      "author_field_name": "Sampled_site_condition",
+     "category": "disease",
      "values": [
       {
        "author_value": "normal",
@@ -178023,68 +174430,9 @@
     "Immune_Non-conventional_DC"
    ],
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Immune_mregDC",
-       "cell_count": 1577,
-       "cell_ratio": 0.5445
-      },
-      {
-       "author_value": "Immune_pDC",
-       "cell_count": 1203,
-       "cell_ratio": 0.4154
-      },
-      {
-       "author_value": "Immune_ASDC",
-       "cell_count": 69,
-       "cell_ratio": 0.0238
-      },
-      {
-       "author_value": "Immune_tolDC",
-       "cell_count": 47,
-       "cell_ratio": 0.0162
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Immune_mregDC",
-       "cell_count": 1577,
-       "cell_ratio": 0.5445
-      },
-      {
-       "author_value": "Immune_pDC",
-       "cell_count": 1203,
-       "cell_ratio": 0.4154
-      },
-      {
-       "author_value": "Immune_ASDC",
-       "cell_count": 69,
-       "cell_ratio": 0.0238
-      },
-      {
-       "author_value": "Immune_tolDC",
-       "cell_count": 47,
-       "cell_ratio": 0.0162
-      }
-     ]
-    },
-    "celltype_HCA_broad": {
-     "author_field_name": "celltype_HCA_broad",
-     "values": [
-      {
-       "author_value": "Immune_Non-conventional_DC",
-       "cell_count": 2896,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Uterus",
@@ -178120,6 +174468,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Mentrual fluid",
@@ -178220,6 +174569,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Mentrual fluid",
@@ -178325,6 +174675,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -178345,6 +174696,7 @@
     },
     "Developmental_stage": {
      "author_field_name": "Developmental_stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Adult",
@@ -178365,6 +174717,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "33",
@@ -178585,6 +174938,7 @@
     },
     "Tanner Stage": {
      "author_field_name": "Tanner Stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Pubic V/Genitals-Breast V",
@@ -178610,6 +174964,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -178690,6 +175045,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Menstrual",
@@ -178770,6 +175126,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "Unknown",
@@ -178865,6 +175222,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Unknown",
@@ -178985,6 +175343,7 @@
     },
     "Observed_pathology": {
      "author_field_name": "Observed_pathology",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -179020,6 +175379,7 @@
     },
     "Sampled_site_condition": {
      "author_field_name": "Sampled_site_condition",
+     "category": "disease",
      "values": [
       {
        "author_value": "Unknown",
@@ -179220,68 +175580,9 @@
    "parent_cell_set_accession": "HCArepro:L2:0005",
    "n_cells": 237668,
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Mesen_OvarianFibs_InncorMedulla",
-       "cell_count": 125985,
-       "cell_ratio": 0.5301
-      },
-      {
-       "author_value": "Mesen_OvarianFibs_Perifol",
-       "cell_count": 44411,
-       "cell_ratio": 0.1869
-      },
-      {
-       "author_value": "Mesen_OvarianFibs_Fetal",
-       "cell_count": 32133,
-       "cell_ratio": 0.1352
-      },
-      {
-       "author_value": "Mesen_OvarianFibs_Outcor",
-       "cell_count": 21434,
-       "cell_ratio": 0.0902
-      },
-      {
-       "author_value": "Mesen_OvarianFibs_Medulla_SMCsLike",
-       "cell_count": 13705,
-       "cell_ratio": 0.0577
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Mesen_OvarianFibs_InncorMedulla",
-       "cell_count": 125985,
-       "cell_ratio": 0.5301
-      },
-      {
-       "author_value": "Mesen_OvarianFibs_Perifol",
-       "cell_count": 44411,
-       "cell_ratio": 0.1869
-      },
-      {
-       "author_value": "unknown",
-       "cell_count": 32133,
-       "cell_ratio": 0.1352
-      },
-      {
-       "author_value": "Mesen_OvarianFibs_Outcor",
-       "cell_count": 21434,
-       "cell_ratio": 0.0902
-      },
-      {
-       "author_value": "Mesen_OvarianFibs_Medulla_SMCsLike",
-       "cell_count": 13705,
-       "cell_ratio": 0.0577
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Ovary",
@@ -179302,6 +175603,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Ovarian Cortex",
@@ -179407,6 +175709,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Cortex_outer",
@@ -179527,6 +175830,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "unknown",
@@ -179557,6 +175861,7 @@
     },
     "Developmental_stage": {
      "author_field_name": "Developmental_stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "paediatric",
@@ -179587,6 +175892,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -179757,6 +176063,7 @@
     },
     "Tanner Stage": {
      "author_field_name": "Tanner Stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Pubic I/Genitals-Breast I",
@@ -179797,6 +176104,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -179937,6 +176245,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Unknown",
@@ -179967,6 +176276,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "control",
@@ -180132,6 +176442,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -180918,48 +177229,9 @@
    "cell_ontology_term": "pericyte",
    "comment": "Supertype/internal node. Its un-subtyped members were split into minted generic leaf/leaves (see children with 'Minted generic leaf' comments). n_cells is the full subtree.",
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Mesen_Pericyte",
-       "cell_count": 38904,
-       "cell_ratio": 0.7541
-      },
-      {
-       "author_value": "Mesen_Pericyte_SMCsIntr",
-       "cell_count": 8167,
-       "cell_ratio": 0.1583
-      },
-      {
-       "author_value": "Mesen_Pericyte_Cyc",
-       "cell_count": 4522,
-       "cell_ratio": 0.0876
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Mesen_Pericyte",
-       "cell_count": 38904,
-       "cell_ratio": 0.7541
-      },
-      {
-       "author_value": "Mesen_Pericyte_SMCsIntr",
-       "cell_count": 8167,
-       "cell_ratio": 0.1583
-      },
-      {
-       "author_value": "Mesen_Pericyte_Cyc",
-       "cell_count": 4522,
-       "cell_ratio": 0.0876
-      }
-     ]
-    },
     "celltype_HCA_broad": {
      "author_field_name": "celltype_HCA_broad",
+     "category": "cross_cutting_cell_type",
      "values": [
       {
        "author_value": "Mesen_Pericyte",
@@ -180975,6 +177247,7 @@
     },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Uterus",
@@ -181005,6 +177278,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Endometrium",
@@ -181080,6 +177354,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Endometrium",
@@ -181185,6 +177460,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -181205,6 +177481,7 @@
     },
     "Developmental_stage": {
      "author_field_name": "Developmental_stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Adult",
@@ -181230,6 +177507,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "23",
@@ -181525,6 +177803,7 @@
     },
     "Tanner Stage": {
      "author_field_name": "Tanner Stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Pubic V/Genitals-Breast V",
@@ -181560,6 +177839,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Postmenopausal",
@@ -181670,6 +177950,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "control",
@@ -181860,6 +178141,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -182085,6 +178367,7 @@
     },
     "Observed_pathology": {
      "author_field_name": "Observed_pathology",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -182125,6 +178408,7 @@
     },
     "Sampled_site_condition": {
      "author_field_name": "Sampled_site_condition",
+     "category": "disease",
      "values": [
       {
        "author_value": "normal",
@@ -182648,48 +178932,9 @@
    "cell_ontology_term": "endothelial cell of venule",
    "comment": "Supertype/internal node. Its un-subtyped members were split into minted generic leaf/leaves (see children with 'Minted generic leaf' comments). n_cells is the full subtree.",
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Endo_ven_tpcv",
-       "cell_count": 16892,
-       "cell_ratio": 0.4739
-      },
-      {
-       "author_value": "Endo_ven_pcv",
-       "cell_count": 13904,
-       "cell_ratio": 0.39
-      },
-      {
-       "author_value": "Endo_ven_apcv",
-       "cell_count": 4851,
-       "cell_ratio": 0.1361
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Endo_ven_tpcv",
-       "cell_count": 16892,
-       "cell_ratio": 0.4739
-      },
-      {
-       "author_value": "Endo_ven_pcv",
-       "cell_count": 13904,
-       "cell_ratio": 0.39
-      },
-      {
-       "author_value": "Endo_ven_apcv",
-       "cell_count": 4851,
-       "cell_ratio": 0.1361
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Uterus",
@@ -182730,6 +178975,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Whole_Uterus",
@@ -182880,6 +179126,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Myometrium",
@@ -183055,6 +179302,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -183085,6 +179333,7 @@
     },
     "Developmental_stage": {
      "author_field_name": "Developmental_stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Adult",
@@ -183115,6 +179364,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "31",
@@ -183410,6 +179660,7 @@
     },
     "Tanner Stage": {
      "author_field_name": "Tanner Stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Pubic V/Genitals-Breast V",
@@ -183450,6 +179701,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -183565,6 +179817,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Postmenopausal",
@@ -183680,6 +179933,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "control",
@@ -183870,6 +180124,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -184095,6 +180350,7 @@
     },
     "Observed_pathology": {
      "author_field_name": "Observed_pathology",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -184135,6 +180391,7 @@
     },
     "Sampled_site_condition": {
      "author_field_name": "Sampled_site_condition",
+     "category": "disease",
      "values": [
       {
        "author_value": "normal",
@@ -184460,28 +180717,9 @@
    "parent_cell_set_accession": "HCArepro:L2:0005",
    "n_cells": 2243,
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Mesen_Prepuce_Fetal",
-       "cell_count": 2243,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA_broad": {
-     "author_field_name": "celltype_HCA_broad",
-     "values": [
-      {
-       "author_value": "Mesen_Prepuce",
-       "cell_count": 2243,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "lower tract",
@@ -184512,6 +180750,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "lower tract",
@@ -184542,6 +180781,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -184552,6 +180792,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "9",
@@ -184729,28 +180970,9 @@
    "parent_cell_set_accession": "HCArepro:L2:0001",
    "n_cells": 2097,
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Epi_PrepuceSquamous_Fetal",
-       "cell_count": 2097,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA_broad": {
-     "author_field_name": "celltype_HCA_broad",
-     "values": [
-      {
-       "author_value": "Epi_PrepuceSquamous",
-       "cell_count": 2097,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "external genitalia",
@@ -184781,6 +181003,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "External genitalia",
@@ -184811,6 +181034,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -184821,6 +181045,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "12",
@@ -184979,33 +181204,9 @@
    ],
    "comment": "Supertype/internal node. Its un-subtyped members were split into minted generic leaf/leaves (see children with 'Minted generic leaf' comments). n_cells is the full subtree. | Marker origin: media-4 broad code 'Germcell_PrimaryOocyte_Fetal' (supertype-level).",
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Germcell_PrimaryOocyte_ZP4neg",
-       "cell_count": 760,
-       "cell_ratio": 0.6603
-      },
-      {
-       "author_value": "Germcell_PrimaryOocyte_ZP4pos",
-       "cell_count": 391,
-       "cell_ratio": 0.3397
-      }
-     ]
-    },
-    "celltype_HCA_broad": {
-     "author_field_name": "celltype_HCA_broad",
-     "values": [
-      {
-       "author_value": "Germcell_PrimaryOocyte",
-       "cell_count": 1151,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Ovary",
@@ -185021,6 +181222,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Gonad_and_extragonadal",
@@ -185056,6 +181258,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Gonad_and_extragonadal",
@@ -185096,6 +181299,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -185126,6 +181330,7 @@
     },
     "Developmental_stage": {
      "author_field_name": "Developmental_stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Fetal",
@@ -185151,6 +181356,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -185246,6 +181452,7 @@
     },
     "Tanner Stage": {
      "author_field_name": "Tanner Stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -185281,6 +181488,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "17",
@@ -185336,6 +181544,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -185356,6 +181565,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "control",
@@ -185436,6 +181646,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -185606,28 +181817,9 @@
    "parent_cell_set_accession": "HCArepro:L2:0012",
    "n_cells": 5796,
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Epi_reteOvarii_Fetal_Undiff",
-       "cell_count": 5796,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA_broad": {
-     "author_field_name": "celltype_HCA_broad",
-     "values": [
-      {
-       "author_value": "Epi_reteOvarii",
-       "cell_count": 5796,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Ovary",
@@ -185648,6 +181840,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Gonad_and_extragonadal",
@@ -185683,6 +181876,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Gonad_and_extragonadal",
@@ -185718,6 +181912,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -185738,6 +181933,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "8.6",
@@ -186146,68 +182342,9 @@
     "Schwann cells"
    ],
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Neural_Schwann_Fetal",
-       "cell_count": 5801,
-       "cell_ratio": 0.6371
-      },
-      {
-       "author_value": "Neural_Schwann_Cyc",
-       "cell_count": 2401,
-       "cell_ratio": 0.2637
-      },
-      {
-       "author_value": "Neural_Schwann_Precursor",
-       "cell_count": 847,
-       "cell_ratio": 0.093
-      },
-      {
-       "author_value": "Neural_Schwann_Immature",
-       "cell_count": 35,
-       "cell_ratio": 0.0038
-      },
-      {
-       "author_value": "Neural_Schwann_myelinating",
-       "cell_count": 22,
-       "cell_ratio": 0.0024
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Neural_Schwann_Fetal",
-       "cell_count": 5801,
-       "cell_ratio": 0.6371
-      },
-      {
-       "author_value": "Neural_Schwann_Cyc",
-       "cell_count": 2401,
-       "cell_ratio": 0.2637
-      },
-      {
-       "author_value": "Neural_Schwann_Precursor",
-       "cell_count": 847,
-       "cell_ratio": 0.093
-      },
-      {
-       "author_value": "Neural_Schwann_Immature",
-       "cell_count": 35,
-       "cell_ratio": 0.0038
-      },
-      {
-       "author_value": "Neural_Schwann_myelinating",
-       "cell_count": 22,
-       "cell_ratio": 0.0024
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Reproductive tract",
@@ -186243,6 +182380,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Vagina",
@@ -186358,6 +182496,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Vagina",
@@ -186488,6 +182627,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -186513,6 +182653,7 @@
     },
     "Developmental_stage": {
      "author_field_name": "Developmental_stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Fetal",
@@ -186538,6 +182679,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -186613,6 +182755,7 @@
     },
     "Tanner Stage": {
      "author_field_name": "Tanner Stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -186633,6 +182776,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "19",
@@ -186778,6 +182922,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -186813,6 +182958,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "control",
@@ -186838,6 +182984,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -186988,33 +183135,9 @@
     "Gonadal_preGranulosa-OSEderived"
    ],
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Gonadal_preGranulosa-OSEderived_late",
-       "cell_count": 50633,
-       "cell_ratio": 0.8838
-      },
-      {
-       "author_value": "Gonadal_preGranulosa-OSEderived_early",
-       "cell_count": 6659,
-       "cell_ratio": 0.1162
-      }
-     ]
-    },
-    "celltype_HCA_broad": {
-     "author_field_name": "celltype_HCA_broad",
-     "values": [
-      {
-       "author_value": "Gonadal_preGranulosa-OSEderived",
-       "cell_count": 57292,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Ovary",
@@ -187035,6 +183158,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Gonad_and_extragonadal",
@@ -187100,6 +183224,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Gonad_and_extragonadal",
@@ -187165,6 +183290,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -187185,6 +183311,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -187200,6 +183327,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "10",
@@ -187807,58 +183935,9 @@
    ],
    "comment": "Marker origin: media-4 broad code 'Neural_SympatheticNeurons' (supertype-level).",
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Neural_SympatheticNeurons_Immature",
-       "cell_count": 4469,
-       "cell_ratio": 0.8747
-      },
-      {
-       "author_value": "Neural_SympatheticNeurons_Immature_Cyc",
-       "cell_count": 394,
-       "cell_ratio": 0.0771
-      },
-      {
-       "author_value": "Neural_SympatheticNeurons_Noradrenergic",
-       "cell_count": 246,
-       "cell_ratio": 0.0482
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Neural_SympatheticNeurons_Immature",
-       "cell_count": 4469,
-       "cell_ratio": 0.8747
-      },
-      {
-       "author_value": "Neural_SympatheticNeurons_Immature_Cyc",
-       "cell_count": 394,
-       "cell_ratio": 0.0771
-      },
-      {
-       "author_value": "Neural_SympatheticNeurons_Noradrenergic",
-       "cell_count": 246,
-       "cell_ratio": 0.0482
-      }
-     ]
-    },
-    "celltype_HCA_broad": {
-     "author_field_name": "celltype_HCA_broad",
-     "values": [
-      {
-       "author_value": "Neural_SympatheticNeurons",
-       "cell_count": 5109,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Reproductive tract",
@@ -187879,6 +183958,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Whole_tract",
@@ -187959,6 +184039,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Whole_tract",
@@ -188039,6 +184120,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -188059,6 +184141,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "6.2",
@@ -188320,168 +184403,9 @@
     "T cells"
    ],
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Immune_CD8_T_RM_GZMKhi",
-       "cell_count": 25502,
-       "cell_ratio": 0.2776
-      },
-      {
-       "author_value": "Immune_CD8_T_RM",
-       "cell_count": 15131,
-       "cell_ratio": 0.1647
-      },
-      {
-       "author_value": "Immune_CD4_T_Unpolarised",
-       "cell_count": 13177,
-       "cell_ratio": 0.1435
-      },
-      {
-       "author_value": "Immune_CD4_Th17",
-       "cell_count": 6802,
-       "cell_ratio": 0.0741
-      },
-      {
-       "author_value": "Immune_CD4_NaiveT",
-       "cell_count": 6169,
-       "cell_ratio": 0.0672
-      },
-      {
-       "author_value": "Immune_CD4_Th17_SCMlike",
-       "cell_count": 5130,
-       "cell_ratio": 0.0559
-      },
-      {
-       "author_value": "Immune_CD8_T_EM",
-       "cell_count": 4022,
-       "cell_ratio": 0.0438
-      },
-      {
-       "author_value": "Immune_MAIT",
-       "cell_count": 3733,
-       "cell_ratio": 0.0406
-      },
-      {
-       "author_value": "Immune_CD4_Treg",
-       "cell_count": 3695,
-       "cell_ratio": 0.0402
-      },
-      {
-       "author_value": "Immune_NKT_γδT_Vδ1",
-       "cell_count": 2836,
-       "cell_ratio": 0.0309
-      },
-      {
-       "author_value": "Immune_CD8_NaiveT",
-       "cell_count": 2551,
-       "cell_ratio": 0.0278
-      },
-      {
-       "author_value": "Immune_T_Cyc",
-       "cell_count": 2208,
-       "cell_ratio": 0.024
-      },
-      {
-       "author_value": "Immune_γδT_Vγ9Vδ2",
-       "cell_count": 781,
-       "cell_ratio": 0.0085
-      },
-      {
-       "author_value": "Immune_CD4_Treg_Cyc",
-       "cell_count": 114,
-       "cell_ratio": 0.0012
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Immune_CD8_T_RM_GZMKhi",
-       "cell_count": 25502,
-       "cell_ratio": 0.2776
-      },
-      {
-       "author_value": "Immune_CD8_T_RM",
-       "cell_count": 15131,
-       "cell_ratio": 0.1647
-      },
-      {
-       "author_value": "Immune_CD4_T_Unpolarised",
-       "cell_count": 13177,
-       "cell_ratio": 0.1435
-      },
-      {
-       "author_value": "Immune_CD4_Th17",
-       "cell_count": 6802,
-       "cell_ratio": 0.0741
-      },
-      {
-       "author_value": "Immune_CD4_NaiveT",
-       "cell_count": 6169,
-       "cell_ratio": 0.0672
-      },
-      {
-       "author_value": "Immune_CD4_Th17_SCMlike",
-       "cell_count": 5130,
-       "cell_ratio": 0.0559
-      },
-      {
-       "author_value": "Immune_CD8_T_EM",
-       "cell_count": 4022,
-       "cell_ratio": 0.0438
-      },
-      {
-       "author_value": "Immune_MAIT",
-       "cell_count": 3733,
-       "cell_ratio": 0.0406
-      },
-      {
-       "author_value": "Immune_CD4_Treg",
-       "cell_count": 3695,
-       "cell_ratio": 0.0402
-      },
-      {
-       "author_value": "Immune_NKT_γδT_Vδ1",
-       "cell_count": 2836,
-       "cell_ratio": 0.0309
-      },
-      {
-       "author_value": "Immune_CD8_NaiveT",
-       "cell_count": 2551,
-       "cell_ratio": 0.0278
-      },
-      {
-       "author_value": "Immune_T_Cyc",
-       "cell_count": 2208,
-       "cell_ratio": 0.024
-      },
-      {
-       "author_value": "Immune_γδT_Vγ9Vδ2",
-       "cell_count": 781,
-       "cell_ratio": 0.0085
-      },
-      {
-       "author_value": "Immune_CD4_Treg_Cyc",
-       "cell_count": 114,
-       "cell_ratio": 0.0012
-      }
-     ]
-    },
-    "celltype_HCA_broad": {
-     "author_field_name": "celltype_HCA_broad",
-     "values": [
-      {
-       "author_value": "Immune_T_cells",
-       "cell_count": 91851,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Uterus",
@@ -188522,6 +184446,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Endometrium",
@@ -188662,6 +184587,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Endometrium",
@@ -188837,6 +184763,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -188862,6 +184789,7 @@
     },
     "Developmental_stage": {
      "author_field_name": "Developmental_stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Adult",
@@ -188892,6 +184820,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "37",
@@ -189182,6 +185111,7 @@
     },
     "Tanner Stage": {
      "author_field_name": "Tanner Stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Pubic V/Genitals-Breast V",
@@ -189222,6 +185152,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -189342,6 +185273,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Unknown",
@@ -189427,6 +185359,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "control",
@@ -189632,6 +185565,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -189862,6 +185796,7 @@
     },
     "Observed_pathology": {
      "author_field_name": "Observed_pathology",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -189902,6 +185837,7 @@
     },
     "Sampled_site_condition": {
      "author_field_name": "Sampled_site_condition",
+     "category": "disease",
      "values": [
       {
        "author_value": "normal",
@@ -190243,58 +186179,9 @@
    "parent_cell_set_accession": "HCArepro:L2:0041",
    "n_cells": 26181,
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Mesen_Theca_Interna_Cyc",
-       "cell_count": 9366,
-       "cell_ratio": 0.3577
-      },
-      {
-       "author_value": "Mesen_Theca_Interna_Steroid",
-       "cell_count": 8428,
-       "cell_ratio": 0.3219
-      },
-      {
-       "author_value": "Mesen_Theca_Interna_Perifol",
-       "cell_count": 5148,
-       "cell_ratio": 0.1966
-      },
-      {
-       "author_value": "Mesen_Theca_Atretic",
-       "cell_count": 3239,
-       "cell_ratio": 0.1237
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Mesen_Theca_Interna_Cyc",
-       "cell_count": 9366,
-       "cell_ratio": 0.3577
-      },
-      {
-       "author_value": "Mesen_Theca_Interna_Steroid",
-       "cell_count": 8428,
-       "cell_ratio": 0.3219
-      },
-      {
-       "author_value": "Mesen_Theca_Interna_Perifol",
-       "cell_count": 5148,
-       "cell_ratio": 0.1966
-      },
-      {
-       "author_value": "Mesen_Theca_Atretic",
-       "cell_count": 3239,
-       "cell_ratio": 0.1237
-      }
-     ]
-    },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Follicle",
@@ -190320,6 +186207,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Antral_follicle",
@@ -190365,6 +186253,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "unknown",
@@ -190385,6 +186274,7 @@
     },
     "Developmental_stage": {
      "author_field_name": "Developmental_stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Adult",
@@ -190410,6 +186300,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "31",
@@ -190555,6 +186446,7 @@
     },
     "Tanner Stage": {
      "author_field_name": "Tanner Stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Pubic V/Genitals-Breast V",
@@ -190590,6 +186482,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Unknown",
@@ -190615,6 +186508,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "Stroke",
@@ -190760,6 +186654,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Stroke",
@@ -191083,28 +186978,9 @@
    "parent_cell_set_accession": "HCArepro:L2:0001",
    "n_cells": 1649,
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Epi_UrethralSquamous_Fetal",
-       "cell_count": 1649,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA_broad": {
-     "author_field_name": "celltype_HCA_broad",
-     "values": [
-      {
-       "author_value": "Epi_UrethralSquamous",
-       "cell_count": 1649,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Reproductive tract",
@@ -191125,6 +187001,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Vagina",
@@ -191185,6 +187062,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Vagina",
@@ -191245,6 +187123,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -191255,6 +187134,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "19",
@@ -191432,33 +187312,9 @@
     "Mesen_UGSFib"
    ],
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Mesen_UGSFib_Upper",
-       "cell_count": 11402,
-       "cell_ratio": 0.6449
-      },
-      {
-       "author_value": "Mesen_UGSFib_Lower",
-       "cell_count": 6277,
-       "cell_ratio": 0.3551
-      }
-     ]
-    },
-    "celltype_HCA_broad": {
-     "author_field_name": "celltype_HCA_broad",
-     "values": [
-      {
-       "author_value": "Mesen_UGSFib",
-       "cell_count": 17679,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Reproductive tract",
@@ -191479,6 +187335,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Whole_tract",
@@ -191564,6 +187421,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Whole_tract",
@@ -191649,6 +187507,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -191669,6 +187528,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "8.6",
@@ -192174,28 +188034,9 @@
    "parent_cell_set_accession": "HCArepro:L2:0045",
    "n_cells": 7550,
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Mesen_UterusSMCs_Fetal",
-       "cell_count": 7550,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA_broad": {
-     "author_field_name": "celltype_HCA_broad",
-     "values": [
-      {
-       "author_value": "Mesen_UterusSMCs",
-       "cell_count": 7550,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Reproductive tract",
@@ -192211,6 +188052,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "uterus",
@@ -192266,6 +188108,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "uterus",
@@ -192321,6 +188164,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "20",
@@ -192571,28 +188415,9 @@
     "RORB"
    ],
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Mesen_UterusFibs_Fetal",
-       "cell_count": 29462,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA_broad": {
-     "author_field_name": "celltype_HCA_broad",
-     "values": [
-      {
-       "author_value": "Mesen_UterusFibs",
-       "cell_count": 29462,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Reproductive tract",
@@ -192613,6 +188438,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Fallopian Tube",
@@ -192693,6 +188519,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Fallopian Tube",
@@ -192773,6 +188600,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -192793,6 +188621,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "12",
@@ -193229,28 +189058,9 @@
    "parent_cell_set_accession": "HCArepro:L2:0161",
    "n_cells": 12364,
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Mesen_UterusLig_Fetal",
-       "cell_count": 12364,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA_broad": {
-     "author_field_name": "celltype_HCA_broad",
-     "values": [
-      {
-       "author_value": "Mesen_UterusLig",
-       "cell_count": 12364,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Reproductive tract",
@@ -193271,6 +189081,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "uterus",
@@ -193351,6 +189162,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "uterus",
@@ -193431,6 +189243,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -193451,6 +189264,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "20",
@@ -193906,28 +189720,9 @@
    "parent_cell_set_accession": "HCArepro:L2:0102",
    "n_cells": 7640,
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Epi_Uterocervical_Fetal",
-       "cell_count": 7640,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA_broad": {
-     "author_field_name": "celltype_HCA_broad",
-     "values": [
-      {
-       "author_value": "Epi_Uterocervical",
-       "cell_count": 7640,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Reproductive tract",
@@ -193943,6 +189738,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "uterus, cervix, vagina",
@@ -194018,6 +189814,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "uterus, cervix, vagina",
@@ -194093,6 +189890,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -194108,6 +189906,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "18",
@@ -194326,28 +190125,9 @@
    "parent_cell_set_accession": "HCArepro:L2:0045",
    "n_cells": 1311,
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Mesen_VaginaSMCs_Lower_Fetal",
-       "cell_count": 1311,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA_broad": {
-     "author_field_name": "celltype_HCA_broad",
-     "values": [
-      {
-       "author_value": "Mesen_VaginaSMCs",
-       "cell_count": 1311,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Reproductive tract",
@@ -194363,6 +190143,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Vagina",
@@ -194403,6 +190184,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Vagina",
@@ -194443,6 +190225,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "19",
@@ -194592,58 +190375,9 @@
    "cell_ontology_term": "stromal cell",
    "comment": "Supertype/internal node. Its un-subtyped members were split into minted generic leaf/leaves (see children with 'Minted generic leaf' comments). n_cells is the full subtree.",
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Mesen_VaginaFibs_Upper_Fetal",
-       "cell_count": 7925,
-       "cell_ratio": 0.7899
-      },
-      {
-       "author_value": "Mesen_VaginaFibs",
-       "cell_count": 1463,
-       "cell_ratio": 0.1458
-      },
-      {
-       "author_value": "Mesen_VaginaFib_Lower_Fetal",
-       "cell_count": 645,
-       "cell_ratio": 0.0643
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "unknown",
-       "cell_count": 8570,
-       "cell_ratio": 0.8542
-      },
-      {
-       "author_value": "Mesen_VaginaFibs",
-       "cell_count": 1463,
-       "cell_ratio": 0.1458
-      }
-     ]
-    },
-    "celltype_HCA_broad": {
-     "author_field_name": "celltype_HCA_broad",
-     "values": [
-      {
-       "author_value": "Mesen_VaginaFibs",
-       "cell_count": 9388,
-       "cell_ratio": 0.9357
-      },
-      {
-       "author_value": "Mesen_VaginaFib",
-       "cell_count": 645,
-       "cell_ratio": 0.0643
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Reproductive tract",
@@ -194669,6 +190403,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Vagina",
@@ -194754,6 +190489,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Vagina",
@@ -194839,6 +190575,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -194859,6 +190596,7 @@
     },
     "Developmental_stage": {
      "author_field_name": "Developmental_stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Fetal",
@@ -194874,6 +190612,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -194909,6 +190648,7 @@
     },
     "Tanner Stage": {
      "author_field_name": "Tanner Stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -194924,6 +190664,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "13",
@@ -195039,6 +190780,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -195059,6 +190801,7 @@
     },
     "Observed_pathology": {
      "author_field_name": "Observed_pathology",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -195300,18 +191043,9 @@
    "parent_cell_set_accession": "HCArepro:L2:0001",
    "n_cells": 980,
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Epi_Vagina_Upper_Fetal",
-       "cell_count": 980,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Reproductive tract",
@@ -195327,6 +191061,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "uterus, cervix, vagina",
@@ -195367,6 +191102,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "uterus, cervix, vagina",
@@ -195407,6 +191143,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "18",
@@ -195539,18 +191276,9 @@
    "parent_cell_set_accession": "HCArepro:L2:0012",
    "n_cells": 6047,
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Epi_Vagina_Lower_Fetal",
-       "cell_count": 6047,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Reproductive tract",
@@ -195566,6 +191294,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "uterus, cervix, vagina",
@@ -195636,6 +191365,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "uterus, cervix, vagina",
@@ -195706,6 +191436,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -195716,6 +191447,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "18",
@@ -195938,48 +191670,9 @@
    "parent_cell_set_accession": "HCArepro:L2:0188",
    "n_cells": 84819,
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Mesen_vSMCs_medArt",
-       "cell_count": 51141,
-       "cell_ratio": 0.6029
-      },
-      {
-       "author_value": "Mesen_vSMCs_largeArt",
-       "cell_count": 33678,
-       "cell_ratio": 0.3971
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Mesen_vSMCs_medArt",
-       "cell_count": 51141,
-       "cell_ratio": 0.6029
-      },
-      {
-       "author_value": "Mesen_vSMCs_largeArt",
-       "cell_count": 33678,
-       "cell_ratio": 0.3971
-      }
-     ]
-    },
-    "celltype_HCA_broad": {
-     "author_field_name": "celltype_HCA_broad",
-     "values": [
-      {
-       "author_value": "Mesen_vSMCs",
-       "cell_count": 84819,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Ovary",
@@ -196010,6 +191703,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Ovarian Cortex",
@@ -196085,6 +191779,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Cortex_outer",
@@ -196185,6 +191880,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -196205,6 +191901,7 @@
     },
     "Developmental_stage": {
      "author_field_name": "Developmental_stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Adult",
@@ -196230,6 +191927,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "28",
@@ -196525,6 +192223,7 @@
     },
     "Tanner Stage": {
      "author_field_name": "Tanner Stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Pubic V/Genitals-Breast V",
@@ -196560,6 +192259,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Unknown",
@@ -196660,6 +192360,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "control",
@@ -196840,6 +192541,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -197055,6 +192757,7 @@
     },
     "Observed_pathology": {
      "author_field_name": "Observed_pathology",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -197090,6 +192793,7 @@
     },
     "Sampled_site_condition": {
      "author_field_name": "Sampled_site_condition",
+     "category": "disease",
      "values": [
       {
        "author_value": "normal",
@@ -197456,58 +193160,9 @@
    "cell_ontology_term": "adventitial fibroblast",
    "comment": "Supertype/internal node. Its un-subtyped members were split into minted generic leaf/leaves (see children with 'Minted generic leaf' comments). n_cells is the full subtree.",
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Mesen_AdvFibsIntr",
-       "cell_count": 33795,
-       "cell_ratio": 0.6122
-      },
-      {
-       "author_value": "Mesen_AdvFibs_PI16low",
-       "cell_count": 18360,
-       "cell_ratio": 0.3326
-      },
-      {
-       "author_value": "Mesen_AdvFibs_PI16hi",
-       "cell_count": 3032,
-       "cell_ratio": 0.0549
-      },
-      {
-       "author_value": "Mesen_AdvFibs",
-       "cell_count": 19,
-       "cell_ratio": 0.0003
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Mesen_AdvFibsIntr",
-       "cell_count": 33795,
-       "cell_ratio": 0.6122
-      },
-      {
-       "author_value": "Mesen_AdvFibs_PI16low",
-       "cell_count": 18360,
-       "cell_ratio": 0.3326
-      },
-      {
-       "author_value": "Mesen_AdvFibs_PI16hi",
-       "cell_count": 3032,
-       "cell_ratio": 0.0549
-      },
-      {
-       "author_value": "Mesen_AdvFibs",
-       "cell_count": 19,
-       "cell_ratio": 0.0003
-      }
-     ]
-    },
     "celltype_HCA_broad": {
      "author_field_name": "celltype_HCA_broad",
+     "category": "cross_cutting_cell_type",
      "values": [
       {
        "author_value": "Mesen_AdvFibsIntr",
@@ -197523,6 +193178,7 @@
     },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Fallopian Tube",
@@ -197548,6 +193204,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Fallopian Tube Isthmus",
@@ -197618,6 +193275,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Fallopian Tube Isthmus",
@@ -197713,6 +193371,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -197733,6 +193392,7 @@
     },
     "Developmental_stage": {
      "author_field_name": "Developmental_stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Adult",
@@ -197758,6 +193418,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "55",
@@ -198043,6 +193704,7 @@
     },
     "Tanner Stage": {
      "author_field_name": "Tanner Stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Pubic V/Genitals-Breast V",
@@ -198078,6 +193740,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Postmenopausal",
@@ -198173,6 +193836,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "control",
@@ -198348,6 +194012,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -198558,6 +194223,7 @@
     },
     "Observed_pathology": {
      "author_field_name": "Observed_pathology",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -198578,6 +194244,7 @@
     },
     "Sampled_site_condition": {
      "author_field_name": "Sampled_site_condition",
+     "category": "disease",
      "values": [
       {
        "author_value": "normal",
@@ -199070,83 +194737,9 @@
    "cell_ontology_term": "capillary endothelial cell",
    "comment": "Object data-quality artifact: the h5ad carries two celltype_HCA_fine labels for the same cell type — 'Endo_cap_APCDD1' and 'Endo_cap_APCDD1+' (trailing '+'). Merged here to one leaf via label normalisation; flag to authors.",
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Endo_cap",
-       "cell_count": 21199,
-       "cell_ratio": 0.5623
-      },
-      {
-       "author_value": "Endo_cap_cycl",
-       "cell_count": 5081,
-       "cell_ratio": 0.1348
-      },
-      {
-       "author_value": "Endo_cap_APCDD1",
-       "cell_count": 4691,
-       "cell_ratio": 0.1244
-      },
-      {
-       "author_value": "Endo_cap_tip",
-       "cell_count": 3614,
-       "cell_ratio": 0.0959
-      },
-      {
-       "author_value": "Endo_cap_APCDD1+",
-       "cell_count": 2567,
-       "cell_ratio": 0.0681
-      },
-      {
-       "author_value": "Endo_cap_kidney",
-       "cell_count": 548,
-       "cell_ratio": 0.0145
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Endo_cap",
-       "cell_count": 21199,
-       "cell_ratio": 0.5623
-      },
-      {
-       "author_value": "Endo_cap_cycl",
-       "cell_count": 5081,
-       "cell_ratio": 0.1348
-      },
-      {
-       "author_value": "Endo_cap_APCDD1",
-       "cell_count": 4691,
-       "cell_ratio": 0.1244
-      },
-      {
-       "author_value": "Endo_cap_tip",
-       "cell_count": 3614,
-       "cell_ratio": 0.0959
-      },
-      {
-       "author_value": "unknown",
-       "cell_count": 3115,
-       "cell_ratio": 0.0826
-      }
-     ]
-    },
-    "celltype_HCA_broad": {
-     "author_field_name": "celltype_HCA_broad",
-     "values": [
-      {
-       "author_value": "Endo_cap",
-       "cell_count": 37700,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Uterus",
@@ -199187,6 +194780,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Endometrium",
@@ -199337,6 +194931,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Endometrium",
@@ -199517,6 +195112,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -199547,6 +195143,7 @@
     },
     "Developmental_stage": {
      "author_field_name": "Developmental_stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Adult",
@@ -199577,6 +195174,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -199882,6 +195480,7 @@
     },
     "Tanner Stage": {
      "author_field_name": "Tanner Stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Pubic V/Genitals-Breast V",
@@ -199922,6 +195521,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -200067,6 +195667,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -200182,6 +195783,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "control",
@@ -200372,6 +195974,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -200597,6 +196200,7 @@
     },
     "Observed_pathology": {
      "author_field_name": "Observed_pathology",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -200637,6 +196241,7 @@
     },
     "Sampled_site_condition": {
      "author_field_name": "Sampled_site_condition",
+     "category": "disease",
      "values": [
       {
        "author_value": "normal",
@@ -200976,118 +196581,9 @@
    ],
    "comment": "Marker origin: media-4 broad code 'Epi_Cil' (supertype-level).",
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Epi_FallopianCil_Diff",
-       "cell_count": 12869,
-       "cell_ratio": 0.4892
-      },
-      {
-       "author_value": "Epi_EndoCil_Diff",
-       "cell_count": 8903,
-       "cell_ratio": 0.3385
-      },
-      {
-       "author_value": "Epi_EndoCil_Cyc",
-       "cell_count": 1975,
-       "cell_ratio": 0.0751
-      },
-      {
-       "author_value": "Epi_EndoCil_eProf",
-       "cell_count": 1014,
-       "cell_ratio": 0.0385
-      },
-      {
-       "author_value": "Epi_FallopianCil_Cyc",
-       "cell_count": 547,
-       "cell_ratio": 0.0208
-      },
-      {
-       "author_value": "Epi_FallopianCil_Fetal",
-       "cell_count": 516,
-       "cell_ratio": 0.0196
-      },
-      {
-       "author_value": "Epi_FallopianCil_Early",
-       "cell_count": 460,
-       "cell_ratio": 0.0175
-      },
-      {
-       "author_value": "Epi_OvarianInclCil",
-       "cell_count": 20,
-       "cell_ratio": 0.0008
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Epi_FallopianCil_Diff",
-       "cell_count": 12869,
-       "cell_ratio": 0.4892
-      },
-      {
-       "author_value": "Epi_EndoCil_Diff",
-       "cell_count": 8903,
-       "cell_ratio": 0.3385
-      },
-      {
-       "author_value": "Epi_EndoCil_Cyc",
-       "cell_count": 1975,
-       "cell_ratio": 0.0751
-      },
-      {
-       "author_value": "Epi_EndoCil_eProf",
-       "cell_count": 1014,
-       "cell_ratio": 0.0385
-      },
-      {
-       "author_value": "Epi_FallopianCil_Cyc",
-       "cell_count": 547,
-       "cell_ratio": 0.0208
-      },
-      {
-       "author_value": "unknown",
-       "cell_count": 516,
-       "cell_ratio": 0.0196
-      },
-      {
-       "author_value": "Epi_FallopianCil_Early",
-       "cell_count": 460,
-       "cell_ratio": 0.0175
-      },
-      {
-       "author_value": "Epi_OvarianInclCil",
-       "cell_count": 20,
-       "cell_ratio": 0.0008
-      }
-     ]
-    },
-    "celltype_HCA_broad": {
-     "author_field_name": "celltype_HCA_broad",
-     "values": [
-      {
-       "author_value": "Epi_FallopianCil",
-       "cell_count": 14392,
-       "cell_ratio": 0.5471
-      },
-      {
-       "author_value": "Epi_EndoCil",
-       "cell_count": 11892,
-       "cell_ratio": 0.4521
-      },
-      {
-       "author_value": "Epi_OvarianInclCil",
-       "cell_count": 20,
-       "cell_ratio": 0.0008
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Fallopian Tube",
@@ -201113,6 +196609,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Endometrium",
@@ -201203,6 +196700,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Endometrium",
@@ -201308,6 +196806,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -201323,6 +196822,7 @@
     },
     "Developmental_stage": {
      "author_field_name": "Developmental_stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Adult",
@@ -201338,6 +196838,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "30",
@@ -201533,6 +197034,7 @@
     },
     "Tanner Stage": {
      "author_field_name": "Tanner Stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Pubic V/Genitals-Breast V",
@@ -201548,6 +197050,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -201598,6 +197101,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Proliferative",
@@ -201703,6 +197207,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "control",
@@ -201763,6 +197268,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -201858,6 +197364,7 @@
     },
     "Observed_pathology": {
      "author_field_name": "Observed_pathology",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -201893,6 +197400,7 @@
     },
     "Sampled_site_condition": {
      "author_field_name": "Sampled_site_condition",
+     "category": "disease",
      "values": [
       {
        "author_value": "normal",
@@ -202298,103 +197806,9 @@
    "parent_cell_set_accession": "HCArepro:L1:0008",
    "n_cells": 8959,
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Immune_cDC2",
-       "cell_count": 3457,
-       "cell_ratio": 0.3859
-      },
-      {
-       "author_value": "Immune_mregDC",
-       "cell_count": 1577,
-       "cell_ratio": 0.176
-      },
-      {
-       "author_value": "Immune_cDC2_CD207hi",
-       "cell_count": 1533,
-       "cell_ratio": 0.1711
-      },
-      {
-       "author_value": "Immune_pDC",
-       "cell_count": 1203,
-       "cell_ratio": 0.1343
-      },
-      {
-       "author_value": "Immune_cDC1",
-       "cell_count": 1073,
-       "cell_ratio": 0.1198
-      },
-      {
-       "author_value": "Immune_ASDC",
-       "cell_count": 69,
-       "cell_ratio": 0.0077
-      },
-      {
-       "author_value": "Immune_tolDC",
-       "cell_count": 47,
-       "cell_ratio": 0.0052
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Immune_cDC2",
-       "cell_count": 3457,
-       "cell_ratio": 0.3859
-      },
-      {
-       "author_value": "Immune_mregDC",
-       "cell_count": 1577,
-       "cell_ratio": 0.176
-      },
-      {
-       "author_value": "Immune_cDC2_CD207hi",
-       "cell_count": 1533,
-       "cell_ratio": 0.1711
-      },
-      {
-       "author_value": "Immune_pDC",
-       "cell_count": 1203,
-       "cell_ratio": 0.1343
-      },
-      {
-       "author_value": "Immune_cDC1",
-       "cell_count": 1073,
-       "cell_ratio": 0.1198
-      },
-      {
-       "author_value": "Immune_ASDC",
-       "cell_count": 69,
-       "cell_ratio": 0.0077
-      },
-      {
-       "author_value": "Immune_tolDC",
-       "cell_count": 47,
-       "cell_ratio": 0.0052
-      }
-     ]
-    },
-    "celltype_HCA_broad": {
-     "author_field_name": "celltype_HCA_broad",
-     "values": [
-      {
-       "author_value": "Immune_Conventional_DC",
-       "cell_count": 6063,
-       "cell_ratio": 0.6767
-      },
-      {
-       "author_value": "Immune_Non-conventional_DC",
-       "cell_count": 2896,
-       "cell_ratio": 0.3233
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Uterus",
@@ -202435,6 +197849,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Endometrium",
@@ -202585,6 +198000,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Endometrium",
@@ -202765,6 +198181,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -202790,6 +198207,7 @@
     },
     "Developmental_stage": {
      "author_field_name": "Developmental_stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Adult",
@@ -202820,6 +198238,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "37",
@@ -203100,6 +198519,7 @@
     },
     "Tanner Stage": {
      "author_field_name": "Tanner Stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Pubic V/Genitals-Breast V",
@@ -203135,6 +198555,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -203255,6 +198676,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Proliferative",
@@ -203340,6 +198762,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "control",
@@ -203520,6 +198943,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -203725,6 +199149,7 @@
     },
     "Observed_pathology": {
      "author_field_name": "Observed_pathology",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -203765,6 +199190,7 @@
     },
     "Sampled_site_condition": {
      "author_field_name": "Sampled_site_condition",
+     "category": "disease",
      "values": [
       {
        "author_value": "normal",
@@ -204045,38 +199471,9 @@
     "SEMA3G"
    ],
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Endo_artery",
-       "cell_count": 11267,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Endo_artery",
-       "cell_count": 11267,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA_broad": {
-     "author_field_name": "celltype_HCA_broad",
-     "values": [
-      {
-       "author_value": "Endo_artery",
-       "cell_count": 11267,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Uterus",
@@ -204117,6 +199514,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Endometrium",
@@ -204267,6 +199665,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Endometrium",
@@ -204447,6 +199846,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -204477,6 +199877,7 @@
     },
     "Developmental_stage": {
      "author_field_name": "Developmental_stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Adult",
@@ -204507,6 +199908,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -204812,6 +200214,7 @@
     },
     "Tanner Stage": {
      "author_field_name": "Tanner Stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Pubic V/Genitals-Breast V",
@@ -204852,6 +200255,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -204997,6 +200401,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -205107,6 +200512,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "control",
@@ -205297,6 +200703,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -205522,6 +200929,7 @@
     },
     "Observed_pathology": {
      "author_field_name": "Observed_pathology",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -205562,6 +200970,7 @@
     },
     "Sampled_site_condition": {
      "author_field_name": "Sampled_site_condition",
+     "category": "disease",
      "values": [
       {
        "author_value": "normal",
@@ -205898,38 +201307,9 @@
     "PDPN"
    ],
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Endo_lymp",
-       "cell_count": 10375,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Endo_lymp",
-       "cell_count": 10375,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA_broad": {
-     "author_field_name": "celltype_HCA_broad",
-     "values": [
-      {
-       "author_value": "Endo_lymp",
-       "cell_count": 10375,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Fallopian Tube",
@@ -205965,6 +201345,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Fallopian Tube Fimbria",
@@ -206105,6 +201486,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Fallopian Tube Fimbria",
@@ -206275,6 +201657,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -206305,6 +201688,7 @@
     },
     "Developmental_stage": {
      "author_field_name": "Developmental_stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Adult",
@@ -206330,6 +201714,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "46",
@@ -206605,6 +201990,7 @@
     },
     "Tanner Stage": {
      "author_field_name": "Tanner Stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Pubic V/Genitals-Breast V",
@@ -206645,6 +202031,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -206750,6 +202137,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Postmenopausal",
@@ -206855,6 +202243,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "control",
@@ -207010,6 +202399,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -207200,6 +202590,7 @@
     },
     "Observed_pathology": {
      "author_field_name": "Observed_pathology",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -207230,6 +202621,7 @@
     },
     "Sampled_site_condition": {
      "author_field_name": "Sampled_site_condition",
+     "category": "disease",
      "values": [
       {
        "author_value": "normal",
@@ -207411,28 +202803,9 @@
    "cell_ontology_term_id": "CL:0000586",
    "cell_ontology_term": "germ cell",
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Germcell_GGCs",
-       "cell_count": 1861,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA_broad": {
-     "author_field_name": "celltype_HCA_broad",
-     "values": [
-      {
-       "author_value": "Germcell_GGCs",
-       "cell_count": 1861,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Ovary",
@@ -207448,6 +202821,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Gonad_and_extragonadal",
@@ -207473,6 +202847,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Gonad_and_extragonadal",
@@ -207498,6 +202873,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -207518,6 +202894,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -207533,6 +202910,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "17",
@@ -207664,88 +203042,9 @@
    ],
    "comment": "Supertype/internal node. Its un-subtyped members were split into minted generic leaf/leaves (see children with 'Minted generic leaf' comments). n_cells is the full subtree.",
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Neural_Schwann_Fetal",
-       "cell_count": 5801,
-       "cell_ratio": 0.5867
-      },
-      {
-       "author_value": "Neural_Schwann_Cyc",
-       "cell_count": 2401,
-       "cell_ratio": 0.2428
-      },
-      {
-       "author_value": "Neural_Schwann_Precursor",
-       "cell_count": 847,
-       "cell_ratio": 0.0857
-      },
-      {
-       "author_value": "Neural_Schwann",
-       "cell_count": 781,
-       "cell_ratio": 0.079
-      },
-      {
-       "author_value": "Neural_Schwann_Immature",
-       "cell_count": 35,
-       "cell_ratio": 0.0035
-      },
-      {
-       "author_value": "Neural_Schwann_myelinating",
-       "cell_count": 22,
-       "cell_ratio": 0.0022
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Neural_Schwann_Fetal",
-       "cell_count": 5801,
-       "cell_ratio": 0.5867
-      },
-      {
-       "author_value": "Neural_Schwann_Cyc",
-       "cell_count": 2401,
-       "cell_ratio": 0.2428
-      },
-      {
-       "author_value": "Neural_Schwann_Precursor",
-       "cell_count": 847,
-       "cell_ratio": 0.0857
-      },
-      {
-       "author_value": "Neural_Schwann",
-       "cell_count": 781,
-       "cell_ratio": 0.079
-      },
-      {
-       "author_value": "Neural_Schwann_Immature",
-       "cell_count": 35,
-       "cell_ratio": 0.0035
-      },
-      {
-       "author_value": "Neural_Schwann_myelinating",
-       "cell_count": 22,
-       "cell_ratio": 0.0022
-      }
-     ]
-    },
-    "celltype_HCA_broad": {
-     "author_field_name": "celltype_HCA_broad",
-     "values": [
-      {
-       "author_value": "Neural_Schwann",
-       "cell_count": 9887,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Reproductive tract",
@@ -207781,6 +203080,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Vagina",
@@ -207921,6 +203221,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Vagina",
@@ -208086,6 +203387,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -208116,6 +203418,7 @@
     },
     "Developmental_stage": {
      "author_field_name": "Developmental_stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Fetal",
@@ -208146,6 +203449,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -208386,6 +203690,7 @@
     },
     "Tanner Stage": {
      "author_field_name": "Tanner Stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -208426,6 +203731,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "19",
@@ -208571,6 +203877,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -208646,6 +203953,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "control",
@@ -208786,6 +204094,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -208931,6 +204240,7 @@
     },
     "Observed_pathology": {
      "author_field_name": "Observed_pathology",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -208946,6 +204256,7 @@
     },
     "Sampled_site_condition": {
      "author_field_name": "Sampled_site_condition",
+     "category": "disease",
      "values": [
       {
        "author_value": "normal",
@@ -209195,38 +204506,9 @@
    "parent_cell_set_accession": "HCArepro:L1:0080",
    "n_cells": 39845,
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Gonadal_preGranulosa-CEderived",
-       "cell_count": 23076,
-       "cell_ratio": 0.5791
-      },
-      {
-       "author_value": "Gonadal_SupportingUndiff",
-       "cell_count": 16769,
-       "cell_ratio": 0.4209
-      }
-     ]
-    },
-    "celltype_HCA_broad": {
-     "author_field_name": "celltype_HCA_broad",
-     "values": [
-      {
-       "author_value": "Gonadal_preGranulosa-CEderived",
-       "cell_count": 23076,
-       "cell_ratio": 0.5791
-      },
-      {
-       "author_value": "Gonadal_SupportingUndiff",
-       "cell_count": 16769,
-       "cell_ratio": 0.4209
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Ovary",
@@ -209247,6 +204529,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Gonad",
@@ -209287,6 +204570,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Gonad",
@@ -209327,6 +204611,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -209347,6 +204632,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -209362,6 +204648,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "6",
@@ -209936,28 +205223,9 @@
     "PAX8"
    ],
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Gonadal_SomaticPrec",
-       "cell_count": 8440,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA_broad": {
-     "author_field_name": "celltype_HCA_broad",
-     "values": [
-      {
-       "author_value": "Gonadal_SomaticPrec",
-       "cell_count": 8440,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Ovary",
@@ -209978,6 +205246,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Gonad",
@@ -210013,6 +205282,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Gonad",
@@ -210048,6 +205318,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -210068,6 +205339,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "6",
@@ -210404,108 +205676,9 @@
    "parent_cell_set_accession": "HCArepro:L1:0034",
    "n_cells": 101966,
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Gonadal_preGranulosa-OSEderived_late",
-       "cell_count": 50633,
-       "cell_ratio": 0.4966
-      },
-      {
-       "author_value": "Granulosa_AMHpos_Steroidogenic",
-       "cell_count": 15814,
-       "cell_ratio": 0.1551
-      },
-      {
-       "author_value": "Granulosa_AMHpos_Cyc",
-       "cell_count": 8927,
-       "cell_ratio": 0.0875
-      },
-      {
-       "author_value": "Gonadal_preGranulosa-OSEderived_early",
-       "cell_count": 6659,
-       "cell_ratio": 0.0653
-      },
-      {
-       "author_value": "Granulosa_AMHneg_Squamous",
-       "cell_count": 5644,
-       "cell_ratio": 0.0554
-      },
-      {
-       "author_value": "Granulosa_AMHpos_Atretic",
-       "cell_count": 5440,
-       "cell_ratio": 0.0534
-      },
-      {
-       "author_value": "Granulosa_sq_Fetal",
-       "cell_count": 3928,
-       "cell_ratio": 0.0385
-      },
-      {
-       "author_value": "Granulosa_AMHneg_Atretic",
-       "cell_count": 2960,
-       "cell_ratio": 0.029
-      },
-      {
-       "author_value": "Granulosa_AMHpos_nonSteroidogenic_early",
-       "cell_count": 1267,
-       "cell_ratio": 0.0124
-      },
-      {
-       "author_value": "Granulosa_AMHpos_nonSteroidogenic",
-       "cell_count": 694,
-       "cell_ratio": 0.0068
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "unknown",
-       "cell_count": 87599,
-       "cell_ratio": 0.8591
-      },
-      {
-       "author_value": "Granulosa_AMHpos_Cyc",
-       "cell_count": 8927,
-       "cell_ratio": 0.0875
-      },
-      {
-       "author_value": "Granulosa_AMHpos_Atretic",
-       "cell_count": 5440,
-       "cell_ratio": 0.0534
-      }
-     ]
-    },
-    "celltype_HCA_broad": {
-     "author_field_name": "celltype_HCA_broad",
-     "values": [
-      {
-       "author_value": "Gonadal_preGranulosa-OSEderived",
-       "cell_count": 57292,
-       "cell_ratio": 0.5619
-      },
-      {
-       "author_value": "Granulosa_AMHpos",
-       "cell_count": 32142,
-       "cell_ratio": 0.3152
-      },
-      {
-       "author_value": "Granulosa_AMHneg",
-       "cell_count": 8604,
-       "cell_ratio": 0.0844
-      },
-      {
-       "author_value": "Granulosa_sq",
-       "cell_count": 3928,
-       "cell_ratio": 0.0385
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Ovary",
@@ -210526,6 +205699,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Gonad_and_extragonadal",
@@ -210611,6 +205785,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Gonad_and_extragonadal",
@@ -210716,6 +205891,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -210746,6 +205922,7 @@
     },
     "Developmental_stage": {
      "author_field_name": "Developmental_stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Fetal",
@@ -210776,6 +205953,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -210921,6 +206099,7 @@
     },
     "Tanner Stage": {
      "author_field_name": "Tanner Stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -210961,6 +206140,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -211101,6 +206281,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -211126,6 +206307,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "control",
@@ -211281,6 +206463,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -211974,48 +207157,9 @@
    "parent_cell_set_accession": "HCArepro:L1:0004",
    "n_cells": 33290,
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Mesen_FallopianLig_Fetal",
-       "cell_count": 18265,
-       "cell_ratio": 0.5487
-      },
-      {
-       "author_value": "Mesen_UterusLig_Fetal",
-       "cell_count": 12364,
-       "cell_ratio": 0.3714
-      },
-      {
-       "author_value": "Mesen_UGSLig",
-       "cell_count": 2661,
-       "cell_ratio": 0.0799
-      }
-     ]
-    },
-    "celltype_HCA_broad": {
-     "author_field_name": "celltype_HCA_broad",
-     "values": [
-      {
-       "author_value": "Mesen_FallopianLig",
-       "cell_count": 18265,
-       "cell_ratio": 0.5487
-      },
-      {
-       "author_value": "Mesen_UterusLig",
-       "cell_count": 12364,
-       "cell_ratio": 0.3714
-      },
-      {
-       "author_value": "Mesen_UGSLig",
-       "cell_count": 2661,
-       "cell_ratio": 0.0799
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Reproductive tract",
@@ -212036,6 +207180,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Fallopian Tube",
@@ -212121,6 +207266,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Fallopian Tube",
@@ -212206,6 +207352,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -212226,6 +207373,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -212241,6 +207389,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "20",
@@ -212815,343 +207964,9 @@
    "parent_cell_set_accession": "HCArepro:L1:0008",
    "n_cells": 142177,
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Immune_CD8_T_RM_GZMKhi",
-       "cell_count": 25502,
-       "cell_ratio": 0.1794
-      },
-      {
-       "author_value": "Immune_CD8_T_RM",
-       "cell_count": 15131,
-       "cell_ratio": 0.1064
-      },
-      {
-       "author_value": "Immune_CD4_T_Unpolarised",
-       "cell_count": 13177,
-       "cell_ratio": 0.0927
-      },
-      {
-       "author_value": "Immune_uNK2",
-       "cell_count": 12245,
-       "cell_ratio": 0.0861
-      },
-      {
-       "author_value": "Immune_uNK3",
-       "cell_count": 10688,
-       "cell_ratio": 0.0752
-      },
-      {
-       "author_value": "Immune_CD4_Th17",
-       "cell_count": 6802,
-       "cell_ratio": 0.0478
-      },
-      {
-       "author_value": "Immune_CD4_NaiveT",
-       "cell_count": 6169,
-       "cell_ratio": 0.0434
-      },
-      {
-       "author_value": "Immune_NK_CD16hi",
-       "cell_count": 5175,
-       "cell_ratio": 0.0364
-      },
-      {
-       "author_value": "Immune_CD4_Th17_SCMlike",
-       "cell_count": 5130,
-       "cell_ratio": 0.0361
-      },
-      {
-       "author_value": "Immune_MemoryB",
-       "cell_count": 4542,
-       "cell_ratio": 0.0319
-      },
-      {
-       "author_value": "Immune_CD8_T_EM",
-       "cell_count": 4022,
-       "cell_ratio": 0.0283
-      },
-      {
-       "author_value": "Immune_MAIT",
-       "cell_count": 3733,
-       "cell_ratio": 0.0263
-      },
-      {
-       "author_value": "Immune_CD4_Treg",
-       "cell_count": 3695,
-       "cell_ratio": 0.026
-      },
-      {
-       "author_value": "Immune_uNK1",
-       "cell_count": 3543,
-       "cell_ratio": 0.0249
-      },
-      {
-       "author_value": "Immune_NK_Cyc",
-       "cell_count": 3503,
-       "cell_ratio": 0.0246
-      },
-      {
-       "author_value": "Immune_NKT_γδT_Vδ1",
-       "cell_count": 2836,
-       "cell_ratio": 0.0199
-      },
-      {
-       "author_value": "Immune_CD8_NaiveT",
-       "cell_count": 2551,
-       "cell_ratio": 0.0179
-      },
-      {
-       "author_value": "Immune_ILC3_NCRhi",
-       "cell_count": 2517,
-       "cell_ratio": 0.0177
-      },
-      {
-       "author_value": "Immune_Plasma_κ",
-       "cell_count": 2314,
-       "cell_ratio": 0.0163
-      },
-      {
-       "author_value": "Immune_T_Cyc",
-       "cell_count": 2208,
-       "cell_ratio": 0.0155
-      },
-      {
-       "author_value": "Immune_NaiveB",
-       "cell_count": 2076,
-       "cell_ratio": 0.0146
-      },
-      {
-       "author_value": "Immune_Plasma_λ",
-       "cell_count": 1782,
-       "cell_ratio": 0.0125
-      },
-      {
-       "author_value": "Immune_γδT_Vγ9Vδ2",
-       "cell_count": 781,
-       "cell_ratio": 0.0055
-      },
-      {
-       "author_value": "Immune_NK_CD56dim_CD16dim_SPTSSBhi",
-       "cell_count": 480,
-       "cell_ratio": 0.0034
-      },
-      {
-       "author_value": "Immune_ImmatureB",
-       "cell_count": 387,
-       "cell_ratio": 0.0027
-      },
-      {
-       "author_value": "Immune_ILC3_NCRlo",
-       "cell_count": 321,
-       "cell_ratio": 0.0023
-      },
-      {
-       "author_value": "Immune_LargePreB",
-       "cell_count": 305,
-       "cell_ratio": 0.0021
-      },
-      {
-       "author_value": "Immune_SmallPreB",
-       "cell_count": 281,
-       "cell_ratio": 0.002
-      },
-      {
-       "author_value": "Immune_ProB",
-       "cell_count": 167,
-       "cell_ratio": 0.0012
-      },
-      {
-       "author_value": "Immune_CD4_Treg_Cyc",
-       "cell_count": 114,
-       "cell_ratio": 0.0008
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Immune_CD8_T_RM_GZMKhi",
-       "cell_count": 25502,
-       "cell_ratio": 0.1794
-      },
-      {
-       "author_value": "Immune_CD8_T_RM",
-       "cell_count": 15131,
-       "cell_ratio": 0.1064
-      },
-      {
-       "author_value": "Immune_CD4_T_Unpolarised",
-       "cell_count": 13177,
-       "cell_ratio": 0.0927
-      },
-      {
-       "author_value": "Immune_uNK2",
-       "cell_count": 12245,
-       "cell_ratio": 0.0861
-      },
-      {
-       "author_value": "Immune_uNK3",
-       "cell_count": 10688,
-       "cell_ratio": 0.0752
-      },
-      {
-       "author_value": "Immune_CD4_Th17",
-       "cell_count": 6802,
-       "cell_ratio": 0.0478
-      },
-      {
-       "author_value": "Immune_CD4_NaiveT",
-       "cell_count": 6169,
-       "cell_ratio": 0.0434
-      },
-      {
-       "author_value": "Immune_NK_CD16hi",
-       "cell_count": 5175,
-       "cell_ratio": 0.0364
-      },
-      {
-       "author_value": "Immune_CD4_Th17_SCMlike",
-       "cell_count": 5130,
-       "cell_ratio": 0.0361
-      },
-      {
-       "author_value": "Immune_MemoryB",
-       "cell_count": 4542,
-       "cell_ratio": 0.0319
-      },
-      {
-       "author_value": "Immune_CD8_T_EM",
-       "cell_count": 4022,
-       "cell_ratio": 0.0283
-      },
-      {
-       "author_value": "Immune_MAIT",
-       "cell_count": 3733,
-       "cell_ratio": 0.0263
-      },
-      {
-       "author_value": "Immune_CD4_Treg",
-       "cell_count": 3695,
-       "cell_ratio": 0.026
-      },
-      {
-       "author_value": "Immune_uNK1",
-       "cell_count": 3543,
-       "cell_ratio": 0.0249
-      },
-      {
-       "author_value": "Immune_NK_Cyc",
-       "cell_count": 3503,
-       "cell_ratio": 0.0246
-      },
-      {
-       "author_value": "Immune_NKT_γδT_Vδ1",
-       "cell_count": 2836,
-       "cell_ratio": 0.0199
-      },
-      {
-       "author_value": "Immune_CD8_NaiveT",
-       "cell_count": 2551,
-       "cell_ratio": 0.0179
-      },
-      {
-       "author_value": "Immune_ILC3_NCRhi",
-       "cell_count": 2517,
-       "cell_ratio": 0.0177
-      },
-      {
-       "author_value": "Immune_Plasma_κ",
-       "cell_count": 2314,
-       "cell_ratio": 0.0163
-      },
-      {
-       "author_value": "Immune_T_Cyc",
-       "cell_count": 2208,
-       "cell_ratio": 0.0155
-      },
-      {
-       "author_value": "Immune_NaiveB",
-       "cell_count": 2076,
-       "cell_ratio": 0.0146
-      },
-      {
-       "author_value": "Immune_Plasma_λ",
-       "cell_count": 1782,
-       "cell_ratio": 0.0125
-      },
-      {
-       "author_value": "Immune_γδT_Vγ9Vδ2",
-       "cell_count": 781,
-       "cell_ratio": 0.0055
-      },
-      {
-       "author_value": "Immune_NK_CD56dim_CD16dim_SPTSSBhi",
-       "cell_count": 480,
-       "cell_ratio": 0.0034
-      },
-      {
-       "author_value": "Immune_ImmatureB",
-       "cell_count": 387,
-       "cell_ratio": 0.0027
-      },
-      {
-       "author_value": "Immune_ILC3_NCRlo",
-       "cell_count": 321,
-       "cell_ratio": 0.0023
-      },
-      {
-       "author_value": "Immune_LargePreB",
-       "cell_count": 305,
-       "cell_ratio": 0.0021
-      },
-      {
-       "author_value": "Immune_SmallPreB",
-       "cell_count": 281,
-       "cell_ratio": 0.002
-      },
-      {
-       "author_value": "Immune_ProB",
-       "cell_count": 167,
-       "cell_ratio": 0.0012
-      },
-      {
-       "author_value": "Immune_CD4_Treg_Cyc",
-       "cell_count": 114,
-       "cell_ratio": 0.0008
-      }
-     ]
-    },
-    "celltype_HCA_broad": {
-     "author_field_name": "celltype_HCA_broad",
-     "values": [
-      {
-       "author_value": "Immune_T_cells",
-       "cell_count": 91851,
-       "cell_ratio": 0.646
-      },
-      {
-       "author_value": "Immune_NK_cells",
-       "cell_count": 35634,
-       "cell_ratio": 0.2506
-      },
-      {
-       "author_value": "Immune_B_cells",
-       "cell_count": 11854,
-       "cell_ratio": 0.0834
-      },
-      {
-       "author_value": "Immune_ILC",
-       "cell_count": 2838,
-       "cell_ratio": 0.02
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Uterus",
@@ -213192,6 +208007,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Endometrium",
@@ -213347,6 +208163,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Endometrium",
@@ -213537,6 +208354,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -213567,6 +208385,7 @@
     },
     "Developmental_stage": {
      "author_field_name": "Developmental_stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Adult",
@@ -213597,6 +208416,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "24",
@@ -213887,6 +208707,7 @@
     },
     "Tanner Stage": {
      "author_field_name": "Tanner Stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Pubic V/Genitals-Breast V",
@@ -213927,6 +208748,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -214067,6 +208889,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Proliferative",
@@ -214152,6 +208975,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "control",
@@ -214357,6 +209181,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -214587,6 +209412,7 @@
     },
     "Observed_pathology": {
      "author_field_name": "Observed_pathology",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -214627,6 +209453,7 @@
     },
     "Sampled_site_condition": {
      "author_field_name": "Sampled_site_condition",
+     "category": "disease",
      "values": [
       {
        "author_value": "normal",
@@ -215032,38 +209859,9 @@
    "parent_cell_set_accession": "HCArepro:L1:0124",
    "n_cells": 88,
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Neural_Melanocyte_Fetal",
-       "cell_count": 88,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Neural_Melanocyte_Fetal",
-       "cell_count": 88,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA_broad": {
-     "author_field_name": "celltype_HCA_broad",
-     "values": [
-      {
-       "author_value": "Neural_Melanocyte",
-       "cell_count": 88,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "external genitalia",
@@ -215094,6 +209892,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "External genitalia",
@@ -215124,6 +209923,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -215134,6 +209934,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "15",
@@ -215207,63 +210008,9 @@
    ],
    "comment": "Marker origin: media-4 broad code 'Epi_Mucinous' (supertype-level).",
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Epi_EndoMucinous",
-       "cell_count": 2110,
-       "cell_ratio": 0.5939
-      },
-      {
-       "author_value": "Epi_CervixMucinous",
-       "cell_count": 1156,
-       "cell_ratio": 0.3254
-      },
-      {
-       "author_value": "Epi_CervixMucinous_Secretory",
-       "cell_count": 287,
-       "cell_ratio": 0.0808
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Epi_EndoMucinous",
-       "cell_count": 2110,
-       "cell_ratio": 0.5939
-      },
-      {
-       "author_value": "Epi_CervixMucinous",
-       "cell_count": 1156,
-       "cell_ratio": 0.3254
-      },
-      {
-       "author_value": "Epi_CervixMucinous_Secretory",
-       "cell_count": 287,
-       "cell_ratio": 0.0808
-      }
-     ]
-    },
-    "celltype_HCA_broad": {
-     "author_field_name": "celltype_HCA_broad",
-     "values": [
-      {
-       "author_value": "Epi_EndoMucinous",
-       "cell_count": 2110,
-       "cell_ratio": 0.5939
-      },
-      {
-       "author_value": "Epi_CervixMucinous",
-       "cell_count": 1443,
-       "cell_ratio": 0.4061
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Uterus",
@@ -215284,6 +210031,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Endometrium",
@@ -215319,6 +210067,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Superficial_Endometrium",
@@ -215354,6 +210103,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -215369,6 +210119,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "35-65",
@@ -215514,6 +210265,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Unknown",
@@ -215609,6 +210361,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "control",
@@ -215639,6 +210392,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -215704,6 +210458,7 @@
     },
     "Observed_pathology": {
      "author_field_name": "Observed_pathology",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not_applicable",
@@ -215734,6 +210489,7 @@
     },
     "Sampled_site_condition": {
      "author_field_name": "Sampled_site_condition",
+     "category": "disease",
      "values": [
       {
        "author_value": "normal",
@@ -215913,188 +210669,9 @@
    "parent_cell_set_accession": "HCArepro:L1:0008",
    "n_cells": 68984,
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Immune_uMac_Inf",
-       "cell_count": 23069,
-       "cell_ratio": 0.3344
-      },
-      {
-       "author_value": "Immune_Mac_LYVE1hi",
-       "cell_count": 16783,
-       "cell_ratio": 0.2433
-      },
-      {
-       "author_value": "Immune_MO_Classical",
-       "cell_count": 13759,
-       "cell_ratio": 0.1995
-      },
-      {
-       "author_value": "Immune_Mast",
-       "cell_count": 5449,
-       "cell_ratio": 0.079
-      },
-      {
-       "author_value": "Immune_uftLAM",
-       "cell_count": 2760,
-       "cell_ratio": 0.04
-      },
-      {
-       "author_value": "Immune_Mac_Cyc",
-       "cell_count": 2560,
-       "cell_ratio": 0.0371
-      },
-      {
-       "author_value": "Immune_MO_NonClassical",
-       "cell_count": 2122,
-       "cell_ratio": 0.0308
-      },
-      {
-       "author_value": "Immune_Mac_Transitional",
-       "cell_count": 1787,
-       "cell_ratio": 0.0259
-      },
-      {
-       "author_value": "Immune_oLAM",
-       "cell_count": 321,
-       "cell_ratio": 0.0047
-      },
-      {
-       "author_value": "Immune_MegaPlat",
-       "cell_count": 177,
-       "cell_ratio": 0.0026
-      },
-      {
-       "author_value": "Immune_LateErythroid",
-       "cell_count": 57,
-       "cell_ratio": 0.0008
-      },
-      {
-       "author_value": "Immune_EarlyMidErythroid",
-       "cell_count": 55,
-       "cell_ratio": 0.0008
-      },
-      {
-       "author_value": "Immune_Neutrophils",
-       "cell_count": 45,
-       "cell_ratio": 0.0007
-      },
-      {
-       "author_value": "Immune_BasoEosino",
-       "cell_count": 40,
-       "cell_ratio": 0.0006
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Immune_uMac_Inf",
-       "cell_count": 23069,
-       "cell_ratio": 0.3344
-      },
-      {
-       "author_value": "Immune_Mac_LYVE1hi",
-       "cell_count": 16783,
-       "cell_ratio": 0.2433
-      },
-      {
-       "author_value": "Immune_MO_Classical",
-       "cell_count": 13759,
-       "cell_ratio": 0.1995
-      },
-      {
-       "author_value": "Immune_Mast",
-       "cell_count": 5449,
-       "cell_ratio": 0.079
-      },
-      {
-       "author_value": "Immune_uftLAM",
-       "cell_count": 2760,
-       "cell_ratio": 0.04
-      },
-      {
-       "author_value": "Immune_Mac_Cyc",
-       "cell_count": 2560,
-       "cell_ratio": 0.0371
-      },
-      {
-       "author_value": "Immune_MO_NonClassical",
-       "cell_count": 2122,
-       "cell_ratio": 0.0308
-      },
-      {
-       "author_value": "Immune_Mac_Transitional",
-       "cell_count": 1787,
-       "cell_ratio": 0.0259
-      },
-      {
-       "author_value": "Immune_oLAM",
-       "cell_count": 321,
-       "cell_ratio": 0.0047
-      },
-      {
-       "author_value": "Immune_MegaPlat",
-       "cell_count": 177,
-       "cell_ratio": 0.0026
-      },
-      {
-       "author_value": "Immune_LateErythroid",
-       "cell_count": 57,
-       "cell_ratio": 0.0008
-      },
-      {
-       "author_value": "Immune_EarlyMidErythroid",
-       "cell_count": 55,
-       "cell_ratio": 0.0008
-      },
-      {
-       "author_value": "Immune_Neutrophils",
-       "cell_count": 45,
-       "cell_ratio": 0.0007
-      },
-      {
-       "author_value": "Immune_BasoEosino",
-       "cell_count": 40,
-       "cell_ratio": 0.0006
-      }
-     ]
-    },
-    "celltype_HCA_broad": {
-     "author_field_name": "celltype_HCA_broad",
-     "values": [
-      {
-       "author_value": "Immune_Macrophages",
-       "cell_count": 47280,
-       "cell_ratio": 0.6854
-      },
-      {
-       "author_value": "Immune_Monocytes",
-       "cell_count": 15881,
-       "cell_ratio": 0.2302
-      },
-      {
-       "author_value": "Immune_Granulocytes",
-       "cell_count": 5534,
-       "cell_ratio": 0.0802
-      },
-      {
-       "author_value": "Immune_Megakaryocytes/platelets",
-       "cell_count": 177,
-       "cell_ratio": 0.0026
-      },
-      {
-       "author_value": "Immune_Erythroid",
-       "cell_count": 112,
-       "cell_ratio": 0.0016
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Uterus",
@@ -216135,6 +210712,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Mentrual fluid",
@@ -216290,6 +210868,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Mentrual fluid",
@@ -216480,6 +211059,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -216510,6 +211090,7 @@
     },
     "Developmental_stage": {
      "author_field_name": "Developmental_stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Adult",
@@ -216540,6 +211121,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "33",
@@ -216825,6 +211407,7 @@
     },
     "Tanner Stage": {
      "author_field_name": "Tanner Stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Pubic V/Genitals-Breast V",
@@ -216865,6 +211448,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -217015,6 +211599,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Menstrual",
@@ -217100,6 +211685,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "control",
@@ -217295,6 +211881,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -217515,6 +212102,7 @@
     },
     "Observed_pathology": {
      "author_field_name": "Observed_pathology",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -217555,6 +212143,7 @@
     },
     "Sampled_site_condition": {
      "author_field_name": "Sampled_site_condition",
+     "category": "disease",
      "values": [
       {
        "author_value": "normal",
@@ -217944,58 +212533,9 @@
    "parent_cell_set_accession": "HCArepro:L1:0124",
    "n_cells": 5109,
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Neural_SympatheticNeurons_Immature",
-       "cell_count": 4469,
-       "cell_ratio": 0.8747
-      },
-      {
-       "author_value": "Neural_SympatheticNeurons_Immature_Cyc",
-       "cell_count": 394,
-       "cell_ratio": 0.0771
-      },
-      {
-       "author_value": "Neural_SympatheticNeurons_Noradrenergic",
-       "cell_count": 246,
-       "cell_ratio": 0.0482
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Neural_SympatheticNeurons_Immature",
-       "cell_count": 4469,
-       "cell_ratio": 0.8747
-      },
-      {
-       "author_value": "Neural_SympatheticNeurons_Immature_Cyc",
-       "cell_count": 394,
-       "cell_ratio": 0.0771
-      },
-      {
-       "author_value": "Neural_SympatheticNeurons_Noradrenergic",
-       "cell_count": 246,
-       "cell_ratio": 0.0482
-      }
-     ]
-    },
-    "celltype_HCA_broad": {
-     "author_field_name": "celltype_HCA_broad",
-     "values": [
-      {
-       "author_value": "Neural_SympatheticNeurons",
-       "cell_count": 5109,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Reproductive tract",
@@ -218016,6 +212556,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Whole_tract",
@@ -218096,6 +212637,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Whole_tract",
@@ -218176,6 +212718,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -218196,6 +212739,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "6.2",
@@ -218459,33 +213003,9 @@
    ],
    "comment": "Marker origin: media-4 broad code 'Germcell_Oocyte' (supertype-level).",
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Germcell_PrimaryOocyte_ZP4neg",
-       "cell_count": 760,
-       "cell_ratio": 0.6603
-      },
-      {
-       "author_value": "Germcell_PrimaryOocyte_ZP4pos",
-       "cell_count": 391,
-       "cell_ratio": 0.3397
-      }
-     ]
-    },
-    "celltype_HCA_broad": {
-     "author_field_name": "celltype_HCA_broad",
-     "values": [
-      {
-       "author_value": "Germcell_PrimaryOocyte",
-       "cell_count": 1151,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Ovary",
@@ -218501,6 +213021,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Gonad_and_extragonadal",
@@ -218536,6 +213057,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Gonad_and_extragonadal",
@@ -218576,6 +213098,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -218606,6 +213129,7 @@
     },
     "Developmental_stage": {
      "author_field_name": "Developmental_stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Fetal",
@@ -218631,6 +213155,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -218726,6 +213251,7 @@
     },
     "Tanner Stage": {
      "author_field_name": "Tanner Stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -218761,6 +213287,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "17",
@@ -218816,6 +213343,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -218836,6 +213364,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "control",
@@ -218916,6 +213445,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -219089,33 +213619,9 @@
     "Germcell_Oogonia"
    ],
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Germcell_Oogonia_premeiotic",
-       "cell_count": 3142,
-       "cell_ratio": 0.6595
-      },
-      {
-       "author_value": "Germcell_Oogonia_meiotic",
-       "cell_count": 1622,
-       "cell_ratio": 0.3405
-      }
-     ]
-    },
-    "celltype_HCA_broad": {
-     "author_field_name": "celltype_HCA_broad",
-     "values": [
-      {
-       "author_value": "Germcell_Oogonia",
-       "cell_count": 4764,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Ovary",
@@ -219131,6 +213637,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Gonad_and_extragonadal",
@@ -219156,6 +213663,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Gonad_and_extragonadal",
@@ -219181,6 +213689,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -219201,6 +213710,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -219216,6 +213726,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "17",
@@ -219376,78 +213887,9 @@
    "parent_cell_set_accession": "HCArepro:L1:0004",
    "n_cells": 69711,
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Mesen_Pericyte",
-       "cell_count": 38904,
-       "cell_ratio": 0.5581
-      },
-      {
-       "author_value": "Mesen_Pericyte_EndoStromalLike",
-       "cell_count": 10229,
-       "cell_ratio": 0.1467
-      },
-      {
-       "author_value": "Mesen_Pericyte_SMCsIntr",
-       "cell_count": 8167,
-       "cell_ratio": 0.1172
-      },
-      {
-       "author_value": "Mesen_Pericyte_EndoSpiralArt",
-       "cell_count": 6617,
-       "cell_ratio": 0.0949
-      },
-      {
-       "author_value": "Mesen_Pericyte_Cyc",
-       "cell_count": 4522,
-       "cell_ratio": 0.0649
-      },
-      {
-       "author_value": "Mesen_Pericyte_EndoStromalLike_MenstrualFluid",
-       "cell_count": 1272,
-       "cell_ratio": 0.0182
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Mesen_Pericyte",
-       "cell_count": 38904,
-       "cell_ratio": 0.5581
-      },
-      {
-       "author_value": "Mesen_Pericyte_EndoStromalLike",
-       "cell_count": 10229,
-       "cell_ratio": 0.1467
-      },
-      {
-       "author_value": "Mesen_Pericyte_SMCsIntr",
-       "cell_count": 8167,
-       "cell_ratio": 0.1172
-      },
-      {
-       "author_value": "Mesen_Pericyte_EndoSpiralArt",
-       "cell_count": 6617,
-       "cell_ratio": 0.0949
-      },
-      {
-       "author_value": "Mesen_Pericyte_Cyc",
-       "cell_count": 4522,
-       "cell_ratio": 0.0649
-      },
-      {
-       "author_value": "Mesen_Pericyte_EndoStromalLike_MenstrualFluid",
-       "cell_count": 1272,
-       "cell_ratio": 0.0182
-      }
-     ]
-    },
     "celltype_HCA_broad": {
      "author_field_name": "celltype_HCA_broad",
+     "category": "cross_cutting_cell_type",
      "values": [
       {
        "author_value": "Mesen_Pericyte",
@@ -219463,6 +213905,7 @@
     },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Uterus",
@@ -219493,6 +213936,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Endometrium",
@@ -219573,6 +214017,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Endometrium",
@@ -219683,6 +214128,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -219703,6 +214149,7 @@
     },
     "Developmental_stage": {
      "author_field_name": "Developmental_stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Adult",
@@ -219728,6 +214175,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "23",
@@ -220023,6 +214471,7 @@
     },
     "Tanner Stage": {
      "author_field_name": "Tanner Stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Pubic V/Genitals-Breast V",
@@ -220058,6 +214507,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Postmenopausal",
@@ -220168,6 +214618,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "control",
@@ -220373,6 +214824,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -220613,6 +215065,7 @@
     },
     "Observed_pathology": {
      "author_field_name": "Observed_pathology",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -220653,6 +215106,7 @@
     },
     "Sampled_site_condition": {
      "author_field_name": "Sampled_site_condition",
+     "category": "disease",
      "values": [
       {
        "author_value": "normal",
@@ -221194,28 +215648,9 @@
    "parent_cell_set_accession": "HCArepro:L1:0004",
    "n_cells": 28897,
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Mesen_PV_Fetal",
-       "cell_count": 28897,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA_broad": {
-     "author_field_name": "celltype_HCA_broad",
-     "values": [
-      {
-       "author_value": "Mesen_PV",
-       "cell_count": 28897,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Reproductive tract",
@@ -221236,6 +215671,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Gonad_and_extragonadal",
@@ -221321,6 +215757,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Gonad_and_extragonadal",
@@ -221406,6 +215843,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -221426,6 +215864,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -221441,6 +215880,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "21",
@@ -222191,38 +216631,9 @@
    "cell_ontology_term": "primordial germ cell",
    "comment": "Supertype/internal node. Its un-subtyped members were split into minted generic leaf/leaves (see children with 'Minted generic leaf' comments). n_cells is the full subtree.",
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Germcell_PGCs",
-       "cell_count": 6862,
-       "cell_ratio": 0.7258
-      },
-      {
-       "author_value": "Germcell_PGC_Cyc",
-       "cell_count": 2592,
-       "cell_ratio": 0.2742
-      }
-     ]
-    },
-    "celltype_HCA_broad": {
-     "author_field_name": "celltype_HCA_broad",
-     "values": [
-      {
-       "author_value": "Germcell_PGCs",
-       "cell_count": 6862,
-       "cell_ratio": 0.7258
-      },
-      {
-       "author_value": "Germcell_PGC",
-       "cell_count": 2592,
-       "cell_ratio": 0.2742
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Ovary",
@@ -222238,6 +216649,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Gonad",
@@ -222268,6 +216680,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Gonad",
@@ -222298,6 +216711,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -222318,6 +216732,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -222333,6 +216748,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "9",
@@ -222509,63 +216925,9 @@
    "parent_cell_set_accession": "HCArepro:L1:0008",
    "n_cells": 747,
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Immune_NMP_Promyelocytes",
-       "cell_count": 286,
-       "cell_ratio": 0.3829
-      },
-      {
-       "author_value": "Immune_MEMP",
-       "cell_count": 250,
-       "cell_ratio": 0.3347
-      },
-      {
-       "author_value": "Immune_HPC",
-       "cell_count": 211,
-       "cell_ratio": 0.2825
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Immune_NMP_Promyelocytes",
-       "cell_count": 286,
-       "cell_ratio": 0.3829
-      },
-      {
-       "author_value": "Immune_MEMP",
-       "cell_count": 250,
-       "cell_ratio": 0.3347
-      },
-      {
-       "author_value": "Immune_HPC",
-       "cell_count": 211,
-       "cell_ratio": 0.2825
-      }
-     ]
-    },
-    "celltype_HCA_broad": {
-     "author_field_name": "celltype_HCA_broad",
-     "values": [
-      {
-       "author_value": "Immune_Myeloid_progenitors",
-       "cell_count": 536,
-       "cell_ratio": 0.7175
-      },
-      {
-       "author_value": "Immune_Haematopoietic_progenitor_cells",
-       "cell_count": 211,
-       "cell_ratio": 0.2825
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Ovary",
@@ -222601,6 +216963,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Gonad_and_extragonadal",
@@ -222701,6 +217064,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Gonad_and_extragonadal",
@@ -222811,6 +217175,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Immune",
@@ -222831,6 +217196,7 @@
     },
     "Developmental_stage": {
      "author_field_name": "Developmental_stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Fetal",
@@ -222851,6 +217217,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -222946,6 +217313,7 @@
     },
     "Tanner Stage": {
      "author_field_name": "Tanner Stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -222966,6 +217334,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "14",
@@ -223096,6 +217465,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -223151,6 +217521,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "control",
@@ -223191,6 +217562,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -223236,6 +217608,7 @@
     },
     "Observed_pathology": {
      "author_field_name": "Observed_pathology",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -223261,6 +217634,7 @@
     },
     "Sampled_site_condition": {
      "author_field_name": "Sampled_site_condition",
+     "category": "disease",
      "values": [
       {
        "author_value": "normal",
@@ -223413,213 +217787,9 @@
    ],
    "comment": "Marker origin: media-4 broad code 'Epi_Sec' (supertype-level).",
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Epi_EndoGlandFun_mSec",
-       "cell_count": 25233,
-       "cell_ratio": 0.1223
-      },
-      {
-       "author_value": "Epi_EndoGlandFun_Prof",
-       "cell_count": 23099,
-       "cell_ratio": 0.112
-      },
-      {
-       "author_value": "Epi_EndoGlandFun_emSec",
-       "cell_count": 18366,
-       "cell_ratio": 0.089
-      },
-      {
-       "author_value": "Epi_EndoGland_nEMC",
-       "cell_count": 18196,
-       "cell_ratio": 0.0882
-      },
-      {
-       "author_value": "Epi_FallopianSec_OVGP1hi_EstrInd",
-       "cell_count": 17601,
-       "cell_ratio": 0.0853
-      },
-      {
-       "author_value": "Epi_FallopianSec_OVGP1lo",
-       "cell_count": 13587,
-       "cell_ratio": 0.0659
-      },
-      {
-       "author_value": "Epi_EndoGlandFun_Prof_Cyc",
-       "cell_count": 12815,
-       "cell_ratio": 0.0621
-      },
-      {
-       "author_value": "Epi_FallopianSec_Fetal",
-       "cell_count": 12310,
-       "cell_ratio": 0.0597
-      },
-      {
-       "author_value": "Epi_EndoGlandLum_mSec",
-       "cell_count": 12046,
-       "cell_ratio": 0.0584
-      },
-      {
-       "author_value": "Epi_EndoGlandFun_lProf",
-       "cell_count": 11900,
-       "cell_ratio": 0.0577
-      },
-      {
-       "author_value": "Epi_EndoGlandLum_Prof",
-       "cell_count": 9672,
-       "cell_ratio": 0.0469
-      },
-      {
-       "author_value": "Epi_MesonephricTub_Fetal",
-       "cell_count": 7359,
-       "cell_ratio": 0.0357
-      },
-      {
-       "author_value": "Epi_Vagina_Lower_Fetal",
-       "cell_count": 6047,
-       "cell_ratio": 0.0293
-      },
-      {
-       "author_value": "Epi_reteOvarii_Fetal_Undiff",
-       "cell_count": 5796,
-       "cell_ratio": 0.0281
-      },
-      {
-       "author_value": "Epi_EndoGlandFun_Menstr",
-       "cell_count": 4248,
-       "cell_ratio": 0.0206
-      },
-      {
-       "author_value": "Epi_UGS_Undiff",
-       "cell_count": 3302,
-       "cell_ratio": 0.016
-      },
-      {
-       "author_value": "Epi_EndoGlandBas_WIF1",
-       "cell_count": 1694,
-       "cell_ratio": 0.0082
-      },
-      {
-       "author_value": "Epi_EndoGlandFun_lSec",
-       "cell_count": 1467,
-       "cell_ratio": 0.0071
-      },
-      {
-       "author_value": "Epi_EndoGlandBas",
-       "cell_count": 748,
-       "cell_ratio": 0.0036
-      },
-      {
-       "author_value": "Epi_FallopianSec_Cyc",
-       "cell_count": 560,
-       "cell_ratio": 0.0027
-      },
-      {
-       "author_value": "Epi_OvarianInclSec",
-       "cell_count": 202,
-       "cell_ratio": 0.001
-      },
-      {
-       "author_value": "Epi_EndoGlandLum_eSec",
-       "cell_count": 24,
-       "cell_ratio": 0.0001
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "unknown",
-       "cell_count": 52415,
-       "cell_ratio": 0.2541
-      },
-      {
-       "author_value": "Epi_EndoGlandFun_mSec",
-       "cell_count": 25233,
-       "cell_ratio": 0.1223
-      },
-      {
-       "author_value": "Epi_EndoGlandFun_Prof",
-       "cell_count": 23099,
-       "cell_ratio": 0.112
-      },
-      {
-       "author_value": "Epi_EndoGlandFun_emSec",
-       "cell_count": 18366,
-       "cell_ratio": 0.089
-      },
-      {
-       "author_value": "Epi_EndoGland_nEMC",
-       "cell_count": 18196,
-       "cell_ratio": 0.0882
-      },
-      {
-       "author_value": "Epi_FallopianSec_OVGP1lo",
-       "cell_count": 13587,
-       "cell_ratio": 0.0659
-      },
-      {
-       "author_value": "Epi_EndoGlandFun_Prof_Cyc",
-       "cell_count": 12815,
-       "cell_ratio": 0.0621
-      },
-      {
-       "author_value": "Epi_EndoGlandLum_mSec",
-       "cell_count": 12046,
-       "cell_ratio": 0.0584
-      },
-      {
-       "author_value": "Epi_EndoGlandFun_lProf",
-       "cell_count": 11900,
-       "cell_ratio": 0.0577
-      },
-      {
-       "author_value": "Epi_EndoGlandLum_Prof",
-       "cell_count": 9672,
-       "cell_ratio": 0.0469
-      },
-      {
-       "author_value": "Epi_EndoGlandFun_Menstr",
-       "cell_count": 4248,
-       "cell_ratio": 0.0206
-      },
-      {
-       "author_value": "Epi_EndoGlandBas_WIF1",
-       "cell_count": 1694,
-       "cell_ratio": 0.0082
-      },
-      {
-       "author_value": "Epi_EndoGlandFun_lSec",
-       "cell_count": 1467,
-       "cell_ratio": 0.0071
-      },
-      {
-       "author_value": "Epi_EndoGlandBas",
-       "cell_count": 748,
-       "cell_ratio": 0.0036
-      },
-      {
-       "author_value": "Epi_FallopianSec_Cyc",
-       "cell_count": 560,
-       "cell_ratio": 0.0027
-      },
-      {
-       "author_value": "Epi_OvarianInclSec",
-       "cell_count": 202,
-       "cell_ratio": 0.001
-      },
-      {
-       "author_value": "Epi_EndoGlandLum_eSec",
-       "cell_count": 24,
-       "cell_ratio": 0.0001
-      }
-     ]
-    },
     "celltype_HCA_broad": {
      "author_field_name": "celltype_HCA_broad",
+     "category": "cross_cutting_cell_type",
      "values": [
       {
        "author_value": "Epi_EndoGlandFun",
@@ -223675,6 +217845,7 @@
     },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Uterus",
@@ -223705,6 +217876,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Endometrium",
@@ -223850,6 +218022,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Superficial_Endometrium",
@@ -224020,6 +218193,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -224045,6 +218219,7 @@
     },
     "Developmental_stage": {
      "author_field_name": "Developmental_stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Adult",
@@ -224065,6 +218240,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -224270,6 +218446,7 @@
     },
     "Tanner Stage": {
      "author_field_name": "Tanner Stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Pubic V/Genitals-Breast V",
@@ -224290,6 +218467,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -224440,6 +218618,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -224550,6 +218729,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "control",
@@ -224625,6 +218805,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -224735,6 +218916,7 @@
     },
     "Observed_pathology": {
      "author_field_name": "Observed_pathology",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -224770,6 +218952,7 @@
     },
     "Sampled_site_condition": {
      "author_field_name": "Sampled_site_condition",
+     "category": "disease",
      "values": [
       {
        "author_value": "normal",
@@ -225888,68 +220071,9 @@
    ],
    "comment": "Marker origin: media-4 broad code 'Mesen_SMCs_Fetal' (supertype-level).",
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Mesen_CervixVaginaSMCs_Fetal",
-       "cell_count": 11569,
-       "cell_ratio": 0.3958
-      },
-      {
-       "author_value": "Mesen_FallopianSMCs_Fetal",
-       "cell_count": 8413,
-       "cell_ratio": 0.2879
-      },
-      {
-       "author_value": "Mesen_UterusSMCs_Fetal",
-       "cell_count": 7550,
-       "cell_ratio": 0.2583
-      },
-      {
-       "author_value": "Mesen_VaginaSMCs_Lower_Fetal",
-       "cell_count": 1311,
-       "cell_ratio": 0.0449
-      },
-      {
-       "author_value": "Mesen_UGSSMCs",
-       "cell_count": 383,
-       "cell_ratio": 0.0131
-      }
-     ]
-    },
-    "celltype_HCA_broad": {
-     "author_field_name": "celltype_HCA_broad",
-     "values": [
-      {
-       "author_value": "Mesen_CervixVaginaSMCs",
-       "cell_count": 11569,
-       "cell_ratio": 0.3958
-      },
-      {
-       "author_value": "Mesen_FallopianSMCs",
-       "cell_count": 8413,
-       "cell_ratio": 0.2879
-      },
-      {
-       "author_value": "Mesen_UterusSMCs",
-       "cell_count": 7550,
-       "cell_ratio": 0.2583
-      },
-      {
-       "author_value": "Mesen_VaginaSMCs",
-       "cell_count": 1311,
-       "cell_ratio": 0.0449
-      },
-      {
-       "author_value": "Mesen_UGSSMCs",
-       "cell_count": 383,
-       "cell_ratio": 0.0131
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Reproductive tract",
@@ -225970,6 +220094,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "cervix, vagina",
@@ -226050,6 +220175,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Cervix, vagina",
@@ -226130,6 +220256,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -226150,6 +220277,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "21",
@@ -226631,38 +220759,9 @@
    "parent_cell_set_accession": "HCArepro:L1:0004",
    "n_cells": 41488,
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Mesen_SMCs",
-       "cell_count": 41488,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Mesen_SMCs",
-       "cell_count": 41488,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
-    "celltype_HCA_broad": {
-     "author_field_name": "celltype_HCA_broad",
-     "values": [
-      {
-       "author_value": "Mesen_SMCs",
-       "cell_count": 41488,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Uterus",
@@ -226688,6 +220787,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Whole_Uterus",
@@ -226753,6 +220853,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Endometrium",
@@ -226843,6 +220944,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -226863,6 +220965,7 @@
     },
     "Developmental_stage": {
      "author_field_name": "Developmental_stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Adult",
@@ -226883,6 +220986,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "23",
@@ -227123,6 +221227,7 @@
     },
     "Tanner Stage": {
      "author_field_name": "Tanner Stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Pubic V/Genitals-Breast V",
@@ -227158,6 +221263,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Postmenopausal",
@@ -227253,6 +221359,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "control",
@@ -227373,6 +221480,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -227523,6 +221631,7 @@
     },
     "Observed_pathology": {
      "author_field_name": "Observed_pathology",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -227548,6 +221657,7 @@
     },
     "Sampled_site_condition": {
      "author_field_name": "Sampled_site_condition",
+     "category": "disease",
      "values": [
       {
        "author_value": "normal",
@@ -227993,83 +222103,9 @@
    ],
    "comment": "Marker origin: media-4 broad code 'Epi_Squamous' (supertype-level).",
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Epi_PrepuceSquamous_Fetal",
-       "cell_count": 2097,
-       "cell_ratio": 0.2249
-      },
-      {
-       "author_value": "Epi_UrethralSquamous_Fetal",
-       "cell_count": 1649,
-       "cell_ratio": 0.1769
-      },
-      {
-       "author_value": "Epi_GenitalSurf_Fetal",
-       "cell_count": 1482,
-       "cell_ratio": 0.159
-      },
-      {
-       "author_value": "Epi_CervixSquamous",
-       "cell_count": 1138,
-       "cell_ratio": 0.1221
-      },
-      {
-       "author_value": "Epi_Vagina_Upper_Fetal",
-       "cell_count": 980,
-       "cell_ratio": 0.1051
-      },
-      {
-       "author_value": "Epi_ParatubalIncl_squamous",
-       "cell_count": 922,
-       "cell_ratio": 0.0989
-      },
-      {
-       "author_value": "Epi_EctocervixVaginaSquamous",
-       "cell_count": 646,
-       "cell_ratio": 0.0693
-      },
-      {
-       "author_value": "Epi_CervixSquamous_Cyc",
-       "cell_count": 409,
-       "cell_ratio": 0.0439
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "unknown",
-       "cell_count": 6208,
-       "cell_ratio": 0.6659
-      },
-      {
-       "author_value": "Epi_CervixSquamous",
-       "cell_count": 1138,
-       "cell_ratio": 0.1221
-      },
-      {
-       "author_value": "Epi_ParatubalIncl_squamous",
-       "cell_count": 922,
-       "cell_ratio": 0.0989
-      },
-      {
-       "author_value": "Epi_EctocervixVaginaSquamous",
-       "cell_count": 646,
-       "cell_ratio": 0.0693
-      },
-      {
-       "author_value": "Epi_CervixSquamous_Cyc",
-       "cell_count": 409,
-       "cell_ratio": 0.0439
-      }
-     ]
-    },
     "celltype_HCA_broad": {
      "author_field_name": "celltype_HCA_broad",
+     "category": "cross_cutting_cell_type",
      "values": [
       {
        "author_value": "Epi_PrepuceSquamous",
@@ -228110,6 +222146,7 @@
     },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Reproductive tract",
@@ -228150,6 +222187,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "uterus, cervix, vagina",
@@ -228250,6 +222288,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "uterus, cervix, vagina",
@@ -228355,6 +222394,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -228370,6 +222410,7 @@
     },
     "Developmental_stage": {
      "author_field_name": "Developmental_stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Fetal",
@@ -228385,6 +222426,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -228485,6 +222527,7 @@
     },
     "Tanner Stage": {
      "author_field_name": "Tanner Stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -228500,6 +222543,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -228605,6 +222649,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -228660,6 +222705,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "control",
@@ -228675,6 +222721,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -228700,6 +222747,7 @@
     },
     "Observed_pathology": {
      "author_field_name": "Observed_pathology",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -228720,6 +222768,7 @@
     },
     "Sampled_site_condition": {
      "author_field_name": "Sampled_site_condition",
+     "category": "disease",
      "values": [
       {
        "author_value": "normal",
@@ -228980,453 +223029,9 @@
    ],
    "comment": "Marker origin: media-4 broad code 'Mesen_InterstitialFibroblast' (supertype-level).",
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Mesen_EndoStromalFib_Prolif",
-       "cell_count": 164476,
-       "cell_ratio": 0.1598
-      },
-      {
-       "author_value": "Mesen_OvarianFibs_InncorMedulla",
-       "cell_count": 125985,
-       "cell_ratio": 0.1224
-      },
-      {
-       "author_value": "Mesen_EndoStromalFib_mSec",
-       "cell_count": 103861,
-       "cell_ratio": 0.1009
-      },
-      {
-       "author_value": "Mesen_FallopianFibs",
-       "cell_count": 64649,
-       "cell_ratio": 0.0628
-      },
-      {
-       "author_value": "Mesen_EndoStromalFib_nEMC_Sec",
-       "cell_count": 50283,
-       "cell_ratio": 0.0488
-      },
-      {
-       "author_value": "Mesen_EndoStromalFib_nEMC",
-       "cell_count": 48007,
-       "cell_ratio": 0.0466
-      },
-      {
-       "author_value": "Mesen_OvarianFibs_Perifol",
-       "cell_count": 44411,
-       "cell_ratio": 0.0431
-      },
-      {
-       "author_value": "Mesen_FallopianFib_Fetal",
-       "cell_count": 41092,
-       "cell_ratio": 0.0399
-      },
-      {
-       "author_value": "Mesen_EndoStromalFib_lSec",
-       "cell_count": 36137,
-       "cell_ratio": 0.0351
-      },
-      {
-       "author_value": "Mesen_EndoStromalFib_Prolif_Cyc",
-       "cell_count": 32491,
-       "cell_ratio": 0.0316
-      },
-      {
-       "author_value": "Mesen_OvarianFibs_Fetal",
-       "cell_count": 32133,
-       "cell_ratio": 0.0312
-      },
-      {
-       "author_value": "Mesen_UterusFibs_Fetal",
-       "cell_count": 29462,
-       "cell_ratio": 0.0286
-      },
-      {
-       "author_value": "Mesen_MesonephricFibs_Fetal",
-       "cell_count": 28521,
-       "cell_ratio": 0.0277
-      },
-      {
-       "author_value": "Mesen_EndoStromalFib_MenstrualFluid",
-       "cell_count": 27092,
-       "cell_ratio": 0.0263
-      },
-      {
-       "author_value": "Mesen_GonadalFibs_Undiff",
-       "cell_count": 26055,
-       "cell_ratio": 0.0253
-      },
-      {
-       "author_value": "Mesen_OvarianFibs_Outcor",
-       "cell_count": 21434,
-       "cell_ratio": 0.0208
-      },
-      {
-       "author_value": "Mesen_EndoStromalFib_eSec",
-       "cell_count": 17251,
-       "cell_ratio": 0.0168
-      },
-      {
-       "author_value": "Mesen_EpoophronFib_Fetal",
-       "cell_count": 13877,
-       "cell_ratio": 0.0135
-      },
-      {
-       "author_value": "Mesen_OvarianFibs_Medulla_SMCsLike",
-       "cell_count": 13705,
-       "cell_ratio": 0.0133
-      },
-      {
-       "author_value": "Mesen_EndoStromalFib_MenstrualEutopic",
-       "cell_count": 13034,
-       "cell_ratio": 0.0127
-      },
-      {
-       "author_value": "Mesen_EndoStromalFib_nEMC_Cyc",
-       "cell_count": 12895,
-       "cell_ratio": 0.0125
-      },
-      {
-       "author_value": "Mesen_CervixFib_Fetal",
-       "cell_count": 11916,
-       "cell_ratio": 0.0116
-      },
-      {
-       "author_value": "Mesen_UGSFib_Upper",
-       "cell_count": 11402,
-       "cell_ratio": 0.0111
-      },
-      {
-       "author_value": "Mesen_CorpusSpongiosumFib_Fetal",
-       "cell_count": 10169,
-       "cell_ratio": 0.0099
-      },
-      {
-       "author_value": "Mesen_CorpusCavernosumFib_Fetal",
-       "cell_count": 9472,
-       "cell_ratio": 0.0092
-      },
-      {
-       "author_value": "Mesen_VaginaFibs_Upper_Fetal",
-       "cell_count": 7925,
-       "cell_ratio": 0.0077
-      },
-      {
-       "author_value": "Mesen_LabioScrotalSwelling_Fetal",
-       "cell_count": 6830,
-       "cell_ratio": 0.0066
-      },
-      {
-       "author_value": "Mesen_UGSFib_Lower",
-       "cell_count": 6277,
-       "cell_ratio": 0.0061
-      },
-      {
-       "author_value": "Mesen_GlansFib_Fetal",
-       "cell_count": 5416,
-       "cell_ratio": 0.0053
-      },
-      {
-       "author_value": "Mesen_EndoStromalFib_Menopause",
-       "cell_count": 2855,
-       "cell_ratio": 0.0028
-      },
-      {
-       "author_value": "Mesen_MullerianFib",
-       "cell_count": 2471,
-       "cell_ratio": 0.0024
-      },
-      {
-       "author_value": "Mesen_Prepuce_Fetal",
-       "cell_count": 2243,
-       "cell_ratio": 0.0022
-      },
-      {
-       "author_value": "Mesen_LabiaFib_Fetal",
-       "cell_count": 1794,
-       "cell_ratio": 0.0017
-      },
-      {
-       "author_value": "Mesen_VaginaFibs",
-       "cell_count": 1463,
-       "cell_ratio": 0.0014
-      },
-      {
-       "author_value": "Mesen_VaginaFib_Lower_Fetal",
-       "cell_count": 645,
-       "cell_ratio": 0.0006
-      },
-      {
-       "author_value": "Mesen_EndoGlandBas",
-       "cell_count": 535,
-       "cell_ratio": 0.0005
-      },
-      {
-       "author_value": "Mesen_OvarianFibs_AdvLike",
-       "cell_count": 507,
-       "cell_ratio": 0.0005
-      },
-      {
-       "author_value": "Mesen_CervixFibs",
-       "cell_count": 452,
-       "cell_ratio": 0.0004
-      },
-      {
-       "author_value": "Mesen_UterotubalJunctionFibs",
-       "cell_count": 150,
-       "cell_ratio": 0.0001
-      },
-      {
-       "author_value": "Mesen_OvarianInclFibs",
-       "cell_count": 96,
-       "cell_ratio": 0.0001
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "unknown",
-       "cell_count": 247700,
-       "cell_ratio": 0.2406
-      },
-      {
-       "author_value": "Mesen_EndoStromalFib_Prolif",
-       "cell_count": 164476,
-       "cell_ratio": 0.1598
-      },
-      {
-       "author_value": "Mesen_OvarianFibs_InncorMedulla",
-       "cell_count": 125985,
-       "cell_ratio": 0.1224
-      },
-      {
-       "author_value": "Mesen_EndoStromalFib_mSec",
-       "cell_count": 103861,
-       "cell_ratio": 0.1009
-      },
-      {
-       "author_value": "Mesen_FallopianFibs",
-       "cell_count": 64649,
-       "cell_ratio": 0.0628
-      },
-      {
-       "author_value": "Mesen_EndoStromalFib_nEMC_Sec",
-       "cell_count": 50283,
-       "cell_ratio": 0.0488
-      },
-      {
-       "author_value": "Mesen_EndoStromalFib_nEMC",
-       "cell_count": 48007,
-       "cell_ratio": 0.0466
-      },
-      {
-       "author_value": "Mesen_OvarianFibs_Perifol",
-       "cell_count": 44411,
-       "cell_ratio": 0.0431
-      },
-      {
-       "author_value": "Mesen_EndoStromalFib_lSec",
-       "cell_count": 36137,
-       "cell_ratio": 0.0351
-      },
-      {
-       "author_value": "Mesen_EndoStromalFib_Prolif_Cyc",
-       "cell_count": 32491,
-       "cell_ratio": 0.0316
-      },
-      {
-       "author_value": "Mesen_EndoStromalFib_MenstrualFluid",
-       "cell_count": 27092,
-       "cell_ratio": 0.0263
-      },
-      {
-       "author_value": "Mesen_OvarianFibs_Outcor",
-       "cell_count": 21434,
-       "cell_ratio": 0.0208
-      },
-      {
-       "author_value": "Mesen_EndoStromalFib_eSec",
-       "cell_count": 17251,
-       "cell_ratio": 0.0168
-      },
-      {
-       "author_value": "Mesen_OvarianFibs_Medulla_SMCsLike",
-       "cell_count": 13705,
-       "cell_ratio": 0.0133
-      },
-      {
-       "author_value": "Mesen_EndoStromalFib_MenstrualEutopic",
-       "cell_count": 13034,
-       "cell_ratio": 0.0127
-      },
-      {
-       "author_value": "Mesen_EndoStromalFib_nEMC_Cyc",
-       "cell_count": 12895,
-       "cell_ratio": 0.0125
-      },
-      {
-       "author_value": "Mesen_EndoStromalFib_Menopause",
-       "cell_count": 2855,
-       "cell_ratio": 0.0028
-      },
-      {
-       "author_value": "Mesen_VaginaFibs",
-       "cell_count": 1463,
-       "cell_ratio": 0.0014
-      },
-      {
-       "author_value": "Mesen_EndoGlandBas",
-       "cell_count": 535,
-       "cell_ratio": 0.0005
-      },
-      {
-       "author_value": "Mesen_OvarianFibs_AdvLike",
-       "cell_count": 507,
-       "cell_ratio": 0.0005
-      },
-      {
-       "author_value": "Mesen_CervixFibs",
-       "cell_count": 452,
-       "cell_ratio": 0.0004
-      },
-      {
-       "author_value": "Mesen_UterotubalJunctionFibs",
-       "cell_count": 150,
-       "cell_ratio": 0.0001
-      },
-      {
-       "author_value": "Mesen_OvarianInclFibs",
-       "cell_count": 96,
-       "cell_ratio": 0.0001
-      }
-     ]
-    },
-    "celltype_HCA_broad": {
-     "author_field_name": "celltype_HCA_broad",
-     "values": [
-      {
-       "author_value": "Mesen_EndoStromalFib",
-       "cell_count": 508382,
-       "cell_ratio": 0.4938
-      },
-      {
-       "author_value": "Mesen_OvarianFibs",
-       "cell_count": 238175,
-       "cell_ratio": 0.2314
-      },
-      {
-       "author_value": "Mesen_FallopianFibs",
-       "cell_count": 64649,
-       "cell_ratio": 0.0628
-      },
-      {
-       "author_value": "Mesen_FallopianFib",
-       "cell_count": 41092,
-       "cell_ratio": 0.0399
-      },
-      {
-       "author_value": "Mesen_UterusFibs",
-       "cell_count": 29462,
-       "cell_ratio": 0.0286
-      },
-      {
-       "author_value": "Mesen_MesonephricFibs",
-       "cell_count": 28521,
-       "cell_ratio": 0.0277
-      },
-      {
-       "author_value": "Mesen_GonadalFibs",
-       "cell_count": 26055,
-       "cell_ratio": 0.0253
-      },
-      {
-       "author_value": "Mesen_UGSFib",
-       "cell_count": 17679,
-       "cell_ratio": 0.0172
-      },
-      {
-       "author_value": "Mesen_EpoophronFib",
-       "cell_count": 13877,
-       "cell_ratio": 0.0135
-      },
-      {
-       "author_value": "Mesen_CervixFib",
-       "cell_count": 11916,
-       "cell_ratio": 0.0116
-      },
-      {
-       "author_value": "Mesen_CorpusSpongiosumFib",
-       "cell_count": 10169,
-       "cell_ratio": 0.0099
-      },
-      {
-       "author_value": "Mesen_CorpusCavernosumFib",
-       "cell_count": 9472,
-       "cell_ratio": 0.0092
-      },
-      {
-       "author_value": "Mesen_VaginaFibs",
-       "cell_count": 9388,
-       "cell_ratio": 0.0091
-      },
-      {
-       "author_value": "Mesen_LabioScrotalSwelling",
-       "cell_count": 6830,
-       "cell_ratio": 0.0066
-      },
-      {
-       "author_value": "Mesen_GlansFib",
-       "cell_count": 5416,
-       "cell_ratio": 0.0053
-      },
-      {
-       "author_value": "Mesen_MullerianFib",
-       "cell_count": 2471,
-       "cell_ratio": 0.0024
-      },
-      {
-       "author_value": "Mesen_Prepuce",
-       "cell_count": 2243,
-       "cell_ratio": 0.0022
-      },
-      {
-       "author_value": "Mesen_LabiaFib",
-       "cell_count": 1794,
-       "cell_ratio": 0.0017
-      },
-      {
-       "author_value": "Mesen_VaginaFib",
-       "cell_count": 645,
-       "cell_ratio": 0.0006
-      },
-      {
-       "author_value": "Mesen_EndoGlandBas",
-       "cell_count": 535,
-       "cell_ratio": 0.0005
-      },
-      {
-       "author_value": "Mesen_CervixFibs",
-       "cell_count": 452,
-       "cell_ratio": 0.0004
-      },
-      {
-       "author_value": "Mesen_UterotubalJunctionFibs",
-       "cell_count": 150,
-       "cell_ratio": 0.0001
-      },
-      {
-       "author_value": "Mesen_OvarianInclFibs",
-       "cell_count": 96,
-       "cell_ratio": 0.0001
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Uterus",
@@ -229467,6 +223072,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Endometrium",
@@ -229617,6 +223223,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Endometrium",
@@ -229797,6 +223404,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -229827,6 +223435,7 @@
     },
     "Developmental_stage": {
      "author_field_name": "Developmental_stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Adult",
@@ -229857,6 +223466,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -230162,6 +223772,7 @@
     },
     "Tanner Stage": {
      "author_field_name": "Tanner Stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Pubic V/Genitals-Breast V",
@@ -230202,6 +223813,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -230352,6 +223964,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -230467,6 +224080,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "control",
@@ -230677,6 +224291,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -230922,6 +224537,7 @@
     },
     "Observed_pathology": {
      "author_field_name": "Observed_pathology",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -230962,6 +224578,7 @@
     },
     "Sampled_site_condition": {
      "author_field_name": "Sampled_site_condition",
+     "category": "disease",
      "values": [
       {
        "author_value": "normal",
@@ -232455,103 +226072,9 @@
    "parent_cell_set_accession": "HCArepro:L1:0038",
    "n_cells": 40459,
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Meso_OSE_Fetal",
-       "cell_count": 23115,
-       "cell_ratio": 0.5713
-      },
-      {
-       "author_value": "Meso_ParamesoCoelEpi",
-       "cell_count": 8490,
-       "cell_ratio": 0.2098
-      },
-      {
-       "author_value": "Meso_Peritoneal_Fetal",
-       "cell_count": 4720,
-       "cell_ratio": 0.1167
-      },
-      {
-       "author_value": "Meso_GonadalCoelEpi",
-       "cell_count": 2840,
-       "cell_ratio": 0.0702
-      },
-      {
-       "author_value": "Meso_OSE",
-       "cell_count": 841,
-       "cell_ratio": 0.0208
-      },
-      {
-       "author_value": "Meso_serosa",
-       "cell_count": 453,
-       "cell_ratio": 0.0112
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "unknown",
-       "cell_count": 39165,
-       "cell_ratio": 0.968
-      },
-      {
-       "author_value": "Meso_OSE",
-       "cell_count": 841,
-       "cell_ratio": 0.0208
-      },
-      {
-       "author_value": "Meso_serosa",
-       "cell_count": 453,
-       "cell_ratio": 0.0112
-      }
-     ]
-    },
-    "celltype_HCA_broad": {
-     "author_field_name": "celltype_HCA_broad",
-     "values": [
-      {
-       "author_value": "Meso_OSE",
-       "cell_count": 23956,
-       "cell_ratio": 0.5921
-      },
-      {
-       "author_value": "Meso_ParamesoCoelEpi",
-       "cell_count": 8490,
-       "cell_ratio": 0.2098
-      },
-      {
-       "author_value": "Meso_Peritoneal",
-       "cell_count": 4720,
-       "cell_ratio": 0.1167
-      },
-      {
-       "author_value": "Meso_GonadalCoelEpi",
-       "cell_count": 2840,
-       "cell_ratio": 0.0702
-      },
-      {
-       "author_value": "Meso_serosa",
-       "cell_count": 453,
-       "cell_ratio": 0.0112
-      }
-     ]
-    },
-    "celltype_HCA_lineage": {
-     "author_field_name": "celltype_HCA_lineage",
-     "values": [
-      {
-       "author_value": "mesothelial",
-       "cell_count": 40459,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Ovary",
@@ -232582,6 +226105,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Gonad_and_extragonadal",
@@ -232717,6 +226241,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Gonad_and_extragonadal",
@@ -232872,6 +226397,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -232897,6 +226423,7 @@
     },
     "Developmental_stage": {
      "author_field_name": "Developmental_stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Fetal",
@@ -232927,6 +226454,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -233087,6 +226615,7 @@
     },
     "Tanner Stage": {
      "author_field_name": "Tanner Stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -233122,6 +226651,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "10",
@@ -233262,6 +226792,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -233322,6 +226853,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "control",
@@ -233392,6 +226924,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -233462,6 +226995,7 @@
     },
     "Observed_pathology": {
      "author_field_name": "Observed_pathology",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -233477,6 +227011,7 @@
     },
     "Sampled_site_condition": {
      "author_field_name": "Sampled_site_condition",
+     "category": "disease",
      "values": [
       {
        "author_value": "normal",
@@ -234174,78 +227709,9 @@
    ],
    "comment": "Marker origin: media-4 broad code 'Mesen_Theca' (supertype-level).",
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Mesen_Theca_Externa",
-       "cell_count": 30089,
-       "cell_ratio": 0.5347
-      },
-      {
-       "author_value": "Mesen_Theca_Interna_Cyc",
-       "cell_count": 9366,
-       "cell_ratio": 0.1664
-      },
-      {
-       "author_value": "Mesen_Theca_Interna_Steroid",
-       "cell_count": 8428,
-       "cell_ratio": 0.1498
-      },
-      {
-       "author_value": "Mesen_Theca_Interna_Perifol",
-       "cell_count": 5148,
-       "cell_ratio": 0.0915
-      },
-      {
-       "author_value": "Mesen_Theca_Atretic",
-       "cell_count": 3239,
-       "cell_ratio": 0.0576
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Mesen_Theca_Externa",
-       "cell_count": 30089,
-       "cell_ratio": 0.5347
-      },
-      {
-       "author_value": "Mesen_Theca_Interna_Cyc",
-       "cell_count": 9366,
-       "cell_ratio": 0.1664
-      },
-      {
-       "author_value": "Mesen_Theca_Interna_Steroid",
-       "cell_count": 8428,
-       "cell_ratio": 0.1498
-      },
-      {
-       "author_value": "Mesen_Theca_Interna_Perifol",
-       "cell_count": 5148,
-       "cell_ratio": 0.0915
-      },
-      {
-       "author_value": "Mesen_Theca_Atretic",
-       "cell_count": 3239,
-       "cell_ratio": 0.0576
-      }
-     ]
-    },
-    "celltype_HCA_broad": {
-     "author_field_name": "celltype_HCA_broad",
-     "values": [
-      {
-       "author_value": "Mesen_Theca",
-       "cell_count": 56270,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Follicle",
@@ -234276,6 +227742,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Cortex_outer",
@@ -234326,6 +227793,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "unknown",
@@ -234346,6 +227814,7 @@
     },
     "Developmental_stage": {
      "author_field_name": "Developmental_stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Adult",
@@ -234371,6 +227840,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "31",
@@ -234521,6 +227991,7 @@
     },
     "Tanner Stage": {
      "author_field_name": "Tanner Stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Pubic V/Genitals-Breast V",
@@ -234556,6 +228027,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Unknown",
@@ -234581,6 +228053,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "Stroke",
@@ -234731,6 +228204,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Stroke",
@@ -235075,38 +228549,9 @@
    "parent_cell_set_accession": "HCArepro:L1:0000",
    "n_cells": 11245,
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Epi_Uterocervical_Fetal",
-       "cell_count": 7640,
-       "cell_ratio": 0.6794
-      },
-      {
-       "author_value": "Epi_Mullerian_Undiff",
-       "cell_count": 3605,
-       "cell_ratio": 0.3206
-      }
-     ]
-    },
-    "celltype_HCA_broad": {
-     "author_field_name": "celltype_HCA_broad",
-     "values": [
-      {
-       "author_value": "Epi_Uterocervical",
-       "cell_count": 7640,
-       "cell_ratio": 0.6794
-      },
-      {
-       "author_value": "Epi_Mullerian",
-       "cell_count": 3605,
-       "cell_ratio": 0.3206
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Reproductive tract",
@@ -235127,6 +228572,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "uterus, cervix, vagina",
@@ -235217,6 +228663,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "uterus, cervix, vagina",
@@ -235307,6 +228754,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -235327,6 +228775,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "18",
@@ -235706,48 +229155,9 @@
    ],
    "comment": "Marker origin: media-4 broad code 'Mesen_vSMCs' (supertype-level).",
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Mesen_vSMCs_medArt",
-       "cell_count": 51141,
-       "cell_ratio": 0.6029
-      },
-      {
-       "author_value": "Mesen_vSMCs_largeArt",
-       "cell_count": 33678,
-       "cell_ratio": 0.3971
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Mesen_vSMCs_medArt",
-       "cell_count": 51141,
-       "cell_ratio": 0.6029
-      },
-      {
-       "author_value": "Mesen_vSMCs_largeArt",
-       "cell_count": 33678,
-       "cell_ratio": 0.3971
-      }
-     ]
-    },
-    "celltype_HCA_broad": {
-     "author_field_name": "celltype_HCA_broad",
-     "values": [
-      {
-       "author_value": "Mesen_vSMCs",
-       "cell_count": 84819,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Ovary",
@@ -235778,6 +229188,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Ovarian Cortex",
@@ -235853,6 +229264,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Cortex_outer",
@@ -235953,6 +229365,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -235973,6 +229386,7 @@
     },
     "Developmental_stage": {
      "author_field_name": "Developmental_stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Adult",
@@ -235998,6 +229412,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "28",
@@ -236293,6 +229708,7 @@
     },
     "Tanner Stage": {
      "author_field_name": "Tanner Stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Pubic V/Genitals-Breast V",
@@ -236328,6 +229744,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Unknown",
@@ -236428,6 +229845,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "control",
@@ -236608,6 +230026,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -236823,6 +230242,7 @@
     },
     "Observed_pathology": {
      "author_field_name": "Observed_pathology",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -236858,6 +230278,7 @@
     },
     "Sampled_site_condition": {
      "author_field_name": "Sampled_site_condition",
+     "category": "disease",
      "values": [
       {
        "author_value": "normal",
@@ -237228,68 +230649,9 @@
    ],
    "comment": "Marker origin: media-4 broad code 'Endo_ven' (supertype-level).",
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Endo_ven_tpcv",
-       "cell_count": 16892,
-       "cell_ratio": 0.3583
-      },
-      {
-       "author_value": "Endo_ven_pcv",
-       "cell_count": 13904,
-       "cell_ratio": 0.2949
-      },
-      {
-       "author_value": "Endo_ven_hev",
-       "cell_count": 11495,
-       "cell_ratio": 0.2438
-      },
-      {
-       "author_value": "Endo_ven_apcv",
-       "cell_count": 4851,
-       "cell_ratio": 0.1029
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Endo_ven_tpcv",
-       "cell_count": 16892,
-       "cell_ratio": 0.3583
-      },
-      {
-       "author_value": "Endo_ven_pcv",
-       "cell_count": 13904,
-       "cell_ratio": 0.2949
-      },
-      {
-       "author_value": "Endo_ven_hev",
-       "cell_count": 11495,
-       "cell_ratio": 0.2438
-      },
-      {
-       "author_value": "Endo_ven_apcv",
-       "cell_count": 4851,
-       "cell_ratio": 0.1029
-      }
-     ]
-    },
-    "celltype_HCA_broad": {
-     "author_field_name": "celltype_HCA_broad",
-     "values": [
-      {
-       "author_value": "Endo_ven",
-       "cell_count": 47142,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Uterus",
@@ -237330,6 +230692,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Endometrium",
@@ -237480,6 +230843,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Endometrium",
@@ -237655,6 +231019,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -237685,6 +231050,7 @@
     },
     "Developmental_stage": {
      "author_field_name": "Developmental_stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Adult",
@@ -237715,6 +231081,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "30",
@@ -238015,6 +231382,7 @@
     },
     "Tanner Stage": {
      "author_field_name": "Tanner Stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Pubic V/Genitals-Breast V",
@@ -238055,6 +231423,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -238170,6 +231539,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Postmenopausal",
@@ -238285,6 +231655,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "control",
@@ -238475,6 +231846,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -238700,6 +232072,7 @@
     },
     "Observed_pathology": {
      "author_field_name": "Observed_pathology",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -238740,6 +232113,7 @@
     },
     "Sampled_site_condition": {
      "author_field_name": "Sampled_site_condition",
+     "category": "disease",
      "values": [
       {
        "author_value": "normal",
@@ -239077,168 +232451,9 @@
    ],
    "comment": "Object data-quality artifact: the h5ad carries two celltype_HCA_fine labels for the same cell type — 'Endo_cap_APCDD1' and 'Endo_cap_APCDD1+' (trailing '+'). Merged here to one leaf via label normalisation; flag to authors. | Marker origin: media-4 broad code 'Endo' (supertype-level).",
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Endo_cap",
-       "cell_count": 21199,
-       "cell_ratio": 0.1991
-      },
-      {
-       "author_value": "Endo_ven_tpcv",
-       "cell_count": 16892,
-       "cell_ratio": 0.1586
-      },
-      {
-       "author_value": "Endo_ven_pcv",
-       "cell_count": 13904,
-       "cell_ratio": 0.1306
-      },
-      {
-       "author_value": "Endo_ven_hev",
-       "cell_count": 11495,
-       "cell_ratio": 0.108
-      },
-      {
-       "author_value": "Endo_artery",
-       "cell_count": 11267,
-       "cell_ratio": 0.1058
-      },
-      {
-       "author_value": "Endo_lymp",
-       "cell_count": 10375,
-       "cell_ratio": 0.0974
-      },
-      {
-       "author_value": "Endo_cap_cycl",
-       "cell_count": 5081,
-       "cell_ratio": 0.0477
-      },
-      {
-       "author_value": "Endo_ven_apcv",
-       "cell_count": 4851,
-       "cell_ratio": 0.0456
-      },
-      {
-       "author_value": "Endo_cap_APCDD1",
-       "cell_count": 4691,
-       "cell_ratio": 0.0441
-      },
-      {
-       "author_value": "Endo_cap_tip",
-       "cell_count": 3614,
-       "cell_ratio": 0.0339
-      },
-      {
-       "author_value": "Endo_cap_APCDD1+",
-       "cell_count": 2567,
-       "cell_ratio": 0.0241
-      },
-      {
-       "author_value": "Endo_cap_kidney",
-       "cell_count": 548,
-       "cell_ratio": 0.0051
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Endo_cap",
-       "cell_count": 21199,
-       "cell_ratio": 0.1991
-      },
-      {
-       "author_value": "Endo_ven_tpcv",
-       "cell_count": 16892,
-       "cell_ratio": 0.1586
-      },
-      {
-       "author_value": "Endo_ven_pcv",
-       "cell_count": 13904,
-       "cell_ratio": 0.1306
-      },
-      {
-       "author_value": "Endo_ven_hev",
-       "cell_count": 11495,
-       "cell_ratio": 0.108
-      },
-      {
-       "author_value": "Endo_artery",
-       "cell_count": 11267,
-       "cell_ratio": 0.1058
-      },
-      {
-       "author_value": "Endo_lymp",
-       "cell_count": 10375,
-       "cell_ratio": 0.0974
-      },
-      {
-       "author_value": "Endo_cap_cycl",
-       "cell_count": 5081,
-       "cell_ratio": 0.0477
-      },
-      {
-       "author_value": "Endo_ven_apcv",
-       "cell_count": 4851,
-       "cell_ratio": 0.0456
-      },
-      {
-       "author_value": "Endo_cap_APCDD1",
-       "cell_count": 4691,
-       "cell_ratio": 0.0441
-      },
-      {
-       "author_value": "Endo_cap_tip",
-       "cell_count": 3614,
-       "cell_ratio": 0.0339
-      },
-      {
-       "author_value": "unknown",
-       "cell_count": 3115,
-       "cell_ratio": 0.0293
-      }
-     ]
-    },
-    "celltype_HCA_broad": {
-     "author_field_name": "celltype_HCA_broad",
-     "values": [
-      {
-       "author_value": "Endo_ven",
-       "cell_count": 47142,
-       "cell_ratio": 0.4427
-      },
-      {
-       "author_value": "Endo_cap",
-       "cell_count": 37700,
-       "cell_ratio": 0.354
-      },
-      {
-       "author_value": "Endo_artery",
-       "cell_count": 11267,
-       "cell_ratio": 0.1058
-      },
-      {
-       "author_value": "Endo_lymp",
-       "cell_count": 10375,
-       "cell_ratio": 0.0974
-      }
-     ]
-    },
-    "celltype_HCA_lineage": {
-     "author_field_name": "celltype_HCA_lineage",
-     "values": [
-      {
-       "author_value": "endothelial",
-       "cell_count": 106484,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Uterus",
@@ -239279,6 +232494,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Endometrium",
@@ -239429,6 +232645,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Endometrium",
@@ -239609,6 +232826,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -239639,6 +232857,7 @@
     },
     "Developmental_stage": {
      "author_field_name": "Developmental_stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Adult",
@@ -239669,6 +232888,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -239974,6 +233194,7 @@
     },
     "Tanner Stage": {
      "author_field_name": "Tanner Stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Pubic V/Genitals-Breast V",
@@ -240014,6 +233235,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -240159,6 +233381,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Postmenopausal",
@@ -240274,6 +233497,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "control",
@@ -240469,6 +233693,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -240699,6 +233924,7 @@
     },
     "Observed_pathology": {
      "author_field_name": "Observed_pathology",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -240739,6 +233965,7 @@
     },
     "Sampled_site_condition": {
      "author_field_name": "Sampled_site_condition",
+     "category": "disease",
      "values": [
       {
        "author_value": "normal",
@@ -241168,518 +234395,9 @@
    "parent_cell_set_accession": null,
    "n_cells": 256697,
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Epi_EndoGlandFun_mSec",
-       "cell_count": 25233,
-       "cell_ratio": 0.0983
-      },
-      {
-       "author_value": "Epi_EndoGlandFun_Prof",
-       "cell_count": 23099,
-       "cell_ratio": 0.09
-      },
-      {
-       "author_value": "Epi_EndoGlandFun_emSec",
-       "cell_count": 18366,
-       "cell_ratio": 0.0715
-      },
-      {
-       "author_value": "Epi_EndoGland_nEMC",
-       "cell_count": 18196,
-       "cell_ratio": 0.0709
-      },
-      {
-       "author_value": "Epi_FallopianSec_OVGP1hi_EstrInd",
-       "cell_count": 17601,
-       "cell_ratio": 0.0686
-      },
-      {
-       "author_value": "Epi_FallopianSec_OVGP1lo",
-       "cell_count": 13587,
-       "cell_ratio": 0.0529
-      },
-      {
-       "author_value": "Epi_FallopianCil_Diff",
-       "cell_count": 12869,
-       "cell_ratio": 0.0501
-      },
-      {
-       "author_value": "Epi_EndoGlandFun_Prof_Cyc",
-       "cell_count": 12815,
-       "cell_ratio": 0.0499
-      },
-      {
-       "author_value": "Epi_FallopianSec_Fetal",
-       "cell_count": 12310,
-       "cell_ratio": 0.048
-      },
-      {
-       "author_value": "Epi_EndoGlandLum_mSec",
-       "cell_count": 12046,
-       "cell_ratio": 0.0469
-      },
-      {
-       "author_value": "Epi_EndoGlandFun_lProf",
-       "cell_count": 11900,
-       "cell_ratio": 0.0464
-      },
-      {
-       "author_value": "Epi_EndoGlandLum_Prof",
-       "cell_count": 9672,
-       "cell_ratio": 0.0377
-      },
-      {
-       "author_value": "Epi_EndoCil_Diff",
-       "cell_count": 8903,
-       "cell_ratio": 0.0347
-      },
-      {
-       "author_value": "Epi_Uterocervical_Fetal",
-       "cell_count": 7640,
-       "cell_ratio": 0.0298
-      },
-      {
-       "author_value": "Epi_MesonephricTub_Fetal",
-       "cell_count": 7359,
-       "cell_ratio": 0.0287
-      },
-      {
-       "author_value": "Epi_Vagina_Lower_Fetal",
-       "cell_count": 6047,
-       "cell_ratio": 0.0236
-      },
-      {
-       "author_value": "Epi_reteOvarii_Fetal_Undiff",
-       "cell_count": 5796,
-       "cell_ratio": 0.0226
-      },
-      {
-       "author_value": "Epi_EndoGlandFun_Menstr",
-       "cell_count": 4248,
-       "cell_ratio": 0.0165
-      },
-      {
-       "author_value": "Epi_Mullerian_Undiff",
-       "cell_count": 3605,
-       "cell_ratio": 0.014
-      },
-      {
-       "author_value": "Epi_UGS_Undiff",
-       "cell_count": 3302,
-       "cell_ratio": 0.0129
-      },
-      {
-       "author_value": "Epi_EndoMucinous",
-       "cell_count": 2110,
-       "cell_ratio": 0.0082
-      },
-      {
-       "author_value": "Epi_PrepuceSquamous_Fetal",
-       "cell_count": 2097,
-       "cell_ratio": 0.0082
-      },
-      {
-       "author_value": "Epi_EndoCil_Cyc",
-       "cell_count": 1975,
-       "cell_ratio": 0.0077
-      },
-      {
-       "author_value": "Epi_EndoGlandBas_WIF1",
-       "cell_count": 1694,
-       "cell_ratio": 0.0066
-      },
-      {
-       "author_value": "Epi_UrethralSquamous_Fetal",
-       "cell_count": 1649,
-       "cell_ratio": 0.0064
-      },
-      {
-       "author_value": "Epi_GenitalSurf_Fetal",
-       "cell_count": 1482,
-       "cell_ratio": 0.0058
-      },
-      {
-       "author_value": "Epi_EndoGlandFun_lSec",
-       "cell_count": 1467,
-       "cell_ratio": 0.0057
-      },
-      {
-       "author_value": "Epi_CervixMucinous",
-       "cell_count": 1156,
-       "cell_ratio": 0.0045
-      },
-      {
-       "author_value": "Epi_CervixSquamous",
-       "cell_count": 1138,
-       "cell_ratio": 0.0044
-      },
-      {
-       "author_value": "Epi_EndoCil_eProf",
-       "cell_count": 1014,
-       "cell_ratio": 0.004
-      },
-      {
-       "author_value": "Epi_Vagina_Upper_Fetal",
-       "cell_count": 980,
-       "cell_ratio": 0.0038
-      },
-      {
-       "author_value": "Epi_ParatubalIncl_squamous",
-       "cell_count": 922,
-       "cell_ratio": 0.0036
-      },
-      {
-       "author_value": "Epi_EndoGlandBas",
-       "cell_count": 748,
-       "cell_ratio": 0.0029
-      },
-      {
-       "author_value": "Epi_EctocervixVaginaSquamous",
-       "cell_count": 646,
-       "cell_ratio": 0.0025
-      },
-      {
-       "author_value": "Epi_FallopianSec_Cyc",
-       "cell_count": 560,
-       "cell_ratio": 0.0022
-      },
-      {
-       "author_value": "Epi_FallopianCil_Cyc",
-       "cell_count": 547,
-       "cell_ratio": 0.0021
-      },
-      {
-       "author_value": "Epi_FallopianCil_Fetal",
-       "cell_count": 516,
-       "cell_ratio": 0.002
-      },
-      {
-       "author_value": "Epi_FallopianCil_Early",
-       "cell_count": 460,
-       "cell_ratio": 0.0018
-      },
-      {
-       "author_value": "Epi_CervixSquamous_Cyc",
-       "cell_count": 409,
-       "cell_ratio": 0.0016
-      },
-      {
-       "author_value": "Epi_CervixMucinous_Secretory",
-       "cell_count": 287,
-       "cell_ratio": 0.0011
-      },
-      {
-       "author_value": "Epi_OvarianInclSec",
-       "cell_count": 202,
-       "cell_ratio": 0.0008
-      },
-      {
-       "author_value": "Epi_EndoGlandLum_eSec",
-       "cell_count": 24,
-       "cell_ratio": 0.0001
-      },
-      {
-       "author_value": "Epi_OvarianInclCil",
-       "cell_count": 20,
-       "cell_ratio": 0.0001
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "unknown",
-       "cell_count": 70384,
-       "cell_ratio": 0.2742
-      },
-      {
-       "author_value": "Epi_EndoGlandFun_mSec",
-       "cell_count": 25233,
-       "cell_ratio": 0.0983
-      },
-      {
-       "author_value": "Epi_EndoGlandFun_Prof",
-       "cell_count": 23099,
-       "cell_ratio": 0.09
-      },
-      {
-       "author_value": "Epi_EndoGlandFun_emSec",
-       "cell_count": 18366,
-       "cell_ratio": 0.0715
-      },
-      {
-       "author_value": "Epi_EndoGland_nEMC",
-       "cell_count": 18196,
-       "cell_ratio": 0.0709
-      },
-      {
-       "author_value": "Epi_FallopianSec_OVGP1lo",
-       "cell_count": 13587,
-       "cell_ratio": 0.0529
-      },
-      {
-       "author_value": "Epi_FallopianCil_Diff",
-       "cell_count": 12869,
-       "cell_ratio": 0.0501
-      },
-      {
-       "author_value": "Epi_EndoGlandFun_Prof_Cyc",
-       "cell_count": 12815,
-       "cell_ratio": 0.0499
-      },
-      {
-       "author_value": "Epi_EndoGlandLum_mSec",
-       "cell_count": 12046,
-       "cell_ratio": 0.0469
-      },
-      {
-       "author_value": "Epi_EndoGlandFun_lProf",
-       "cell_count": 11900,
-       "cell_ratio": 0.0464
-      },
-      {
-       "author_value": "Epi_EndoGlandLum_Prof",
-       "cell_count": 9672,
-       "cell_ratio": 0.0377
-      },
-      {
-       "author_value": "Epi_EndoCil_Diff",
-       "cell_count": 8903,
-       "cell_ratio": 0.0347
-      },
-      {
-       "author_value": "Epi_EndoGlandFun_Menstr",
-       "cell_count": 4248,
-       "cell_ratio": 0.0165
-      },
-      {
-       "author_value": "Epi_EndoMucinous",
-       "cell_count": 2110,
-       "cell_ratio": 0.0082
-      },
-      {
-       "author_value": "Epi_EndoCil_Cyc",
-       "cell_count": 1975,
-       "cell_ratio": 0.0077
-      },
-      {
-       "author_value": "Epi_EndoGlandBas_WIF1",
-       "cell_count": 1694,
-       "cell_ratio": 0.0066
-      },
-      {
-       "author_value": "Epi_EndoGlandFun_lSec",
-       "cell_count": 1467,
-       "cell_ratio": 0.0057
-      },
-      {
-       "author_value": "Epi_CervixMucinous",
-       "cell_count": 1156,
-       "cell_ratio": 0.0045
-      },
-      {
-       "author_value": "Epi_CervixSquamous",
-       "cell_count": 1138,
-       "cell_ratio": 0.0044
-      },
-      {
-       "author_value": "Epi_EndoCil_eProf",
-       "cell_count": 1014,
-       "cell_ratio": 0.004
-      },
-      {
-       "author_value": "Epi_ParatubalIncl_squamous",
-       "cell_count": 922,
-       "cell_ratio": 0.0036
-      },
-      {
-       "author_value": "Epi_EndoGlandBas",
-       "cell_count": 748,
-       "cell_ratio": 0.0029
-      },
-      {
-       "author_value": "Epi_EctocervixVaginaSquamous",
-       "cell_count": 646,
-       "cell_ratio": 0.0025
-      },
-      {
-       "author_value": "Epi_FallopianSec_Cyc",
-       "cell_count": 560,
-       "cell_ratio": 0.0022
-      },
-      {
-       "author_value": "Epi_FallopianCil_Cyc",
-       "cell_count": 547,
-       "cell_ratio": 0.0021
-      },
-      {
-       "author_value": "Epi_FallopianCil_Early",
-       "cell_count": 460,
-       "cell_ratio": 0.0018
-      },
-      {
-       "author_value": "Epi_CervixSquamous_Cyc",
-       "cell_count": 409,
-       "cell_ratio": 0.0016
-      },
-      {
-       "author_value": "Epi_CervixMucinous_Secretory",
-       "cell_count": 287,
-       "cell_ratio": 0.0011
-      },
-      {
-       "author_value": "Epi_OvarianInclSec",
-       "cell_count": 202,
-       "cell_ratio": 0.0008
-      },
-      {
-       "author_value": "Epi_EndoGlandLum_eSec",
-       "cell_count": 24,
-       "cell_ratio": 0.0001
-      },
-      {
-       "author_value": "Epi_OvarianInclCil",
-       "cell_count": 20,
-       "cell_ratio": 0.0001
-      }
-     ]
-    },
-    "celltype_HCA_broad": {
-     "author_field_name": "celltype_HCA_broad",
-     "values": [
-      {
-       "author_value": "Epi_EndoGlandFun",
-       "cell_count": 97128,
-       "cell_ratio": 0.3784
-      },
-      {
-       "author_value": "Epi_FallopianSec",
-       "cell_count": 44058,
-       "cell_ratio": 0.1716
-      },
-      {
-       "author_value": "Epi_EndoGlandLum",
-       "cell_count": 21742,
-       "cell_ratio": 0.0847
-      },
-      {
-       "author_value": "Epi_EndoGland",
-       "cell_count": 18196,
-       "cell_ratio": 0.0709
-      },
-      {
-       "author_value": "Epi_FallopianCil",
-       "cell_count": 14392,
-       "cell_ratio": 0.0561
-      },
-      {
-       "author_value": "Epi_EndoCil",
-       "cell_count": 11892,
-       "cell_ratio": 0.0463
-      },
-      {
-       "author_value": "Epi_Uterocervical",
-       "cell_count": 7640,
-       "cell_ratio": 0.0298
-      },
-      {
-       "author_value": "Epi_MesonephricTub",
-       "cell_count": 7359,
-       "cell_ratio": 0.0287
-      },
-      {
-       "author_value": "Epi_Vagina",
-       "cell_count": 7027,
-       "cell_ratio": 0.0274
-      },
-      {
-       "author_value": "Epi_reteOvarii",
-       "cell_count": 5796,
-       "cell_ratio": 0.0226
-      },
-      {
-       "author_value": "Epi_Mullerian",
-       "cell_count": 3605,
-       "cell_ratio": 0.014
-      },
-      {
-       "author_value": "Epi_UGS",
-       "cell_count": 3302,
-       "cell_ratio": 0.0129
-      },
-      {
-       "author_value": "Epi_EndoGlandBas",
-       "cell_count": 2442,
-       "cell_ratio": 0.0095
-      },
-      {
-       "author_value": "Epi_EndoMucinous",
-       "cell_count": 2110,
-       "cell_ratio": 0.0082
-      },
-      {
-       "author_value": "Epi_PrepuceSquamous",
-       "cell_count": 2097,
-       "cell_ratio": 0.0082
-      },
-      {
-       "author_value": "Epi_UrethralSquamous",
-       "cell_count": 1649,
-       "cell_ratio": 0.0064
-      },
-      {
-       "author_value": "Epi_CervixSquamous",
-       "cell_count": 1547,
-       "cell_ratio": 0.006
-      },
-      {
-       "author_value": "Epi_GenitalSurf",
-       "cell_count": 1482,
-       "cell_ratio": 0.0058
-      },
-      {
-       "author_value": "Epi_CervixMucinous",
-       "cell_count": 1443,
-       "cell_ratio": 0.0056
-      },
-      {
-       "author_value": "Epi_ParatubalIncl",
-       "cell_count": 922,
-       "cell_ratio": 0.0036
-      },
-      {
-       "author_value": "Epi_EctocervixVaginaSquamous",
-       "cell_count": 646,
-       "cell_ratio": 0.0025
-      },
-      {
-       "author_value": "Epi_OvarianInclSec",
-       "cell_count": 202,
-       "cell_ratio": 0.0008
-      },
-      {
-       "author_value": "Epi_OvarianInclCil",
-       "cell_count": 20,
-       "cell_ratio": 0.0001
-      }
-     ]
-    },
-    "celltype_HCA_lineage": {
-     "author_field_name": "celltype_HCA_lineage",
-     "values": [
-      {
-       "author_value": "epithelial",
-       "cell_count": 256697,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Uterus",
@@ -241720,6 +234438,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Endometrium",
@@ -241870,6 +234589,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Superficial_Endometrium",
@@ -242045,6 +234765,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -242070,6 +234791,7 @@
     },
     "Developmental_stage": {
      "author_field_name": "Developmental_stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Adult",
@@ -242090,6 +234812,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -242305,6 +235028,7 @@
     },
     "Tanner Stage": {
      "author_field_name": "Tanner Stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Pubic V/Genitals-Breast V",
@@ -242325,6 +235049,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -242475,6 +235200,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -242585,6 +235311,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "control",
@@ -242660,6 +235387,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -242770,6 +235498,7 @@
     },
     "Observed_pathology": {
      "author_field_name": "Observed_pathology",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -242810,6 +235539,7 @@
     },
     "Sampled_site_condition": {
      "author_field_name": "Sampled_site_condition",
+     "category": "disease",
      "values": [
       {
        "author_value": "normal",
@@ -244023,88 +236753,9 @@
    ],
    "comment": "Marker origin: media-4 broad code 'Germcell' (supertype-level).",
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Germcell_PGCs",
-       "cell_count": 6862,
-       "cell_ratio": 0.3983
-      },
-      {
-       "author_value": "Germcell_Oogonia_premeiotic",
-       "cell_count": 3142,
-       "cell_ratio": 0.1824
-      },
-      {
-       "author_value": "Germcell_PGC_Cyc",
-       "cell_count": 2592,
-       "cell_ratio": 0.1504
-      },
-      {
-       "author_value": "Germcell_GGCs",
-       "cell_count": 1861,
-       "cell_ratio": 0.108
-      },
-      {
-       "author_value": "Germcell_Oogonia_meiotic",
-       "cell_count": 1622,
-       "cell_ratio": 0.0941
-      },
-      {
-       "author_value": "Germcell_PrimaryOocyte_ZP4neg",
-       "cell_count": 760,
-       "cell_ratio": 0.0441
-      },
-      {
-       "author_value": "Germcell_PrimaryOocyte_ZP4pos",
-       "cell_count": 391,
-       "cell_ratio": 0.0227
-      }
-     ]
-    },
-    "celltype_HCA_broad": {
-     "author_field_name": "celltype_HCA_broad",
-     "values": [
-      {
-       "author_value": "Germcell_PGCs",
-       "cell_count": 6862,
-       "cell_ratio": 0.3983
-      },
-      {
-       "author_value": "Germcell_Oogonia",
-       "cell_count": 4764,
-       "cell_ratio": 0.2765
-      },
-      {
-       "author_value": "Germcell_PGC",
-       "cell_count": 2592,
-       "cell_ratio": 0.1504
-      },
-      {
-       "author_value": "Germcell_GGCs",
-       "cell_count": 1861,
-       "cell_ratio": 0.108
-      },
-      {
-       "author_value": "Germcell_PrimaryOocyte",
-       "cell_count": 1151,
-       "cell_ratio": 0.0668
-      }
-     ]
-    },
-    "celltype_HCA_lineage": {
-     "author_field_name": "celltype_HCA_lineage",
-     "values": [
-      {
-       "author_value": "germ_cell",
-       "cell_count": 17230,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Ovary",
@@ -244120,6 +236771,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Gonad_and_extragonadal",
@@ -244175,6 +236827,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Gonad_and_extragonadal",
@@ -244235,6 +236888,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -244265,6 +236919,7 @@
     },
     "Developmental_stage": {
      "author_field_name": "Developmental_stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Fetal",
@@ -244290,6 +236945,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -244385,6 +237041,7 @@
     },
     "Tanner Stage": {
      "author_field_name": "Tanner Stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -244420,6 +237077,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "17",
@@ -244545,6 +237203,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -244565,6 +237224,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "control",
@@ -244645,6 +237305,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -244855,48 +237516,9 @@
    "parent_cell_set_accession": null,
    "n_cells": 48285,
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Gonadal_preGranulosa-CEderived",
-       "cell_count": 23076,
-       "cell_ratio": 0.4779
-      },
-      {
-       "author_value": "Gonadal_SupportingUndiff",
-       "cell_count": 16769,
-       "cell_ratio": 0.3473
-      },
-      {
-       "author_value": "Gonadal_SomaticPrec",
-       "cell_count": 8440,
-       "cell_ratio": 0.1748
-      }
-     ]
-    },
-    "celltype_HCA_broad": {
-     "author_field_name": "celltype_HCA_broad",
-     "values": [
-      {
-       "author_value": "Gonadal_preGranulosa-CEderived",
-       "cell_count": 23076,
-       "cell_ratio": 0.4779
-      },
-      {
-       "author_value": "Gonadal_SupportingUndiff",
-       "cell_count": 16769,
-       "cell_ratio": 0.3473
-      },
-      {
-       "author_value": "Gonadal_SomaticPrec",
-       "cell_count": 8440,
-       "cell_ratio": 0.1748
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Ovary",
@@ -244917,6 +237539,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Gonad",
@@ -244967,6 +237590,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Gonad",
@@ -245017,6 +237641,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -245037,6 +237662,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -245052,6 +237678,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "6",
@@ -245640,638 +238267,9 @@
    "parent_cell_set_accession": null,
    "n_cells": 220867,
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Immune_CD8_T_RM_GZMKhi",
-       "cell_count": 25502,
-       "cell_ratio": 0.1155
-      },
-      {
-       "author_value": "Immune_uMac_Inf",
-       "cell_count": 23069,
-       "cell_ratio": 0.1044
-      },
-      {
-       "author_value": "Immune_Mac_LYVE1hi",
-       "cell_count": 16783,
-       "cell_ratio": 0.076
-      },
-      {
-       "author_value": "Immune_CD8_T_RM",
-       "cell_count": 15131,
-       "cell_ratio": 0.0685
-      },
-      {
-       "author_value": "Immune_MO_Classical",
-       "cell_count": 13759,
-       "cell_ratio": 0.0623
-      },
-      {
-       "author_value": "Immune_CD4_T_Unpolarised",
-       "cell_count": 13177,
-       "cell_ratio": 0.0597
-      },
-      {
-       "author_value": "Immune_uNK2",
-       "cell_count": 12245,
-       "cell_ratio": 0.0554
-      },
-      {
-       "author_value": "Immune_uNK3",
-       "cell_count": 10688,
-       "cell_ratio": 0.0484
-      },
-      {
-       "author_value": "Immune_CD4_Th17",
-       "cell_count": 6802,
-       "cell_ratio": 0.0308
-      },
-      {
-       "author_value": "Immune_CD4_NaiveT",
-       "cell_count": 6169,
-       "cell_ratio": 0.0279
-      },
-      {
-       "author_value": "Immune_Mast",
-       "cell_count": 5449,
-       "cell_ratio": 0.0247
-      },
-      {
-       "author_value": "Immune_NK_CD16hi",
-       "cell_count": 5175,
-       "cell_ratio": 0.0234
-      },
-      {
-       "author_value": "Immune_CD4_Th17_SCMlike",
-       "cell_count": 5130,
-       "cell_ratio": 0.0232
-      },
-      {
-       "author_value": "Immune_MemoryB",
-       "cell_count": 4542,
-       "cell_ratio": 0.0206
-      },
-      {
-       "author_value": "Immune_CD8_T_EM",
-       "cell_count": 4022,
-       "cell_ratio": 0.0182
-      },
-      {
-       "author_value": "Immune_MAIT",
-       "cell_count": 3733,
-       "cell_ratio": 0.0169
-      },
-      {
-       "author_value": "Immune_CD4_Treg",
-       "cell_count": 3695,
-       "cell_ratio": 0.0167
-      },
-      {
-       "author_value": "Immune_uNK1",
-       "cell_count": 3543,
-       "cell_ratio": 0.016
-      },
-      {
-       "author_value": "Immune_NK_Cyc",
-       "cell_count": 3503,
-       "cell_ratio": 0.0159
-      },
-      {
-       "author_value": "Immune_cDC2",
-       "cell_count": 3457,
-       "cell_ratio": 0.0157
-      },
-      {
-       "author_value": "Immune_NKT_γδT_Vδ1",
-       "cell_count": 2836,
-       "cell_ratio": 0.0128
-      },
-      {
-       "author_value": "Immune_uftLAM",
-       "cell_count": 2760,
-       "cell_ratio": 0.0125
-      },
-      {
-       "author_value": "Immune_Mac_Cyc",
-       "cell_count": 2560,
-       "cell_ratio": 0.0116
-      },
-      {
-       "author_value": "Immune_CD8_NaiveT",
-       "cell_count": 2551,
-       "cell_ratio": 0.0115
-      },
-      {
-       "author_value": "Immune_ILC3_NCRhi",
-       "cell_count": 2517,
-       "cell_ratio": 0.0114
-      },
-      {
-       "author_value": "Immune_Plasma_κ",
-       "cell_count": 2314,
-       "cell_ratio": 0.0105
-      },
-      {
-       "author_value": "Immune_T_Cyc",
-       "cell_count": 2208,
-       "cell_ratio": 0.01
-      },
-      {
-       "author_value": "Immune_MO_NonClassical",
-       "cell_count": 2122,
-       "cell_ratio": 0.0096
-      },
-      {
-       "author_value": "Immune_NaiveB",
-       "cell_count": 2076,
-       "cell_ratio": 0.0094
-      },
-      {
-       "author_value": "Immune_Mac_Transitional",
-       "cell_count": 1787,
-       "cell_ratio": 0.0081
-      },
-      {
-       "author_value": "Immune_Plasma_λ",
-       "cell_count": 1782,
-       "cell_ratio": 0.0081
-      },
-      {
-       "author_value": "Immune_mregDC",
-       "cell_count": 1577,
-       "cell_ratio": 0.0071
-      },
-      {
-       "author_value": "Immune_cDC2_CD207hi",
-       "cell_count": 1533,
-       "cell_ratio": 0.0069
-      },
-      {
-       "author_value": "Immune_pDC",
-       "cell_count": 1203,
-       "cell_ratio": 0.0054
-      },
-      {
-       "author_value": "Immune_cDC1",
-       "cell_count": 1073,
-       "cell_ratio": 0.0049
-      },
-      {
-       "author_value": "Immune_γδT_Vγ9Vδ2",
-       "cell_count": 781,
-       "cell_ratio": 0.0035
-      },
-      {
-       "author_value": "Immune_NK_CD56dim_CD16dim_SPTSSBhi",
-       "cell_count": 480,
-       "cell_ratio": 0.0022
-      },
-      {
-       "author_value": "Immune_ImmatureB",
-       "cell_count": 387,
-       "cell_ratio": 0.0018
-      },
-      {
-       "author_value": "Immune_ILC3_NCRlo",
-       "cell_count": 321,
-       "cell_ratio": 0.0015
-      },
-      {
-       "author_value": "Immune_oLAM",
-       "cell_count": 321,
-       "cell_ratio": 0.0015
-      },
-      {
-       "author_value": "Immune_LargePreB",
-       "cell_count": 305,
-       "cell_ratio": 0.0014
-      },
-      {
-       "author_value": "Immune_NMP_Promyelocytes",
-       "cell_count": 286,
-       "cell_ratio": 0.0013
-      },
-      {
-       "author_value": "Immune_SmallPreB",
-       "cell_count": 281,
-       "cell_ratio": 0.0013
-      },
-      {
-       "author_value": "Immune_MEMP",
-       "cell_count": 250,
-       "cell_ratio": 0.0011
-      },
-      {
-       "author_value": "Immune_HPC",
-       "cell_count": 211,
-       "cell_ratio": 0.001
-      },
-      {
-       "author_value": "Immune_MegaPlat",
-       "cell_count": 177,
-       "cell_ratio": 0.0008
-      },
-      {
-       "author_value": "Immune_ProB",
-       "cell_count": 167,
-       "cell_ratio": 0.0008
-      },
-      {
-       "author_value": "Immune_CD4_Treg_Cyc",
-       "cell_count": 114,
-       "cell_ratio": 0.0005
-      },
-      {
-       "author_value": "Immune_ASDC",
-       "cell_count": 69,
-       "cell_ratio": 0.0003
-      },
-      {
-       "author_value": "Immune_LateErythroid",
-       "cell_count": 57,
-       "cell_ratio": 0.0003
-      },
-      {
-       "author_value": "Immune_EarlyMidErythroid",
-       "cell_count": 55,
-       "cell_ratio": 0.0002
-      },
-      {
-       "author_value": "Immune_tolDC",
-       "cell_count": 47,
-       "cell_ratio": 0.0002
-      },
-      {
-       "author_value": "Immune_Neutrophils",
-       "cell_count": 45,
-       "cell_ratio": 0.0002
-      },
-      {
-       "author_value": "Immune_BasoEosino",
-       "cell_count": 40,
-       "cell_ratio": 0.0002
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Immune_CD8_T_RM_GZMKhi",
-       "cell_count": 25502,
-       "cell_ratio": 0.1155
-      },
-      {
-       "author_value": "Immune_uMac_Inf",
-       "cell_count": 23069,
-       "cell_ratio": 0.1044
-      },
-      {
-       "author_value": "Immune_Mac_LYVE1hi",
-       "cell_count": 16783,
-       "cell_ratio": 0.076
-      },
-      {
-       "author_value": "Immune_CD8_T_RM",
-       "cell_count": 15131,
-       "cell_ratio": 0.0685
-      },
-      {
-       "author_value": "Immune_MO_Classical",
-       "cell_count": 13759,
-       "cell_ratio": 0.0623
-      },
-      {
-       "author_value": "Immune_CD4_T_Unpolarised",
-       "cell_count": 13177,
-       "cell_ratio": 0.0597
-      },
-      {
-       "author_value": "Immune_uNK2",
-       "cell_count": 12245,
-       "cell_ratio": 0.0554
-      },
-      {
-       "author_value": "Immune_uNK3",
-       "cell_count": 10688,
-       "cell_ratio": 0.0484
-      },
-      {
-       "author_value": "Immune_CD4_Th17",
-       "cell_count": 6802,
-       "cell_ratio": 0.0308
-      },
-      {
-       "author_value": "Immune_CD4_NaiveT",
-       "cell_count": 6169,
-       "cell_ratio": 0.0279
-      },
-      {
-       "author_value": "Immune_Mast",
-       "cell_count": 5449,
-       "cell_ratio": 0.0247
-      },
-      {
-       "author_value": "Immune_NK_CD16hi",
-       "cell_count": 5175,
-       "cell_ratio": 0.0234
-      },
-      {
-       "author_value": "Immune_CD4_Th17_SCMlike",
-       "cell_count": 5130,
-       "cell_ratio": 0.0232
-      },
-      {
-       "author_value": "Immune_MemoryB",
-       "cell_count": 4542,
-       "cell_ratio": 0.0206
-      },
-      {
-       "author_value": "Immune_CD8_T_EM",
-       "cell_count": 4022,
-       "cell_ratio": 0.0182
-      },
-      {
-       "author_value": "Immune_MAIT",
-       "cell_count": 3733,
-       "cell_ratio": 0.0169
-      },
-      {
-       "author_value": "Immune_CD4_Treg",
-       "cell_count": 3695,
-       "cell_ratio": 0.0167
-      },
-      {
-       "author_value": "Immune_uNK1",
-       "cell_count": 3543,
-       "cell_ratio": 0.016
-      },
-      {
-       "author_value": "Immune_NK_Cyc",
-       "cell_count": 3503,
-       "cell_ratio": 0.0159
-      },
-      {
-       "author_value": "Immune_cDC2",
-       "cell_count": 3457,
-       "cell_ratio": 0.0157
-      },
-      {
-       "author_value": "Immune_NKT_γδT_Vδ1",
-       "cell_count": 2836,
-       "cell_ratio": 0.0128
-      },
-      {
-       "author_value": "Immune_uftLAM",
-       "cell_count": 2760,
-       "cell_ratio": 0.0125
-      },
-      {
-       "author_value": "Immune_Mac_Cyc",
-       "cell_count": 2560,
-       "cell_ratio": 0.0116
-      },
-      {
-       "author_value": "Immune_CD8_NaiveT",
-       "cell_count": 2551,
-       "cell_ratio": 0.0115
-      },
-      {
-       "author_value": "Immune_ILC3_NCRhi",
-       "cell_count": 2517,
-       "cell_ratio": 0.0114
-      },
-      {
-       "author_value": "Immune_Plasma_κ",
-       "cell_count": 2314,
-       "cell_ratio": 0.0105
-      },
-      {
-       "author_value": "Immune_T_Cyc",
-       "cell_count": 2208,
-       "cell_ratio": 0.01
-      },
-      {
-       "author_value": "Immune_MO_NonClassical",
-       "cell_count": 2122,
-       "cell_ratio": 0.0096
-      },
-      {
-       "author_value": "Immune_NaiveB",
-       "cell_count": 2076,
-       "cell_ratio": 0.0094
-      },
-      {
-       "author_value": "Immune_Mac_Transitional",
-       "cell_count": 1787,
-       "cell_ratio": 0.0081
-      },
-      {
-       "author_value": "Immune_Plasma_λ",
-       "cell_count": 1782,
-       "cell_ratio": 0.0081
-      },
-      {
-       "author_value": "Immune_mregDC",
-       "cell_count": 1577,
-       "cell_ratio": 0.0071
-      },
-      {
-       "author_value": "Immune_cDC2_CD207hi",
-       "cell_count": 1533,
-       "cell_ratio": 0.0069
-      },
-      {
-       "author_value": "Immune_pDC",
-       "cell_count": 1203,
-       "cell_ratio": 0.0054
-      },
-      {
-       "author_value": "Immune_cDC1",
-       "cell_count": 1073,
-       "cell_ratio": 0.0049
-      },
-      {
-       "author_value": "Immune_γδT_Vγ9Vδ2",
-       "cell_count": 781,
-       "cell_ratio": 0.0035
-      },
-      {
-       "author_value": "Immune_NK_CD56dim_CD16dim_SPTSSBhi",
-       "cell_count": 480,
-       "cell_ratio": 0.0022
-      },
-      {
-       "author_value": "Immune_ImmatureB",
-       "cell_count": 387,
-       "cell_ratio": 0.0018
-      },
-      {
-       "author_value": "Immune_ILC3_NCRlo",
-       "cell_count": 321,
-       "cell_ratio": 0.0015
-      },
-      {
-       "author_value": "Immune_oLAM",
-       "cell_count": 321,
-       "cell_ratio": 0.0015
-      },
-      {
-       "author_value": "Immune_LargePreB",
-       "cell_count": 305,
-       "cell_ratio": 0.0014
-      },
-      {
-       "author_value": "Immune_NMP_Promyelocytes",
-       "cell_count": 286,
-       "cell_ratio": 0.0013
-      },
-      {
-       "author_value": "Immune_SmallPreB",
-       "cell_count": 281,
-       "cell_ratio": 0.0013
-      },
-      {
-       "author_value": "Immune_MEMP",
-       "cell_count": 250,
-       "cell_ratio": 0.0011
-      },
-      {
-       "author_value": "Immune_HPC",
-       "cell_count": 211,
-       "cell_ratio": 0.001
-      },
-      {
-       "author_value": "Immune_MegaPlat",
-       "cell_count": 177,
-       "cell_ratio": 0.0008
-      },
-      {
-       "author_value": "Immune_ProB",
-       "cell_count": 167,
-       "cell_ratio": 0.0008
-      },
-      {
-       "author_value": "Immune_CD4_Treg_Cyc",
-       "cell_count": 114,
-       "cell_ratio": 0.0005
-      },
-      {
-       "author_value": "Immune_ASDC",
-       "cell_count": 69,
-       "cell_ratio": 0.0003
-      },
-      {
-       "author_value": "Immune_LateErythroid",
-       "cell_count": 57,
-       "cell_ratio": 0.0003
-      },
-      {
-       "author_value": "Immune_EarlyMidErythroid",
-       "cell_count": 55,
-       "cell_ratio": 0.0002
-      },
-      {
-       "author_value": "Immune_tolDC",
-       "cell_count": 47,
-       "cell_ratio": 0.0002
-      },
-      {
-       "author_value": "Immune_Neutrophils",
-       "cell_count": 45,
-       "cell_ratio": 0.0002
-      },
-      {
-       "author_value": "Immune_BasoEosino",
-       "cell_count": 40,
-       "cell_ratio": 0.0002
-      }
-     ]
-    },
-    "celltype_HCA_broad": {
-     "author_field_name": "celltype_HCA_broad",
-     "values": [
-      {
-       "author_value": "Immune_T_cells",
-       "cell_count": 91851,
-       "cell_ratio": 0.4159
-      },
-      {
-       "author_value": "Immune_Macrophages",
-       "cell_count": 47280,
-       "cell_ratio": 0.2141
-      },
-      {
-       "author_value": "Immune_NK_cells",
-       "cell_count": 35634,
-       "cell_ratio": 0.1613
-      },
-      {
-       "author_value": "Immune_Monocytes",
-       "cell_count": 15881,
-       "cell_ratio": 0.0719
-      },
-      {
-       "author_value": "Immune_B_cells",
-       "cell_count": 11854,
-       "cell_ratio": 0.0537
-      },
-      {
-       "author_value": "Immune_Conventional_DC",
-       "cell_count": 6063,
-       "cell_ratio": 0.0275
-      },
-      {
-       "author_value": "Immune_Granulocytes",
-       "cell_count": 5534,
-       "cell_ratio": 0.0251
-      },
-      {
-       "author_value": "Immune_Non-conventional_DC",
-       "cell_count": 2896,
-       "cell_ratio": 0.0131
-      },
-      {
-       "author_value": "Immune_ILC",
-       "cell_count": 2838,
-       "cell_ratio": 0.0128
-      },
-      {
-       "author_value": "Immune_Myeloid_progenitors",
-       "cell_count": 536,
-       "cell_ratio": 0.0024
-      },
-      {
-       "author_value": "Immune_Haematopoietic_progenitor_cells",
-       "cell_count": 211,
-       "cell_ratio": 0.001
-      },
-      {
-       "author_value": "Immune_Megakaryocytes/platelets",
-       "cell_count": 177,
-       "cell_ratio": 0.0008
-      },
-      {
-       "author_value": "Immune_Erythroid",
-       "cell_count": 112,
-       "cell_ratio": 0.0005
-      }
-     ]
-    },
-    "celltype_HCA_lineage": {
-     "author_field_name": "celltype_HCA_lineage",
-     "values": [
-      {
-       "author_value": "immune",
-       "cell_count": 220867,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Uterus",
@@ -246312,6 +238310,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Endometrium",
@@ -246467,6 +238466,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Endometrium",
@@ -246657,6 +238657,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -246687,6 +238688,7 @@
     },
     "Developmental_stage": {
      "author_field_name": "Developmental_stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Adult",
@@ -246717,6 +238719,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "33",
@@ -247007,6 +239010,7 @@
     },
     "Tanner Stage": {
      "author_field_name": "Tanner Stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Pubic V/Genitals-Breast V",
@@ -247047,6 +239051,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -247197,6 +239202,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Menstrual",
@@ -247282,6 +239288,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "control",
@@ -247492,6 +239499,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -247727,6 +239735,7 @@
     },
     "Observed_pathology": {
      "author_field_name": "Observed_pathology",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -247767,6 +239776,7 @@
     },
     "Sampled_site_condition": {
      "author_field_name": "Sampled_site_condition",
+     "category": "disease",
      "values": [
       {
        "author_value": "normal",
@@ -248300,763 +240310,9 @@
    "parent_cell_set_accession": null,
    "n_cells": 1428376,
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Mesen_EndoStromalFib_Prolif",
-       "cell_count": 164476,
-       "cell_ratio": 0.1151
-      },
-      {
-       "author_value": "Mesen_OvarianFibs_InncorMedulla",
-       "cell_count": 125985,
-       "cell_ratio": 0.0882
-      },
-      {
-       "author_value": "Mesen_EndoStromalFib_mSec",
-       "cell_count": 103861,
-       "cell_ratio": 0.0727
-      },
-      {
-       "author_value": "Mesen_FallopianFibs",
-       "cell_count": 64649,
-       "cell_ratio": 0.0453
-      },
-      {
-       "author_value": "Mesen_vSMCs_medArt",
-       "cell_count": 51141,
-       "cell_ratio": 0.0358
-      },
-      {
-       "author_value": "Mesen_EndoStromalFib_nEMC_Sec",
-       "cell_count": 50283,
-       "cell_ratio": 0.0352
-      },
-      {
-       "author_value": "Mesen_EndoStromalFib_nEMC",
-       "cell_count": 48007,
-       "cell_ratio": 0.0336
-      },
-      {
-       "author_value": "Mesen_OvarianFibs_Perifol",
-       "cell_count": 44411,
-       "cell_ratio": 0.0311
-      },
-      {
-       "author_value": "Mesen_SMCs",
-       "cell_count": 41488,
-       "cell_ratio": 0.029
-      },
-      {
-       "author_value": "Mesen_FallopianFib_Fetal",
-       "cell_count": 41092,
-       "cell_ratio": 0.0288
-      },
-      {
-       "author_value": "Mesen_Pericyte",
-       "cell_count": 38904,
-       "cell_ratio": 0.0272
-      },
-      {
-       "author_value": "Mesen_EndoStromalFib_lSec",
-       "cell_count": 36137,
-       "cell_ratio": 0.0253
-      },
-      {
-       "author_value": "Mesen_AdvFibsIntr",
-       "cell_count": 33795,
-       "cell_ratio": 0.0237
-      },
-      {
-       "author_value": "Mesen_vSMCs_largeArt",
-       "cell_count": 33678,
-       "cell_ratio": 0.0236
-      },
-      {
-       "author_value": "Mesen_EndoStromalFib_Prolif_Cyc",
-       "cell_count": 32491,
-       "cell_ratio": 0.0227
-      },
-      {
-       "author_value": "Mesen_OvarianFibs_Fetal",
-       "cell_count": 32133,
-       "cell_ratio": 0.0225
-      },
-      {
-       "author_value": "Mesen_Theca_Externa",
-       "cell_count": 30089,
-       "cell_ratio": 0.0211
-      },
-      {
-       "author_value": "Mesen_UterusFibs_Fetal",
-       "cell_count": 29462,
-       "cell_ratio": 0.0206
-      },
-      {
-       "author_value": "Mesen_PV_Fetal",
-       "cell_count": 28897,
-       "cell_ratio": 0.0202
-      },
-      {
-       "author_value": "Mesen_MesonephricFibs_Fetal",
-       "cell_count": 28521,
-       "cell_ratio": 0.02
-      },
-      {
-       "author_value": "Mesen_EndoStromalFib_MenstrualFluid",
-       "cell_count": 27092,
-       "cell_ratio": 0.019
-      },
-      {
-       "author_value": "Mesen_GonadalFibs_Undiff",
-       "cell_count": 26055,
-       "cell_ratio": 0.0182
-      },
-      {
-       "author_value": "Mesen_OvarianFibs_Outcor",
-       "cell_count": 21434,
-       "cell_ratio": 0.015
-      },
-      {
-       "author_value": "Mesen_AdvFibs_PI16low",
-       "cell_count": 18360,
-       "cell_ratio": 0.0129
-      },
-      {
-       "author_value": "Mesen_FallopianLig_Fetal",
-       "cell_count": 18265,
-       "cell_ratio": 0.0128
-      },
-      {
-       "author_value": "Mesen_EndoStromalFib_eSec",
-       "cell_count": 17251,
-       "cell_ratio": 0.0121
-      },
-      {
-       "author_value": "Mesen_EpoophronFib_Fetal",
-       "cell_count": 13877,
-       "cell_ratio": 0.0097
-      },
-      {
-       "author_value": "Mesen_OvarianFibs_Medulla_SMCsLike",
-       "cell_count": 13705,
-       "cell_ratio": 0.0096
-      },
-      {
-       "author_value": "Mesen_EndoStromalFib_MenstrualEutopic",
-       "cell_count": 13034,
-       "cell_ratio": 0.0091
-      },
-      {
-       "author_value": "Mesen_EndoStromalFib_nEMC_Cyc",
-       "cell_count": 12895,
-       "cell_ratio": 0.009
-      },
-      {
-       "author_value": "Mesen_UterusLig_Fetal",
-       "cell_count": 12364,
-       "cell_ratio": 0.0087
-      },
-      {
-       "author_value": "Mesen_CervixFib_Fetal",
-       "cell_count": 11916,
-       "cell_ratio": 0.0083
-      },
-      {
-       "author_value": "Mesen_CervixVaginaSMCs_Fetal",
-       "cell_count": 11569,
-       "cell_ratio": 0.0081
-      },
-      {
-       "author_value": "Mesen_UGSFib_Upper",
-       "cell_count": 11402,
-       "cell_ratio": 0.008
-      },
-      {
-       "author_value": "Mesen_Pericyte_EndoStromalLike",
-       "cell_count": 10229,
-       "cell_ratio": 0.0072
-      },
-      {
-       "author_value": "Mesen_CorpusSpongiosumFib_Fetal",
-       "cell_count": 10169,
-       "cell_ratio": 0.0071
-      },
-      {
-       "author_value": "Mesen_CorpusCavernosumFib_Fetal",
-       "cell_count": 9472,
-       "cell_ratio": 0.0066
-      },
-      {
-       "author_value": "Mesen_Theca_Interna_Cyc",
-       "cell_count": 9366,
-       "cell_ratio": 0.0066
-      },
-      {
-       "author_value": "Mesen_Theca_Interna_Steroid",
-       "cell_count": 8428,
-       "cell_ratio": 0.0059
-      },
-      {
-       "author_value": "Mesen_FallopianSMCs_Fetal",
-       "cell_count": 8413,
-       "cell_ratio": 0.0059
-      },
-      {
-       "author_value": "Mesen_Pericyte_SMCsIntr",
-       "cell_count": 8167,
-       "cell_ratio": 0.0057
-      },
-      {
-       "author_value": "Mesen_VaginaFibs_Upper_Fetal",
-       "cell_count": 7925,
-       "cell_ratio": 0.0055
-      },
-      {
-       "author_value": "Mesen_UterusSMCs_Fetal",
-       "cell_count": 7550,
-       "cell_ratio": 0.0053
-      },
-      {
-       "author_value": "Mesen_LabioScrotalSwelling_Fetal",
-       "cell_count": 6830,
-       "cell_ratio": 0.0048
-      },
-      {
-       "author_value": "Mesen_Pericyte_EndoSpiralArt",
-       "cell_count": 6617,
-       "cell_ratio": 0.0046
-      },
-      {
-       "author_value": "Mesen_UGSFib_Lower",
-       "cell_count": 6277,
-       "cell_ratio": 0.0044
-      },
-      {
-       "author_value": "Mesen_GlansFib_Fetal",
-       "cell_count": 5416,
-       "cell_ratio": 0.0038
-      },
-      {
-       "author_value": "Mesen_Theca_Interna_Perifol",
-       "cell_count": 5148,
-       "cell_ratio": 0.0036
-      },
-      {
-       "author_value": "Mesen_Pericyte_Cyc",
-       "cell_count": 4522,
-       "cell_ratio": 0.0032
-      },
-      {
-       "author_value": "Mesen_Theca_Atretic",
-       "cell_count": 3239,
-       "cell_ratio": 0.0023
-      },
-      {
-       "author_value": "Mesen_AdvFibs_PI16hi",
-       "cell_count": 3032,
-       "cell_ratio": 0.0021
-      },
-      {
-       "author_value": "Mesen_EndoStromalFib_Menopause",
-       "cell_count": 2855,
-       "cell_ratio": 0.002
-      },
-      {
-       "author_value": "Mesen_UGSLig",
-       "cell_count": 2661,
-       "cell_ratio": 0.0019
-      },
-      {
-       "author_value": "Mesen_MullerianFib",
-       "cell_count": 2471,
-       "cell_ratio": 0.0017
-      },
-      {
-       "author_value": "Mesen_Prepuce_Fetal",
-       "cell_count": 2243,
-       "cell_ratio": 0.0016
-      },
-      {
-       "author_value": "Mesen_LabiaFib_Fetal",
-       "cell_count": 1794,
-       "cell_ratio": 0.0013
-      },
-      {
-       "author_value": "Mesen_VaginaFibs",
-       "cell_count": 1463,
-       "cell_ratio": 0.001
-      },
-      {
-       "author_value": "Mesen_VaginaSMCs_Lower_Fetal",
-       "cell_count": 1311,
-       "cell_ratio": 0.0009
-      },
-      {
-       "author_value": "Mesen_Pericyte_EndoStromalLike_MenstrualFluid",
-       "cell_count": 1272,
-       "cell_ratio": 0.0009
-      },
-      {
-       "author_value": "Mesen_VaginaFib_Lower_Fetal",
-       "cell_count": 645,
-       "cell_ratio": 0.0005
-      },
-      {
-       "author_value": "Mesen_EndoGlandBas",
-       "cell_count": 535,
-       "cell_ratio": 0.0004
-      },
-      {
-       "author_value": "Mesen_OvarianFibs_AdvLike",
-       "cell_count": 507,
-       "cell_ratio": 0.0004
-      },
-      {
-       "author_value": "Mesen_CervixFibs",
-       "cell_count": 452,
-       "cell_ratio": 0.0003
-      },
-      {
-       "author_value": "Mesen_UGSSMCs",
-       "cell_count": 383,
-       "cell_ratio": 0.0003
-      },
-      {
-       "author_value": "Mesen_UterotubalJunctionFibs",
-       "cell_count": 150,
-       "cell_ratio": 0.0001
-      },
-      {
-       "author_value": "Mesen_OvarianInclFibs",
-       "cell_count": 96,
-       "cell_ratio": 0.0001
-      },
-      {
-       "author_value": "Mesen_AdvFibs",
-       "cell_count": 19,
-       "cell_ratio": 0.0
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "unknown",
-       "cell_count": 339113,
-       "cell_ratio": 0.2374
-      },
-      {
-       "author_value": "Mesen_EndoStromalFib_Prolif",
-       "cell_count": 164476,
-       "cell_ratio": 0.1151
-      },
-      {
-       "author_value": "Mesen_OvarianFibs_InncorMedulla",
-       "cell_count": 125985,
-       "cell_ratio": 0.0882
-      },
-      {
-       "author_value": "Mesen_EndoStromalFib_mSec",
-       "cell_count": 103861,
-       "cell_ratio": 0.0727
-      },
-      {
-       "author_value": "Mesen_FallopianFibs",
-       "cell_count": 64649,
-       "cell_ratio": 0.0453
-      },
-      {
-       "author_value": "Mesen_vSMCs_medArt",
-       "cell_count": 51141,
-       "cell_ratio": 0.0358
-      },
-      {
-       "author_value": "Mesen_EndoStromalFib_nEMC_Sec",
-       "cell_count": 50283,
-       "cell_ratio": 0.0352
-      },
-      {
-       "author_value": "Mesen_EndoStromalFib_nEMC",
-       "cell_count": 48007,
-       "cell_ratio": 0.0336
-      },
-      {
-       "author_value": "Mesen_OvarianFibs_Perifol",
-       "cell_count": 44411,
-       "cell_ratio": 0.0311
-      },
-      {
-       "author_value": "Mesen_SMCs",
-       "cell_count": 41488,
-       "cell_ratio": 0.029
-      },
-      {
-       "author_value": "Mesen_Pericyte",
-       "cell_count": 38904,
-       "cell_ratio": 0.0272
-      },
-      {
-       "author_value": "Mesen_EndoStromalFib_lSec",
-       "cell_count": 36137,
-       "cell_ratio": 0.0253
-      },
-      {
-       "author_value": "Mesen_AdvFibsIntr",
-       "cell_count": 33795,
-       "cell_ratio": 0.0237
-      },
-      {
-       "author_value": "Mesen_vSMCs_largeArt",
-       "cell_count": 33678,
-       "cell_ratio": 0.0236
-      },
-      {
-       "author_value": "Mesen_EndoStromalFib_Prolif_Cyc",
-       "cell_count": 32491,
-       "cell_ratio": 0.0227
-      },
-      {
-       "author_value": "Mesen_Theca_Externa",
-       "cell_count": 30089,
-       "cell_ratio": 0.0211
-      },
-      {
-       "author_value": "Mesen_EndoStromalFib_MenstrualFluid",
-       "cell_count": 27092,
-       "cell_ratio": 0.019
-      },
-      {
-       "author_value": "Mesen_OvarianFibs_Outcor",
-       "cell_count": 21434,
-       "cell_ratio": 0.015
-      },
-      {
-       "author_value": "Mesen_AdvFibs_PI16low",
-       "cell_count": 18360,
-       "cell_ratio": 0.0129
-      },
-      {
-       "author_value": "Mesen_EndoStromalFib_eSec",
-       "cell_count": 17251,
-       "cell_ratio": 0.0121
-      },
-      {
-       "author_value": "Mesen_OvarianFibs_Medulla_SMCsLike",
-       "cell_count": 13705,
-       "cell_ratio": 0.0096
-      },
-      {
-       "author_value": "Mesen_EndoStromalFib_MenstrualEutopic",
-       "cell_count": 13034,
-       "cell_ratio": 0.0091
-      },
-      {
-       "author_value": "Mesen_EndoStromalFib_nEMC_Cyc",
-       "cell_count": 12895,
-       "cell_ratio": 0.009
-      },
-      {
-       "author_value": "Mesen_Pericyte_EndoStromalLike",
-       "cell_count": 10229,
-       "cell_ratio": 0.0072
-      },
-      {
-       "author_value": "Mesen_Theca_Interna_Cyc",
-       "cell_count": 9366,
-       "cell_ratio": 0.0066
-      },
-      {
-       "author_value": "Mesen_Theca_Interna_Steroid",
-       "cell_count": 8428,
-       "cell_ratio": 0.0059
-      },
-      {
-       "author_value": "Mesen_Pericyte_SMCsIntr",
-       "cell_count": 8167,
-       "cell_ratio": 0.0057
-      },
-      {
-       "author_value": "Mesen_Pericyte_EndoSpiralArt",
-       "cell_count": 6617,
-       "cell_ratio": 0.0046
-      },
-      {
-       "author_value": "Mesen_Theca_Interna_Perifol",
-       "cell_count": 5148,
-       "cell_ratio": 0.0036
-      },
-      {
-       "author_value": "Mesen_Pericyte_Cyc",
-       "cell_count": 4522,
-       "cell_ratio": 0.0032
-      },
-      {
-       "author_value": "Mesen_Theca_Atretic",
-       "cell_count": 3239,
-       "cell_ratio": 0.0023
-      },
-      {
-       "author_value": "Mesen_AdvFibs_PI16hi",
-       "cell_count": 3032,
-       "cell_ratio": 0.0021
-      },
-      {
-       "author_value": "Mesen_EndoStromalFib_Menopause",
-       "cell_count": 2855,
-       "cell_ratio": 0.002
-      },
-      {
-       "author_value": "Mesen_VaginaFibs",
-       "cell_count": 1463,
-       "cell_ratio": 0.001
-      },
-      {
-       "author_value": "Mesen_Pericyte_EndoStromalLike_MenstrualFluid",
-       "cell_count": 1272,
-       "cell_ratio": 0.0009
-      },
-      {
-       "author_value": "Mesen_EndoGlandBas",
-       "cell_count": 535,
-       "cell_ratio": 0.0004
-      },
-      {
-       "author_value": "Mesen_OvarianFibs_AdvLike",
-       "cell_count": 507,
-       "cell_ratio": 0.0004
-      },
-      {
-       "author_value": "Mesen_CervixFibs",
-       "cell_count": 452,
-       "cell_ratio": 0.0003
-      },
-      {
-       "author_value": "Mesen_UterotubalJunctionFibs",
-       "cell_count": 150,
-       "cell_ratio": 0.0001
-      },
-      {
-       "author_value": "Mesen_OvarianInclFibs",
-       "cell_count": 96,
-       "cell_ratio": 0.0001
-      },
-      {
-       "author_value": "Mesen_AdvFibs",
-       "cell_count": 19,
-       "cell_ratio": 0.0
-      }
-     ]
-    },
-    "celltype_HCA_broad": {
-     "author_field_name": "celltype_HCA_broad",
-     "values": [
-      {
-       "author_value": "Mesen_EndoStromalFib",
-       "cell_count": 508382,
-       "cell_ratio": 0.3559
-      },
-      {
-       "author_value": "Mesen_OvarianFibs",
-       "cell_count": 238175,
-       "cell_ratio": 0.1667
-      },
-      {
-       "author_value": "Mesen_vSMCs",
-       "cell_count": 84819,
-       "cell_ratio": 0.0594
-      },
-      {
-       "author_value": "Mesen_FallopianFibs",
-       "cell_count": 64649,
-       "cell_ratio": 0.0453
-      },
-      {
-       "author_value": "Mesen_Pericyte",
-       "cell_count": 63824,
-       "cell_ratio": 0.0447
-      },
-      {
-       "author_value": "Mesen_Theca",
-       "cell_count": 56270,
-       "cell_ratio": 0.0394
-      },
-      {
-       "author_value": "Mesen_SMCs",
-       "cell_count": 41488,
-       "cell_ratio": 0.029
-      },
-      {
-       "author_value": "Mesen_FallopianFib",
-       "cell_count": 41092,
-       "cell_ratio": 0.0288
-      },
-      {
-       "author_value": "Mesen_AdvFibsIntr",
-       "cell_count": 33795,
-       "cell_ratio": 0.0237
-      },
-      {
-       "author_value": "Mesen_UterusFibs",
-       "cell_count": 29462,
-       "cell_ratio": 0.0206
-      },
-      {
-       "author_value": "Mesen_PV",
-       "cell_count": 28897,
-       "cell_ratio": 0.0202
-      },
-      {
-       "author_value": "Mesen_MesonephricFibs",
-       "cell_count": 28521,
-       "cell_ratio": 0.02
-      },
-      {
-       "author_value": "Mesen_AdvFibs",
-       "cell_count": 27298,
-       "cell_ratio": 0.0191
-      },
-      {
-       "author_value": "Mesen_GonadalFibs",
-       "cell_count": 26055,
-       "cell_ratio": 0.0182
-      },
-      {
-       "author_value": "Mesen_FallopianLig",
-       "cell_count": 18265,
-       "cell_ratio": 0.0128
-      },
-      {
-       "author_value": "Mesen_UGSFib",
-       "cell_count": 17679,
-       "cell_ratio": 0.0124
-      },
-      {
-       "author_value": "Mesen_EpoophronFib",
-       "cell_count": 13877,
-       "cell_ratio": 0.0097
-      },
-      {
-       "author_value": "Mesen_UterusLig",
-       "cell_count": 12364,
-       "cell_ratio": 0.0087
-      },
-      {
-       "author_value": "Mesen_CervixFib",
-       "cell_count": 11916,
-       "cell_ratio": 0.0083
-      },
-      {
-       "author_value": "Mesen_CervixVaginaSMCs",
-       "cell_count": 11569,
-       "cell_ratio": 0.0081
-      },
-      {
-       "author_value": "Mesen_CorpusSpongiosumFib",
-       "cell_count": 10169,
-       "cell_ratio": 0.0071
-      },
-      {
-       "author_value": "Mesen_CorpusCavernosumFib",
-       "cell_count": 9472,
-       "cell_ratio": 0.0066
-      },
-      {
-       "author_value": "Mesen_VaginaFibs",
-       "cell_count": 9388,
-       "cell_ratio": 0.0066
-      },
-      {
-       "author_value": "Mesen_FallopianSMCs",
-       "cell_count": 8413,
-       "cell_ratio": 0.0059
-      },
-      {
-       "author_value": "Mesen_UterusSMCs",
-       "cell_count": 7550,
-       "cell_ratio": 0.0053
-      },
-      {
-       "author_value": "Mesen_LabioScrotalSwelling",
-       "cell_count": 6830,
-       "cell_ratio": 0.0048
-      },
-      {
-       "author_value": "Mesen_GlansFib",
-       "cell_count": 5416,
-       "cell_ratio": 0.0038
-      },
-      {
-       "author_value": "Mesen_UGSLig",
-       "cell_count": 2661,
-       "cell_ratio": 0.0019
-      },
-      {
-       "author_value": "Mesen_MullerianFib",
-       "cell_count": 2471,
-       "cell_ratio": 0.0017
-      },
-      {
-       "author_value": "Mesen_Prepuce",
-       "cell_count": 2243,
-       "cell_ratio": 0.0016
-      },
-      {
-       "author_value": "Mesen_LabiaFib",
-       "cell_count": 1794,
-       "cell_ratio": 0.0013
-      },
-      {
-       "author_value": "Mesen_VaginaSMCs",
-       "cell_count": 1311,
-       "cell_ratio": 0.0009
-      },
-      {
-       "author_value": "Mesen_VaginaFib",
-       "cell_count": 645,
-       "cell_ratio": 0.0005
-      },
-      {
-       "author_value": "Mesen_EndoGlandBas",
-       "cell_count": 535,
-       "cell_ratio": 0.0004
-      },
-      {
-       "author_value": "Mesen_CervixFibs",
-       "cell_count": 452,
-       "cell_ratio": 0.0003
-      },
-      {
-       "author_value": "Mesen_UGSSMCs",
-       "cell_count": 383,
-       "cell_ratio": 0.0003
-      },
-      {
-       "author_value": "Mesen_UterotubalJunctionFibs",
-       "cell_count": 150,
-       "cell_ratio": 0.0001
-      },
-      {
-       "author_value": "Mesen_OvarianInclFibs",
-       "cell_count": 96,
-       "cell_ratio": 0.0001
-      }
-     ]
-    },
-    "celltype_HCA_lineage": {
-     "author_field_name": "celltype_HCA_lineage",
-     "values": [
-      {
-       "author_value": "mesenchymal",
-       "cell_count": 1428376,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Uterus",
@@ -249097,6 +240353,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Endometrium",
@@ -249247,6 +240504,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Endometrium",
@@ -249432,6 +240690,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -249462,6 +240721,7 @@
     },
     "Developmental_stage": {
      "author_field_name": "Developmental_stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Adult",
@@ -249492,6 +240752,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -249797,6 +241058,7 @@
     },
     "Tanner Stage": {
      "author_field_name": "Tanner Stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Pubic V/Genitals-Breast V",
@@ -249837,6 +241099,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -249987,6 +241250,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -250102,6 +241366,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "control",
@@ -250312,6 +241577,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -250557,6 +241823,7 @@
     },
     "Observed_pathology": {
      "author_field_name": "Observed_pathology",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -250597,6 +241864,7 @@
     },
     "Sampled_site_condition": {
      "author_field_name": "Sampled_site_condition",
+     "category": "disease",
      "values": [
       {
        "author_value": "normal",
@@ -252218,103 +243486,9 @@
    ],
    "comment": "Marker origin: media-4 broad code 'Mesothelial' (supertype-level).",
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Meso_OSE_Fetal",
-       "cell_count": 23115,
-       "cell_ratio": 0.5713
-      },
-      {
-       "author_value": "Meso_ParamesoCoelEpi",
-       "cell_count": 8490,
-       "cell_ratio": 0.2098
-      },
-      {
-       "author_value": "Meso_Peritoneal_Fetal",
-       "cell_count": 4720,
-       "cell_ratio": 0.1167
-      },
-      {
-       "author_value": "Meso_GonadalCoelEpi",
-       "cell_count": 2840,
-       "cell_ratio": 0.0702
-      },
-      {
-       "author_value": "Meso_OSE",
-       "cell_count": 841,
-       "cell_ratio": 0.0208
-      },
-      {
-       "author_value": "Meso_serosa",
-       "cell_count": 453,
-       "cell_ratio": 0.0112
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "unknown",
-       "cell_count": 39165,
-       "cell_ratio": 0.968
-      },
-      {
-       "author_value": "Meso_OSE",
-       "cell_count": 841,
-       "cell_ratio": 0.0208
-      },
-      {
-       "author_value": "Meso_serosa",
-       "cell_count": 453,
-       "cell_ratio": 0.0112
-      }
-     ]
-    },
-    "celltype_HCA_broad": {
-     "author_field_name": "celltype_HCA_broad",
-     "values": [
-      {
-       "author_value": "Meso_OSE",
-       "cell_count": 23956,
-       "cell_ratio": 0.5921
-      },
-      {
-       "author_value": "Meso_ParamesoCoelEpi",
-       "cell_count": 8490,
-       "cell_ratio": 0.2098
-      },
-      {
-       "author_value": "Meso_Peritoneal",
-       "cell_count": 4720,
-       "cell_ratio": 0.1167
-      },
-      {
-       "author_value": "Meso_GonadalCoelEpi",
-       "cell_count": 2840,
-       "cell_ratio": 0.0702
-      },
-      {
-       "author_value": "Meso_serosa",
-       "cell_count": 453,
-       "cell_ratio": 0.0112
-      }
-     ]
-    },
-    "celltype_HCA_lineage": {
-     "author_field_name": "celltype_HCA_lineage",
-     "values": [
-      {
-       "author_value": "mesothelial",
-       "cell_count": 40459,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Ovary",
@@ -252345,6 +243519,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Gonad_and_extragonadal",
@@ -252480,6 +243655,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Gonad_and_extragonadal",
@@ -252635,6 +243811,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -252660,6 +243837,7 @@
     },
     "Developmental_stage": {
      "author_field_name": "Developmental_stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Fetal",
@@ -252690,6 +243868,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -252850,6 +244029,7 @@
     },
     "Tanner Stage": {
      "author_field_name": "Tanner Stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -252885,6 +244065,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "10",
@@ -253025,6 +244206,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -253085,6 +244267,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "control",
@@ -253155,6 +244338,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -253225,6 +244409,7 @@
     },
     "Observed_pathology": {
      "author_field_name": "Observed_pathology",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -253240,6 +244425,7 @@
     },
     "Sampled_site_condition": {
      "author_field_name": "Sampled_site_condition",
+     "category": "disease",
      "values": [
       {
        "author_value": "normal",
@@ -253929,148 +245115,9 @@
     "Neural crest-derived cell"
    ],
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Neural_Schwann_Fetal",
-       "cell_count": 5801,
-       "cell_ratio": 0.3846
-      },
-      {
-       "author_value": "Neural_SympatheticNeurons_Immature",
-       "cell_count": 4469,
-       "cell_ratio": 0.2963
-      },
-      {
-       "author_value": "Neural_Schwann_Cyc",
-       "cell_count": 2401,
-       "cell_ratio": 0.1592
-      },
-      {
-       "author_value": "Neural_Schwann_Precursor",
-       "cell_count": 847,
-       "cell_ratio": 0.0562
-      },
-      {
-       "author_value": "Neural_Schwann",
-       "cell_count": 781,
-       "cell_ratio": 0.0518
-      },
-      {
-       "author_value": "Neural_SympatheticNeurons_Immature_Cyc",
-       "cell_count": 394,
-       "cell_ratio": 0.0261
-      },
-      {
-       "author_value": "Neural_SympatheticNeurons_Noradrenergic",
-       "cell_count": 246,
-       "cell_ratio": 0.0163
-      },
-      {
-       "author_value": "Neural_Melanocyte_Fetal",
-       "cell_count": 88,
-       "cell_ratio": 0.0058
-      },
-      {
-       "author_value": "Neural_Schwann_Immature",
-       "cell_count": 35,
-       "cell_ratio": 0.0023
-      },
-      {
-       "author_value": "Neural_Schwann_myelinating",
-       "cell_count": 22,
-       "cell_ratio": 0.0015
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "Neural_Schwann_Fetal",
-       "cell_count": 5801,
-       "cell_ratio": 0.3846
-      },
-      {
-       "author_value": "Neural_SympatheticNeurons_Immature",
-       "cell_count": 4469,
-       "cell_ratio": 0.2963
-      },
-      {
-       "author_value": "Neural_Schwann_Cyc",
-       "cell_count": 2401,
-       "cell_ratio": 0.1592
-      },
-      {
-       "author_value": "Neural_Schwann_Precursor",
-       "cell_count": 847,
-       "cell_ratio": 0.0562
-      },
-      {
-       "author_value": "Neural_Schwann",
-       "cell_count": 781,
-       "cell_ratio": 0.0518
-      },
-      {
-       "author_value": "Neural_SympatheticNeurons_Immature_Cyc",
-       "cell_count": 394,
-       "cell_ratio": 0.0261
-      },
-      {
-       "author_value": "Neural_SympatheticNeurons_Noradrenergic",
-       "cell_count": 246,
-       "cell_ratio": 0.0163
-      },
-      {
-       "author_value": "Neural_Melanocyte_Fetal",
-       "cell_count": 88,
-       "cell_ratio": 0.0058
-      },
-      {
-       "author_value": "Neural_Schwann_Immature",
-       "cell_count": 35,
-       "cell_ratio": 0.0023
-      },
-      {
-       "author_value": "Neural_Schwann_myelinating",
-       "cell_count": 22,
-       "cell_ratio": 0.0015
-      }
-     ]
-    },
-    "celltype_HCA_broad": {
-     "author_field_name": "celltype_HCA_broad",
-     "values": [
-      {
-       "author_value": "Neural_Schwann",
-       "cell_count": 9887,
-       "cell_ratio": 0.6555
-      },
-      {
-       "author_value": "Neural_SympatheticNeurons",
-       "cell_count": 5109,
-       "cell_ratio": 0.3387
-      },
-      {
-       "author_value": "Neural_Melanocyte",
-       "cell_count": 88,
-       "cell_ratio": 0.0058
-      }
-     ]
-    },
-    "celltype_HCA_lineage": {
-     "author_field_name": "celltype_HCA_lineage",
-     "values": [
-      {
-       "author_value": "neural",
-       "cell_count": 15084,
-       "cell_ratio": 1.0
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Reproductive tract",
@@ -254106,6 +245153,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Whole_tract",
@@ -254246,6 +245294,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Whole_tract",
@@ -254411,6 +245460,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -254441,6 +245491,7 @@
     },
     "Developmental_stage": {
      "author_field_name": "Developmental_stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Fetal",
@@ -254471,6 +245522,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -254711,6 +245763,7 @@
     },
     "Tanner Stage": {
      "author_field_name": "Tanner Stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -254751,6 +245804,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "19",
@@ -254896,6 +245950,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -254971,6 +246026,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "control",
@@ -255111,6 +246167,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -255256,6 +246313,7 @@
     },
     "Observed_pathology": {
      "author_field_name": "Observed_pathology",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",
@@ -255271,6 +246329,7 @@
     },
     "Sampled_site_condition": {
      "author_field_name": "Sampled_site_condition",
+     "category": "disease",
      "values": [
       {
        "author_value": "normal",
@@ -255584,108 +246643,9 @@
    "parent_cell_set_accession": null,
    "n_cells": 101966,
    "composition": {
-    "celltype_HCA_fine": {
-     "author_field_name": "celltype_HCA_fine",
-     "values": [
-      {
-       "author_value": "Gonadal_preGranulosa-OSEderived_late",
-       "cell_count": 50633,
-       "cell_ratio": 0.4966
-      },
-      {
-       "author_value": "Granulosa_AMHpos_Steroidogenic",
-       "cell_count": 15814,
-       "cell_ratio": 0.1551
-      },
-      {
-       "author_value": "Granulosa_AMHpos_Cyc",
-       "cell_count": 8927,
-       "cell_ratio": 0.0875
-      },
-      {
-       "author_value": "Gonadal_preGranulosa-OSEderived_early",
-       "cell_count": 6659,
-       "cell_ratio": 0.0653
-      },
-      {
-       "author_value": "Granulosa_AMHneg_Squamous",
-       "cell_count": 5644,
-       "cell_ratio": 0.0554
-      },
-      {
-       "author_value": "Granulosa_AMHpos_Atretic",
-       "cell_count": 5440,
-       "cell_ratio": 0.0534
-      },
-      {
-       "author_value": "Granulosa_sq_Fetal",
-       "cell_count": 3928,
-       "cell_ratio": 0.0385
-      },
-      {
-       "author_value": "Granulosa_AMHneg_Atretic",
-       "cell_count": 2960,
-       "cell_ratio": 0.029
-      },
-      {
-       "author_value": "Granulosa_AMHpos_nonSteroidogenic_early",
-       "cell_count": 1267,
-       "cell_ratio": 0.0124
-      },
-      {
-       "author_value": "Granulosa_AMHpos_nonSteroidogenic",
-       "cell_count": 694,
-       "cell_ratio": 0.0068
-      }
-     ]
-    },
-    "celltype_HCA": {
-     "author_field_name": "celltype_HCA",
-     "values": [
-      {
-       "author_value": "unknown",
-       "cell_count": 87599,
-       "cell_ratio": 0.8591
-      },
-      {
-       "author_value": "Granulosa_AMHpos_Cyc",
-       "cell_count": 8927,
-       "cell_ratio": 0.0875
-      },
-      {
-       "author_value": "Granulosa_AMHpos_Atretic",
-       "cell_count": 5440,
-       "cell_ratio": 0.0534
-      }
-     ]
-    },
-    "celltype_HCA_broad": {
-     "author_field_name": "celltype_HCA_broad",
-     "values": [
-      {
-       "author_value": "Gonadal_preGranulosa-OSEderived",
-       "cell_count": 57292,
-       "cell_ratio": 0.5619
-      },
-      {
-       "author_value": "Granulosa_AMHpos",
-       "cell_count": 32142,
-       "cell_ratio": 0.3152
-      },
-      {
-       "author_value": "Granulosa_AMHneg",
-       "cell_count": 8604,
-       "cell_ratio": 0.0844
-      },
-      {
-       "author_value": "Granulosa_sq",
-       "cell_count": 3928,
-       "cell_ratio": 0.0385
-      }
-     ]
-    },
     "Organ": {
      "author_field_name": "Organ",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Ovary",
@@ -255706,6 +246666,7 @@
     },
     "Organ_part": {
      "author_field_name": "Organ_part",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Gonad_and_extragonadal",
@@ -255791,6 +246752,7 @@
     },
     "Tissue_ROI": {
      "author_field_name": "Tissue_ROI",
+     "category": "tissue",
      "values": [
       {
        "author_value": "Gonad_and_extragonadal",
@@ -255896,6 +246858,7 @@
     },
     "Target_cell_population": {
      "author_field_name": "Target_cell_population",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -255926,6 +246889,7 @@
     },
     "Developmental_stage": {
      "author_field_name": "Developmental_stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Fetal",
@@ -255956,6 +246920,7 @@
     },
     "Postnatal_age_years": {
      "author_field_name": "Postnatal_age_years",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -256101,6 +247066,7 @@
     },
     "Tanner Stage": {
      "author_field_name": "Tanner Stage",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -256141,6 +247107,7 @@
     },
     "Gestational_age_pcw": {
      "author_field_name": "Gestational_age_pcw",
+     "category": "development_stage",
      "values": [
       {
        "author_value": "Not applicable",
@@ -256281,6 +247248,7 @@
     },
     "Menstrual_stage": {
      "author_field_name": "Menstrual_stage",
+     "category": "unclassified",
      "values": [
       {
        "author_value": "Not applicable",
@@ -256306,6 +247274,7 @@
     },
     "Disease": {
      "author_field_name": "Disease",
+     "category": "disease",
      "values": [
       {
        "author_value": "control",
@@ -256461,6 +247430,7 @@
     },
     "Clinical_diagnosis": {
      "author_field_name": "Clinical_diagnosis",
+     "category": "disease",
      "values": [
       {
        "author_value": "Not applicable",


### PR DESCRIPTION
Takes the reworked CAS+ across from `HCA_reproductive_atlas_v1`, where the composition work was done, into the test project on `dev`.

**What changed upstream**

- Every composition entry is typed: 843 `tissue`, 742 `development_stage`, 677 `disease`, 501 `unclassified`, 7 `cross_cutting_cell_type`.
- Two redundant cell-type columns pruned; 15 composition fields remain.
- 312 annotations, all carrying `cell_fullname`; 303 with transferred annotations.
- Validates against the merged schema with **zero errors**.

**What it does not change**

Composition volume is essentially the same — 33,071 values against 34,753. The file is no smaller in substance; what is new is that a consumer can select on what a descriptor *is* rather than on an author'''s column name.

**Why that matters downstream**

Sizing the per-cell-type subject block for the reading agent, selecting by category rather than by a hand-listed set of column names:

| block | median | p95 | max | x20 cell types |
|---|---|---|---|---|
| whole annotation, minus transfers | 7,099 ch | 22,522 | 25,024 | ~35k tokens |
| category-selected, values >=5% | **510 ch** | **803** | **1,253** | **~2.5k tokens** |

Against a paper narrative of 8-14k tokens, the naive block is several times the paper and the selected one is noise-level. The selection rule is now general — take `tissue` and `development_stage` — rather than fitted to this project'''s column names.

One thing the numbers surface: `development_stage` legitimately pulls in the donor-age column, so a mid-sized cell set shows nine ages alongside a single stage value. Summarising numeric distributions within that category is a follow-up, not a blocker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
