### PR TITLE
Subject blocks: what a reading agent is told about a cell set

### DIFF
--- a/src/atlas_chat/atlas_chat/cli_subject_block.py
+++ b/src/atlas_chat/atlas_chat/cli_subject_block.py
@@ -1,0 +1,19 @@
+"""CLI for subject blocks.
+
+Thin entry point so blocks are inspectable without a Claude Code session:
+
+.. code-block:: bash
+
+    python -m atlas_chat.cli_subject_block --cas cas.json --label "Mast" --min-ratio 0.01
+
+The implementation lives in :mod:`atlas_chat.services.subject_block`.
+"""
+
+from __future__ import annotations
+
+from atlas_chat.services.subject_block import build_parser, main
+
+__all__ = ["build_parser", "main"]
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/atlas_chat/atlas_chat/schemas/subject_block.schema.json
+++ b/src/atlas_chat/atlas_chat/schemas/subject_block.schema.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "subject_block.schema.json",
+  "title": "SubjectBlock",
+  "description": "What a reading agent is told about one cell set before being asked anything about it. Identity and enough context to find the right passages and to notice when a passage is about something else — never the answers to the questions being asked, which is why nothing derived from prior annotation of this cell set's biology appears here.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["cell_label", "labelset", "n_cells"],
+  "properties": {
+    "cell_label": {
+      "type": "string",
+      "description": "The atlas's own label for the cell set."
+    },
+    "cell_fullname": {
+      "type": "string",
+      "description": "The label written out, where the atlas gives one and it differs from the label itself."
+    },
+    "labelset": {
+      "type": "string",
+      "description": "The labelset the cell set belongs to, which is what makes its granularity legible against its parent and children."
+    },
+    "n_cells": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Cells in the set. Carried because a claim about a handful of cells and a claim about tens of thousands are not equally weighty."
+    },
+    "synonyms": {
+      "type": "array",
+      "description": "Other names the atlas records for this cell set.",
+      "items": { "type": "string" }
+    },
+    "parent": {
+      "type": "string",
+      "description": "Label of the cell set this one sits within."
+    },
+    "children": {
+      "type": "array",
+      "description": "Labels of the cell sets that subdivide this one. Present so that a subdivision is not mistaken for another name for the whole: an alternative name must denote the same cells, and without the children that rule cannot be applied.",
+      "items": { "type": "string" }
+    },
+    "context": {
+      "type": "object",
+      "description": "Where and when these cells were sampled, grouped by descriptor category and then by the source column, carrying only values above the ratio the caller set. Several columns may report the same category at different granularities; they are kept apart because they are not the same statement.",
+      "additionalProperties": {
+        "type": "object",
+        "additionalProperties": {
+          "type": "array",
+          "items": { "type": "string" }
+        }
+      }
+    }
+  }
+}

--- a/src/atlas_chat/atlas_chat/services/subject_block.py
+++ b/src/atlas_chat/atlas_chat/services/subject_block.py
@@ -1,0 +1,210 @@
+"""What a reading agent is told about a cell set before it is asked anything.
+
+A CAS+ annotation is far too large to put in front of a reader: most of it is
+the composition breakdown, which runs to hundreds of values because it records
+every descriptor of every cell. Nearly all of that is donor and sample detail
+that says nothing about the cell type and would crowd out the paper.
+
+So this selects. Two rules, both of which have to be given rather than guessed:
+
+* **which descriptor categories count as context** — where and when the cells
+  were sampled, rather than everything recorded about the donors they came from;
+* **a floor on how much of the cell set a value must account for** — the
+  distributions have long tails of single-cell values.
+
+The categories are named rather than the columns, so the same call works on an
+atlas whose columns are named differently.
+
+Two things are deliberately absent. Anything stating the biology the reader is
+being asked to find — markers, ontology terms — stays out, because supplying it
+invites the reader to recognise it in the text rather than find it. And children
+are included precisely so that a subdivision is not offered back as another name
+for the whole.
+
+Nothing here calls a model.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+#: Descriptor categories that say where and when the cells were sampled, as
+#: against what was recorded about their donors.
+CONTEXT_CATEGORIES = ("tissue", "development_stage")
+
+#: A descriptor value is carried when it accounts for at least this much of the
+#: cell set.
+DEFAULT_MIN_RATIO = 0.01
+
+
+class SubjectBlockError(RuntimeError):
+    """Raised when a requested cell set is not in the document."""
+
+
+def _relations(annotations: list[dict[str, Any]]) -> tuple[dict[str, str], dict[str, list[str]]]:
+    """Accession → label, and accession → the labels of its children."""
+    label_of = {
+        a["cell_set_accession"]: a["cell_label"] for a in annotations if a.get("cell_set_accession")
+    }
+    children: dict[str, list[str]] = {}
+    for a in annotations:
+        parent = a.get("parent_cell_set_accession")
+        if parent:
+            children.setdefault(parent, []).append(a["cell_label"])
+    return label_of, children
+
+
+def _context(
+    annotation: dict[str, Any], categories: tuple[str, ...], min_ratio: float
+) -> dict[str, dict[str, list[str]]]:
+    out: dict[str, dict[str, list[str]]] = {}
+    for column, entry in (annotation.get("composition") or {}).items():
+        category = entry.get("category")
+        if category not in categories:
+            continue
+        ranked = sorted(entry.get("values") or [], key=lambda v: -(v.get("cell_ratio") or 0))
+        kept = [str(v["author_value"]) for v in ranked if (v.get("cell_ratio") or 0) >= min_ratio]
+        if kept:
+            out.setdefault(category, {})[column] = kept
+    return out
+
+
+def build(
+    annotation: dict[str, Any],
+    *,
+    label_of: dict[str, str],
+    children: dict[str, list[str]],
+    categories: tuple[str, ...] = CONTEXT_CATEGORIES,
+    min_ratio: float = DEFAULT_MIN_RATIO,
+) -> dict[str, Any]:
+    """Assemble the block for one annotation.
+
+    Args:
+        annotation: the CAS+ annotation.
+        label_of: accession → label, for naming the parent.
+        children: accession → child labels.
+        categories: descriptor categories to carry as context.
+        min_ratio: floor on a value's share of the cell set.
+
+    Returns:
+        The block, with absent parts omitted rather than written empty.
+    """
+    block: dict[str, Any] = {"cell_label": annotation["cell_label"]}
+    fullname = annotation.get("cell_fullname")
+    if fullname and fullname != annotation["cell_label"]:
+        block["cell_fullname"] = fullname
+    block["labelset"] = annotation["labelset"]
+    block["n_cells"] = annotation.get("n_cells", 0)
+
+    if annotation.get("synonyms"):
+        block["synonyms"] = list(annotation["synonyms"])
+    parent = label_of.get(annotation.get("parent_cell_set_accession") or "")
+    if parent:
+        block["parent"] = parent
+    kids = children.get(annotation.get("cell_set_accession") or "")
+    if kids:
+        block["children"] = sorted(kids)
+
+    context = _context(annotation, categories, min_ratio)
+    if context:
+        block["context"] = context
+    return block
+
+
+def build_all(
+    cas_doc: dict[str, Any],
+    cell_labels: list[str] | None = None,
+    *,
+    categories: tuple[str, ...] = CONTEXT_CATEGORIES,
+    min_ratio: float = DEFAULT_MIN_RATIO,
+) -> list[dict[str, Any]]:
+    """Blocks for the named cell sets, in the order asked for.
+
+    Args:
+        cas_doc: the CAS+ document.
+        cell_labels: which cell sets to build for. All of them when omitted.
+        categories: descriptor categories to carry as context.
+        min_ratio: floor on a value's share of the cell set.
+
+    Returns:
+        One block per requested label.
+
+    Raises:
+        SubjectBlockError: a requested label is not in the document. A silently
+            missing subject would become a cell type nobody was asked about.
+    """
+    annotations = cas_doc.get("annotations") or []
+    label_of, children = _relations(annotations)
+    by_label: dict[str, dict[str, Any]] = {a["cell_label"]: a for a in annotations}
+
+    wanted = cell_labels if cell_labels is not None else [a["cell_label"] for a in annotations]
+    missing = [label for label in wanted if label not in by_label]
+    if missing:
+        raise SubjectBlockError(f"not in the document: {', '.join(sorted(missing))}")
+
+    return [
+        build(
+            by_label[label],
+            label_of=label_of,
+            children=children,
+            categories=categories,
+            min_ratio=min_ratio,
+        )
+        for label in wanted
+    ]
+
+
+# ------------------------------------------------------------------
+# CLI
+# ------------------------------------------------------------------
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="python -m atlas_chat.cli_subject_block",
+        description="Assemble what a reading agent is told about one or more cell sets.",
+    )
+    parser.add_argument("--cas", required=True, help="the CAS+ document")
+    parser.add_argument("--label", action="append", help="repeatable; all cell sets when omitted")
+    parser.add_argument("--out", help="write JSON here instead of stdout")
+    parser.add_argument(
+        "--min-ratio",
+        type=float,
+        default=DEFAULT_MIN_RATIO,
+        help=f"floor on a value's share of the cell set (default {DEFAULT_MIN_RATIO})",
+    )
+    parser.add_argument(
+        "--category",
+        action="append",
+        help=f"repeatable; default {' '.join(CONTEXT_CATEGORIES)}",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    cas_doc = json.loads(Path(args.cas).read_text(encoding="utf-8"))
+    try:
+        blocks = build_all(
+            cas_doc,
+            args.label,
+            categories=tuple(args.category) if args.category else CONTEXT_CATEGORIES,
+            min_ratio=args.min_ratio,
+        )
+    except SubjectBlockError as exc:
+        print(str(exc))
+        return 2
+    payload = json.dumps(blocks, indent=2)
+    if args.out:
+        Path(args.out).write_text(payload + "\n", encoding="utf-8")
+        chars = sum(len(json.dumps(b)) for b in blocks)
+        print(f"{len(blocks)} subject blocks, {chars:,} chars -> {args.out}")
+    else:
+        print(payload)
+    return 0

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,42 @@
+"""Locating corpus material that is too large to live in the repository.
+
+A project's supplements run to hundreds of megabytes, so they sit outside the
+checkout and their location is given by ``ATLAS_CHAT_CORPUS_ROOT``. Under it,
+each project is a directory holding a ``supplements`` store.
+
+The two ways this can go wrong are told apart deliberately. A variable that is
+not set means the corpus is simply not provisioned on this machine, which is
+normal and skips. A variable that is set and wrong is a misconfiguration, and
+failing on it is the only way anyone finds out — a run that silently reports no
+supplements looks exactly like a paper that has none.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+CORPUS_ENV = "ATLAS_CHAT_CORPUS_ROOT"
+
+
+@pytest.fixture(scope="session")
+def corpus_root() -> Path:
+    """Root holding one directory per project."""
+    raw = os.getenv(CORPUS_ENV)
+    if not raw:
+        pytest.skip(f"{CORPUS_ENV} is not set; corpus material is not on this machine")
+    root = Path(raw).expanduser()
+    if not root.is_dir():
+        raise AssertionError(f"{CORPUS_ENV} points at {root}, which is not a directory")
+    return root
+
+
+@pytest.fixture(scope="session")
+def reproductive_store(corpus_root: Path) -> Path:
+    """The reproductive project's supplement store."""
+    store = corpus_root / "hca_reproductive" / "supplements"
+    if not store.is_dir():
+        raise AssertionError(f"no supplement store at {store}")
+    return store

--- a/tests/integration/test_corpus_store_live.py
+++ b/tests/integration/test_corpus_store_live.py
@@ -1,0 +1,53 @@
+"""The corpus on disk, read through the store's own API.
+
+Real material, not a fixture: what these assert is that a store assembled by
+the setup steps is readable by the code that has to consume it, and that its
+prose pointers resolve to text rather than to nothing.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from atlas_chat.services.supplement_store import load_manifest
+
+pytestmark = pytest.mark.integration
+
+
+def _manifests(store: Path) -> list[Path]:
+    return sorted(store.glob("papers/*/manifest.json"))
+
+
+def test_the_store_holds_manifests(reproductive_store: Path) -> None:
+    assert _manifests(reproductive_store), f"no manifests under {reproductive_store}"
+
+
+def test_every_manifest_names_the_paper_it_describes(reproductive_store: Path) -> None:
+    for path in _manifests(reproductive_store):
+        manifest = json.loads(path.read_text(encoding="utf-8"))
+        assert (manifest.get("paper") or {}).get("doi"), f"{path} names no DOI"
+
+
+def test_manifests_load_through_the_stores_own_api(reproductive_store: Path) -> None:
+    """A manifest that only parses as JSON is not the same as one the store can
+    find: the lookup is by DOI, through a slug the store computes itself."""
+    for path in _manifests(reproductive_store):
+        doi = json.loads(path.read_text(encoding="utf-8"))["paper"]["doi"]
+        assert load_manifest(reproductive_store, doi) is not None, f"{doi} not findable"
+
+
+def test_prose_marked_as_folding_in_resolves_to_text_on_disk(reproductive_store: Path) -> None:
+    """A pointer that folds in but whose text is missing would be read as a
+    paper with nothing to say, rather than as an extraction that failed."""
+    unresolved = []
+    for path in _manifests(reproductive_store):
+        manifest = json.loads(path.read_text(encoding="utf-8"))
+        for pointer in manifest.get("prose") or []:
+            if not pointer.get("folds_in"):
+                continue
+            text_file = pointer.get("text_file")
+            if not text_file or not (reproductive_store / text_file).is_file():
+                unresolved.append(f"{manifest['paper']['doi']}: {text_file!r}")
+    assert not unresolved, "prose folds in but its text is missing: " + "; ".join(unresolved)

--- a/tests/unit/test_subject_block.py
+++ b/tests/unit/test_subject_block.py
@@ -1,0 +1,178 @@
+"""Unit tests for what a reading agent is told about a cell set."""
+
+from __future__ import annotations
+
+import json
+
+import jsonschema
+import pytest
+from atlas_chat.services.subject_block import (
+    SubjectBlockError,
+    build_all,
+    main,
+)
+
+from atlas_chat.schemas import load_schema
+
+pytestmark = pytest.mark.unit
+
+
+def _cas() -> dict:
+    def values(pairs):
+        return [{"author_value": v, "cell_ratio": r} for v, r in pairs]
+
+    return {
+        "labelsets": [{"name": "fine"}, {"name": "broad"}],
+        "annotations": [
+            {
+                "labelset": "broad",
+                "cell_label": "Parent",
+                "cell_fullname": "Parent",
+                "cell_set_accession": "P",
+                "n_cells": 100,
+            },
+            {
+                "labelset": "fine",
+                "cell_label": "Subject",
+                "cell_fullname": "The subject in full",
+                "cell_set_accession": "S",
+                "parent_cell_set_accession": "P",
+                "n_cells": 60,
+                "synonyms": ["Subj"],
+                "marker_gene_evidence": ["GENE1"],
+                "cell_ontology_term_id": "CL:0000000",
+                "composition": {
+                    "organ": {
+                        "category": "tissue",
+                        "values": values([("Kept", 0.9), ("Dropped", 0.001)]),
+                    },
+                    "region": {
+                        "category": "tissue",
+                        "values": values([("AlsoKept", 0.5)]),
+                    },
+                    "stage": {
+                        "category": "development_stage",
+                        "values": values([("Adult", 1.0)]),
+                    },
+                    "diagnosis": {
+                        "category": "disease",
+                        "values": values([("Excluded", 1.0)]),
+                    },
+                    "untyped": {"values": values([("AlsoExcluded", 1.0)])},
+                },
+            },
+            {
+                "labelset": "fine",
+                "cell_label": "Child",
+                "cell_set_accession": "C",
+                "parent_cell_set_accession": "S",
+                "n_cells": 20,
+            },
+        ],
+    }
+
+
+def _subject() -> dict:
+    return build_all(_cas(), ["Subject"])[0]
+
+
+def test_identity_and_relations_are_carried():
+    b = _subject()
+    assert b["cell_label"] == "Subject"
+    assert b["cell_fullname"] == "The subject in full"
+    assert b["labelset"] == "fine"
+    assert b["n_cells"] == 60
+    assert b["synonyms"] == ["Subj"]
+    assert b["parent"] == "Parent"
+    assert b["children"] == ["Child"]
+
+
+def test_children_are_present_so_a_subdivision_is_not_taken_for_a_synonym():
+    """An alternative name has to denote the same cells; without the children
+    that rule cannot be applied to a candidate."""
+    assert "Child" in _subject()["children"]
+
+
+def test_a_fullname_identical_to_the_label_is_not_repeated():
+    b = build_all(_cas(), ["Parent"])[0]
+    assert "cell_fullname" not in b
+
+
+def test_context_carries_only_the_named_categories():
+    ctx = _subject()["context"]
+    assert set(ctx) == {"tissue", "development_stage"}
+    assert "disease" not in ctx
+
+
+def test_an_untyped_descriptor_is_not_context():
+    """Absence of a category claims nothing, so it cannot be read as context."""
+    flat = json.dumps(_subject())
+    assert "AlsoExcluded" not in flat
+
+
+def test_columns_reporting_the_same_category_are_kept_apart():
+    """Different granularities of the same category are different statements."""
+    assert _subject()["context"]["tissue"] == {"organ": ["Kept"], "region": ["AlsoKept"]}
+
+
+def test_values_below_the_floor_are_dropped():
+    assert "Dropped" not in json.dumps(_subject())
+
+
+def test_the_floor_is_the_callers_choice():
+    b = build_all(_cas(), ["Subject"], min_ratio=0.0)[0]
+    assert b["context"]["tissue"]["organ"] == ["Kept", "Dropped"]
+
+
+def test_the_categories_are_the_callers_choice():
+    b = build_all(_cas(), ["Subject"], categories=("disease",))[0]
+    assert set(b["context"]) == {"disease"}
+
+
+def test_nothing_stating_the_biology_the_reader_must_find_is_included():
+    """Supplying markers or an ontology term invites the reader to recognise
+    them in the text rather than find them."""
+    flat = json.dumps(_subject())
+    assert "GENE1" not in flat
+    assert "CL:0000000" not in flat
+
+
+def test_a_cell_set_with_no_context_omits_the_key_rather_than_writing_it_empty():
+    assert "context" not in build_all(_cas(), ["Child"])[0]
+
+
+def test_an_unknown_label_is_an_error_not_a_missing_block():
+    """A silently missing subject is a cell type nobody was asked about."""
+    with pytest.raises(SubjectBlockError):
+        build_all(_cas(), ["Subject", "Nonexistent"])
+
+
+def test_blocks_come_back_in_the_order_asked_for():
+    labels = ["Child", "Subject", "Parent"]
+    assert [b["cell_label"] for b in build_all(_cas(), labels)] == labels
+
+
+def test_all_cell_sets_when_none_are_named():
+    assert len(build_all(_cas())) == 3
+
+
+def test_every_block_validates_against_the_schema():
+    schema = load_schema("subject_block.schema.json")
+    for block in build_all(_cas()):
+        jsonschema.validate(block, schema)
+
+
+def test_cli_writes_blocks_and_reports_their_size(tmp_path, capsys):
+    cas = tmp_path / "cas.json"
+    cas.write_text(json.dumps(_cas()), encoding="utf-8")
+    out = tmp_path / "blocks.json"
+    assert main(["--cas", str(cas), "--label", "Subject", "--out", str(out)]) == 0
+    assert json.loads(out.read_text())[0]["cell_label"] == "Subject"
+    assert "1 subject blocks" in capsys.readouterr().out
+
+
+def test_cli_exits_nonzero_on_an_unknown_label(tmp_path, capsys):
+    cas = tmp_path / "cas.json"
+    cas.write_text(json.dumps(_cas()), encoding="utf-8")
+    assert main(["--cas", str(cas), "--label", "Nope"]) == 2
+    assert "not in the document" in capsys.readouterr().out


### PR DESCRIPTION
Item 3 of the ingest specification: what a reading agent is told about a cell set before it is asked anything.

## Why

A CAS+ annotation cannot be put in front of a reader. Most of it is the composition breakdown — every descriptor of every cell — and nearly all of that is donor and sample detail that says nothing about the cell type. On the reference project the annotations come to 4.5 MB, against a paper narrative of 8-14k tokens.

## What it does

`services/subject_block.py` selects on two rules, both **given rather than guessed**: which descriptor categories count as context, and how much of the cell set a value must account for.

Naming *categories* rather than *columns* is what makes the same call work on an atlas whose columns are named differently — which the typing from #57 is what enables. The previous version of this selection was a hand-listed set of column names fitted to one project.

At the defaults — `tissue` and `development_stage`, values above 1% of the cell set:

| | chars |
|---|---|
| full annotations (312) | 4,507,744 |
| subject blocks (312) | **230,424** |

**94.9% reduction.** A batch of twenty cell sets goes from ~65k tokens to ~3.4k at the median, ~156k to ~6k at p95.

## Two deliberate choices

**Markers and ontology terms are excluded.** They state the biology the reader is being asked to find, and supplying them invites recognition rather than reading.

**Children are included.** For the opposite reason: an alternative name must denote the same cells, so without the children the rule cannot be applied to a candidate. This is the failure mode where a cell type'''s own subset gets offered back as its synonym.

Also: columns reporting the same category at different granularities are kept apart rather than merged, because they are not the same statement.

## Corpus location

Supplements are too large for the checkout, so `ATLAS_CHAT_CORPUS_ROOT` names where they live and the integration fixtures resolve a project'''s store under it.

The two failure modes are told apart on purpose: **unset skips** (the corpus is not provisioned on this machine), **set-but-wrong fails** (a misconfiguration — and a run silently reporting no supplements looks exactly like a paper that has none). Both paths verified.

## Verification

- 17 unit tests; 461 unit tests pass overall; ruff clean.
- 4 integration tests against the real 494 MB corpus: manifests load through the store'''s own DOI lookup, and every prose pointer marked as folding in resolves to text on disk.
- The 94.9% figure is from running the CLI over the committed reproductive CAS+, not from a fixture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
