### PR TITLE
Fetch a preprint's supplements from the preprint server

### DIFF
--- a/docs/pipeline.md
+++ b/docs/pipeline.md
@@ -85,7 +85,11 @@ paper body, so this gets its own subsystem: fetch, store, triage, index.
 **Fetch — `services/supplement_fetch.py`.** `resolve_pmcid()` and `fetch_jats()`
 get the paper; `fetch_bundle()` pulls the EuropePMC supplementary bundle, with
 `publisher_direct_url()` / `springer_url()` as a fallback where the bundle is
-absent. `verify_payload()` and `is_non_evidence()` discard junk. `should_attempt()`
+absent. A preprint has no PMC record, so `biorxiv_listing()` /
+`parse_supplement_page()` / `biorxiv_get()` read the file list off the preprint
+server's own supplementary-material page and fetch each file from it (needs the
+`[text-access]` extra for the impersonating HTTP client).
+`verify_payload()` and `is_non_evidence()` discard junk. `should_attempt()`
 holds the retry policy. `fetch_supplements()` does one paper, `fetch_corpus()` does
 the project's whole paper set. Library only — no CLI.
 

--- a/src/atlas_chat/atlas_chat/schemas/supplement_manifest.schema.json
+++ b/src/atlas_chat/atlas_chat/schemas/supplement_manifest.schema.json
@@ -146,11 +146,12 @@
       "properties": {
         "route": {
           "type": "string",
-          "description": "'jats_listing' = known from the article XML but bytes not fetched by this route. 'publisher_direct' = fetched from the publisher's static host. 'europepmc_bundle' = from Europe PMC's supplementaryFiles zip. 'manual' = supplied by a user. 'none' = no route available.",
+          "description": "'jats_listing' = known from the article XML but bytes not fetched by this route. 'publisher_direct' = fetched from the publisher's static host. 'europepmc_bundle' = from Europe PMC's supplementaryFiles zip. 'biorxiv' = listed on, and fetched from, the preprint's bioRxiv page. 'manual' = supplied by a user. 'none' = no route available.",
           "enum": [
             "jats_listing",
             "publisher_direct",
             "europepmc_bundle",
+            "biorxiv",
             "manual",
             "none"
           ]

--- a/src/atlas_chat/atlas_chat/services/fetch_preprint.py
+++ b/src/atlas_chat/atlas_chat/services/fetch_preprint.py
@@ -87,8 +87,12 @@ def _try_europepmc(doi: str, out_path: Path) -> tuple[bool, str]:
 # ------------------------------------------------------------------
 
 
-def _biorxiv_metadata(doi: str) -> dict | None:
-    """Hit api.biorxiv.org/details (no CF) for the JATS URL + metadata."""
+def biorxiv_metadata(doi: str) -> dict | None:
+    """Hit api.biorxiv.org/details (no CF) for the JATS URL + metadata.
+
+    Returns None for a DOI bioRxiv does not host, which is also the cheapest
+    test of whether a paper is a bioRxiv preprint at all.
+    """
     url = f"{BIORXIV_API}/{doi}/na/json"
     try:
         with urllib.request.urlopen(url, timeout=20) as fh:
@@ -195,7 +199,7 @@ def fetch_preprint(doi: str, out_dir: Path) -> FetchedPreprint:
         return FetchedPreprint(doi=doi, jats_path=jats_path, source_used="europepmc")
 
     # Paths 2 + 3 need bioRxiv metadata first
-    meta = _biorxiv_metadata(doi)
+    meta = biorxiv_metadata(doi)
     if not meta:
         attempts.append(("biorxiv_api", "metadata lookup failed"))
         raise PreprintFetchError(doi, attempts)

--- a/src/atlas_chat/atlas_chat/services/supplement_fetch.py
+++ b/src/atlas_chat/atlas_chat/services/supplement_fetch.py
@@ -25,9 +25,14 @@ Oxford, PNAS, and a bioRxiv preprint):
    per publisher. Only Springer Nature is implemented, because its ESM stem is
    derivable from the DOI alone (verified on 8 of 8 Springer papers in the
    corpus) — for others, a template can be added when a corpus needs it.
-4. **Manual** (``manual``). Recorded as a gap naming the file and where to get
-   it. The only route for the 5 corpus papers with no PMC record at all, and for
-   closed-access papers generally.
+4. **bioRxiv** (``biorxiv``). A preprint has no PMC record, so the three rungs
+   above are all blind to it, but the preprint server lists its supplements on
+   a page of its own and serves each file individually. That page supplies
+   both the listing (with the author's labels) and the bytes, so this route
+   stands in for rungs 1 and 3 at once for the papers it covers.
+5. **Manual** (``manual``). Recorded as a gap naming the file and where to get
+   it. The route of last resort for closed-access papers, and for anything
+   published where none of the above reaches.
 
 Two traps this module exists to avoid
 -------------------------------------
@@ -56,11 +61,13 @@ import urllib.parse
 import zipfile
 from collections import Counter
 from datetime import UTC, datetime
+from html import unescape
 from pathlib import Path
 from typing import Any
 
 import httpx
 
+from atlas_chat.services.fetch_preprint import biorxiv_metadata
 from atlas_chat.services.supplement_store import (
     MANIFEST_VERSION,
     SupplementStoreError,
@@ -339,6 +346,102 @@ def fetch_one_file(client: httpx.Client, url: str, dest: Path) -> tuple[bool, st
 
 
 # ------------------------------------------------------------------
+# Route: bioRxiv
+# ------------------------------------------------------------------
+
+BIORXIV_CONTENT = "https://www.biorxiv.org/content"
+
+#: One supplement's markup on the page. Splitting on the container class rather
+#: than matching a nested structure keeps the parse tolerant of the surrounding
+#: page changing around it.
+BIORXIV_ENTRY_MARKER = "supplementary-material-expansion"
+BIORXIV_LINK = re.compile(r'href="([^"]+/embed/[^"?]+)[^"]*"')
+BIORXIV_LABEL = re.compile(r'supplementary-material-label"[^>]*>([^<]+)<')
+
+
+def biorxiv_get(url: str) -> tuple[bytes | None, str]:
+    """GET one URL from bioRxiv, which serves nothing to an ordinary client.
+
+    The site is behind a bot filter that answers a plain HTTP request with a
+    challenge page rather than an error, so the request has to present a
+    browser's TLS fingerprint — the same approach, and the same optional
+    dependency, as fetching a preprint's JATS.
+
+    Returns:
+        ``(payload, note)``; the note says what went wrong when payload is None.
+    """
+    try:
+        from curl_cffi import requests as cf_requests  # type: ignore[import-not-found]
+    except ImportError:
+        return None, "curl_cffi not installed (uv sync --extra text-access)"
+    try:
+        resp = cf_requests.get(url, impersonate="chrome120", timeout=180)
+    except Exception as exc:  # curl_cffi raises its own error hierarchy
+        return None, f"{type(exc).__name__}: {exc}"
+    if resp.status_code != 200:
+        return None, f"HTTP {resp.status_code}"
+    return resp.content, "ok"
+
+
+def parse_supplement_page(page: str) -> list[dict[str, Any]]:
+    """Read the file list off a bioRxiv supplementary-material page.
+
+    Returns:
+        Manifest ``files`` entries with ``status: "listed"``, each carrying the
+        download URL the page gave for it, since it encodes a posting date that
+        cannot be derived from the DOI.
+    """
+    out: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for chunk in page.split(BIORXIV_ENTRY_MARKER)[1:]:
+        link = BIORXIV_LINK.search(chunk)
+        if not link:
+            continue
+        url = unescape(link.group(1))
+        file_id = url.rsplit("/", 1)[-1]
+        if file_id in seen:
+            continue
+        seen.add(file_id)
+        entry: dict[str, Any] = {
+            "file_id": file_id,
+            "media_type": media_type(file_id),
+            "status": "listed",
+            "retrieval": {"route": "biorxiv", "url": url},
+        }
+        label = BIORXIV_LABEL.search(chunk)
+        if label:
+            entry["label"] = unescape(label.group(1)).strip()
+        out.append(entry)
+    return out
+
+
+def biorxiv_listing(doi: str) -> list[dict[str, Any]]:
+    """List a bioRxiv preprint's supplements, if the DOI is one.
+
+    bioRxiv has issued more than one DOI prefix, so being a preprint is not
+    something the DOI can be pattern-matched for: the test is whether bioRxiv's
+    own metadata service knows the paper. It also supplies the version number,
+    which the content URL needs.
+
+    Returns:
+        Manifest ``files`` entries, empty for a paper bioRxiv does not host or
+        whose page could not be read.
+    """
+    meta = biorxiv_metadata(doi)
+    if not meta:
+        return []
+    version = meta.get("version") or "1"
+    url = f"{BIORXIV_CONTENT}/{doi}v{version}.supplementary-material"
+    payload, note = biorxiv_get(url)
+    if payload is None:
+        logger.info("%s: bioRxiv supplement page unreadable — %s", doi, note)
+        return []
+    listed = parse_supplement_page(payload.decode("utf-8", errors="replace"))
+    logger.info("%s: bioRxiv lists %d supplementary file(s)", doi, len(listed))
+    return listed
+
+
+# ------------------------------------------------------------------
 # The negative cache
 # ------------------------------------------------------------------
 
@@ -443,13 +546,17 @@ def _fetch(
                 }
             )
     else:
-        gaps.append(
-            {
-                "file_id": doi,
-                "reason": "no PMC record in Europe PMC, so no programmatic route exists",
-                "action": f"download from https://doi.org/{doi} into incoming/ and run adopt",
-            }
-        )
+        # No PMC record, so the listing has to come from wherever the paper
+        # itself is published. For a preprint that is the preprint server.
+        listed = biorxiv_listing(doi)
+        if not listed:
+            gaps.append(
+                {
+                    "file_id": doi,
+                    "reason": "no PMC record in Europe PMC, so no programmatic route exists",
+                    "action": f"download from https://doi.org/{doi} into incoming/ and run adopt",
+                }
+            )
 
     if listed:
         manifest["files"] = _merge_files(manifest.get("files", []), listed)
@@ -541,7 +648,35 @@ def _fetch(
                 "note": note,
             }
 
-    # --- route 4: nothing left but a person --------------------------
+    # --- route 4: the preprint server ---------------------------------
+    for entry in wanted:
+        if entry.get("status") == "present":
+            continue
+        retrieval = entry.get("retrieval", {})
+        if retrieval.get("route") != "biorxiv":
+            continue
+        url = retrieval.get("url")
+        dest = files_dir(store_root, doi) / entry["file_id"]
+        payload, note = biorxiv_get(url)
+        if payload is not None:
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            dest.write_bytes(payload)
+            ok, note = verify_payload(dest, media_type(entry["file_id"]))
+        else:
+            ok = False
+        if ok:
+            _mark_present(entry, store_root, doi, dest, "biorxiv", url=url)
+        else:
+            dest.unlink(missing_ok=True)
+            entry["status"] = "failed"
+            entry["retrieval"] = {
+                "route": "biorxiv",
+                "url": url,
+                "attempted_at": _now(),
+                "note": note,
+            }
+
+    # --- route 5: nothing left but a person --------------------------
     for entry in wanted:
         if entry.get("status") == "present":
             continue

--- a/tests/integration/test_biorxiv_supplements_live.py
+++ b/tests/integration/test_biorxiv_supplements_live.py
@@ -1,0 +1,84 @@
+"""Integration tests for the bioRxiv supplement route against the real site.
+
+No mocks. bioRxiv answers a plain HTTP client with a bot challenge rather than
+an error, so the route depends on both the metadata API and the impersonating
+client behaving as they did when it was written; these tests fail hard if
+either changes shape.
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from atlas_chat.services import supplement_fetch as fetch
+from atlas_chat.services import supplement_store as store
+
+pytestmark = pytest.mark.integration
+
+# A preprint with several supplementary workbooks and no PMC record, so every
+# other rung of the waterfall is blind to it.
+PREPRINT = "10.64898/2026.06.10.731198"
+
+
+@pytest.fixture
+def client():
+    with httpx.Client(follow_redirects=True, timeout=fetch.TIMEOUT) as c:
+        yield c
+
+
+def test_metadata_lookup_identifies_the_preprint() -> None:
+    """How the route decides a DOI is a preprint, and which version to ask for."""
+    meta = fetch.biorxiv_metadata(PREPRINT)
+
+    assert meta is not None
+    assert meta["doi"] == PREPRINT
+    assert meta["version"].isdigit()
+
+
+def test_metadata_lookup_declines_a_journal_doi() -> None:
+    assert fetch.biorxiv_metadata("10.1038/s41588-024-01873-w") is None
+
+
+def test_the_supplement_page_lists_files_with_labels() -> None:
+    listed = fetch.biorxiv_listing(PREPRINT)
+
+    assert listed, "the preprint's supplement page should list files"
+    assert all(entry["retrieval"]["route"] == "biorxiv" for entry in listed)
+    assert all(entry["retrieval"]["url"].startswith("https://") for entry in listed)
+    # The author's labels are the only description of the files there is.
+    assert any(entry.get("label") for entry in listed)
+
+
+def test_a_listed_file_downloads_and_opens() -> None:
+    listed = fetch.biorxiv_listing(PREPRINT)
+    workbook = next(entry for entry in listed if entry["media_type"] == "xlsx")
+
+    payload, note = fetch.biorxiv_get(workbook["retrieval"]["url"])
+
+    assert payload is not None, note
+    assert payload[:4] == b"PK\x03\x04", "an xlsx is a zip container"
+
+
+def test_preprint_is_fully_retrieved_end_to_end(tmp_path, client) -> None:
+    manifest = fetch.fetch_supplements(tmp_path, PREPRINT, client=client)
+
+    store.validate_manifest(manifest)
+    assert store.cross_check_manifest(manifest) == []
+    assert manifest["files"]
+    assert manifest["gaps"] == []
+    for entry in manifest["files"]:
+        assert entry["status"] == "present"
+        assert entry["retrieval"]["route"] == "biorxiv"
+        assert (tmp_path / entry["path"]).stat().st_size == entry["size_bytes"]
+        assert len(entry["retrieval"]["sha256"]) == 64
+
+
+def test_a_retrieved_workbook_is_immediately_indexable(tmp_path, client) -> None:
+    """What fetch writes, the store must be able to outline."""
+    manifest = fetch.fetch_supplements(tmp_path, PREPRINT, client=client)
+
+    workbook = next(f for f in manifest["files"] if f["media_type"] == "xlsx")
+    outline = store.outline_file(tmp_path / workbook["path"])
+
+    assert outline["tables"]

--- a/tests/unit/test_supplement_fetch.py
+++ b/tests/unit/test_supplement_fetch.py
@@ -248,6 +248,17 @@ def _waterfall_handler(
     return handler
 
 
+def _no_pmc_handler():
+    """Europe PMC knows nothing about the paper, so every PMC route is blind."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if "/search" in str(request.url):
+            return httpx.Response(200, json={"resultList": {"result": []}})
+        return httpx.Response(404)
+
+    return handler
+
+
 def test_bundle_route_stores_only_listed_files(tmp_path: Path) -> None:
     """Figure images bloat the bundle; only the listed supplements are wanted."""
     bundle = _zip(
@@ -301,13 +312,10 @@ def test_everything_failing_leaves_actionable_gaps(tmp_path: Path) -> None:
     assert all("incoming/" in gap["action"] for gap in manifest["gaps"] if "action" in gap)
 
 
-def test_no_pmc_record_records_the_manual_route(tmp_path: Path) -> None:
-    def handler(request: httpx.Request) -> httpx.Response:
-        if "/search" in str(request.url):
-            return httpx.Response(200, json={"resultList": {"result": []}})
-        return httpx.Response(404)
+def test_no_pmc_record_records_the_manual_route(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(fetch, "biorxiv_metadata", lambda doi: None)
 
-    with _client(handler) as client:
+    with _client(_no_pmc_handler()) as client:
         manifest = fetch.fetch_supplements(tmp_path, "10.1126/science.adx0659", client=client)
 
     assert manifest["files"] == []
@@ -526,3 +534,148 @@ def test_corrupt_bytes_are_not_left_on_disk(tmp_path: Path) -> None:
     assert entry["status"] in {"failed", "unavailable"}
     assert "path" not in entry
     assert not list((tmp_path / "papers").rglob("*.xlsx"))
+
+
+# ------------------------------------------------------------------
+# The preprint route
+# ------------------------------------------------------------------
+
+PREPRINT_DOI = "10.5555/2026.01.02.123456"
+
+SUPPLEMENT_PAGE = """
+<div class="supplementary-material-expansion" id="DC1">
+  <span class="supplementary-material-label">Supplementary Information</span>
+  <a href="https://www.biorxiv.org/content/x/early/d/s/DC1/embed/media-1.docx?download=true">
+  [supplements/file01.docx]</a>
+</div>
+<div class="supplementary-material-expansion" id="DC2">
+  <span class="supplementary-material-label">Supplementary Table 1</span>
+  <a href="https://www.biorxiv.org/content/x/early/d/s/DC2/embed/media-2.xlsx?download=true">
+  [supplements/file02.xlsx]</a>
+</div>
+<a href="https://www.biorxiv.org/content/x.full.pdf">Full text</a>
+"""
+
+
+def _preprint_bytes(url: str) -> bytes:
+    return _xlsx() if url.endswith((".xlsx", ".docx")) else _pdf()
+
+
+def _serve_preprint(monkeypatch, *, page: str | None = SUPPLEMENT_PAGE, files: bool = True):
+    """Stand in for both bioRxiv boundaries: the metadata API and the site."""
+    monkeypatch.setattr(fetch, "biorxiv_metadata", lambda doi: {"doi": doi, "version": "2"})
+    requested: list[str] = []
+
+    def get(url: str) -> tuple[bytes | None, str]:
+        requested.append(url)
+        if url.endswith(".supplementary-material"):
+            return (page.encode(), "ok") if page is not None else (None, "HTTP 403")
+        return (_preprint_bytes(url), "ok") if files else (None, "HTTP 404")
+
+    monkeypatch.setattr(fetch, "biorxiv_get", get)
+    return requested
+
+
+def test_page_parse_reads_files_labels_and_urls() -> None:
+    listed = fetch.parse_supplement_page(SUPPLEMENT_PAGE)
+
+    assert [entry["file_id"] for entry in listed] == ["media-1.docx", "media-2.xlsx"]
+    assert listed[1]["label"] == "Supplementary Table 1"
+    assert listed[1]["retrieval"] == {
+        "route": "biorxiv",
+        "url": "https://www.biorxiv.org/content/x/early/d/s/DC2/embed/media-2.xlsx",
+    }
+    assert all(entry["status"] == "listed" for entry in listed)
+
+
+def test_page_parse_finds_nothing_in_a_page_without_supplements() -> None:
+    assert fetch.parse_supplement_page("<html><body>no supplements here</body></html>") == []
+
+
+def test_listing_declines_a_doi_the_preprint_server_does_not_host(monkeypatch) -> None:
+    """The metadata lookup is the test of what a preprint is — not the prefix."""
+    monkeypatch.setattr(fetch, "biorxiv_metadata", lambda doi: None)
+
+    assert fetch.biorxiv_listing("10.1126/science.adx0659") == []
+
+
+def test_listing_uses_the_version_the_metadata_reports(monkeypatch) -> None:
+    requested = _serve_preprint(monkeypatch)
+
+    fetch.biorxiv_listing(PREPRINT_DOI)
+
+    assert requested[0].endswith(f"{PREPRINT_DOI}v2.supplementary-material")
+
+
+def test_preprint_supplements_are_retrieved_without_a_pmc_record(
+    tmp_path: Path, monkeypatch
+) -> None:
+    _serve_preprint(monkeypatch)
+
+    with _client(_no_pmc_handler()) as client:
+        manifest = fetch.fetch_supplements(tmp_path, PREPRINT_DOI, client=client)
+
+    assert {f["file_id"] for f in manifest["files"]} == {"media-1.docx", "media-2.xlsx"}
+    for entry in manifest["files"]:
+        assert entry["status"] == "present"
+        assert entry["retrieval"]["route"] == "biorxiv"
+        assert (tmp_path / entry["path"]).stat().st_size == entry["size_bytes"]
+    assert manifest["gaps"] == []
+    store.validate_manifest(manifest)
+    assert store.cross_check_manifest(manifest) == []
+
+
+def test_an_unreadable_preprint_page_still_leaves_the_manual_route(
+    tmp_path: Path, monkeypatch
+) -> None:
+    _serve_preprint(monkeypatch, page=None)
+
+    with _client(_no_pmc_handler()) as client:
+        manifest = fetch.fetch_supplements(tmp_path, PREPRINT_DOI, client=client)
+
+    assert manifest["files"] == []
+    assert "no PMC record" in manifest["gaps"][0]["reason"]
+
+
+def test_a_listed_file_that_will_not_download_becomes_a_gap(tmp_path: Path, monkeypatch) -> None:
+    _serve_preprint(monkeypatch, files=False)
+
+    with _client(_no_pmc_handler()) as client:
+        manifest = fetch.fetch_supplements(tmp_path, PREPRINT_DOI, client=client)
+
+    assert all(f["status"] == "failed" for f in manifest["files"])
+    assert all(f["retrieval"]["attempted_at"] for f in manifest["files"])
+    assert {gap["file_id"] for gap in manifest["gaps"]} == {"media-1.docx", "media-2.xlsx"}
+    store.validate_manifest(manifest)
+
+
+def test_a_second_run_refetches_neither_the_page_nor_the_files(tmp_path: Path, monkeypatch) -> None:
+    requested = _serve_preprint(monkeypatch)
+
+    with _client(_no_pmc_handler()) as client:
+        fetch.fetch_supplements(tmp_path, PREPRINT_DOI, client=client)
+        first = len(requested)
+        fetch.fetch_supplements(tmp_path, PREPRINT_DOI, client=client)
+
+    assert first == 3, "the page, then one request per file"
+    assert len(requested) == first + 1, "only the page is read again"
+
+
+def test_corrupt_preprint_bytes_are_not_left_on_disk(tmp_path: Path, monkeypatch) -> None:
+    """Storing an unopenable file would poison indexing later."""
+    _serve_preprint(monkeypatch)
+    served = fetch.biorxiv_get
+
+    def truncated(url: str) -> tuple[bytes | None, str]:
+        if url.endswith(".supplementary-material"):
+            return served(url)
+        return b"PK\x03\x04truncated", "ok"
+
+    monkeypatch.setattr(fetch, "biorxiv_get", truncated)
+
+    with _client(_no_pmc_handler()) as client:
+        manifest = fetch.fetch_supplements(tmp_path, PREPRINT_DOI, client=client)
+
+    assert all(f["status"] == "failed" for f in manifest["files"])
+    assert all("path" not in f for f in manifest["files"])
+    assert not list((tmp_path / "papers").rglob("media-*"))


### PR DESCRIPTION
A preprint has no Europe PMC record, so every rung of the fetch waterfall failed and the paper was recorded as a manual gap — for the reproductive project that meant the atlas paper itself, the one whose supplements matter most, was the only paper in the corpus never attempted by any route.

The preprint server serves them. This adds a `biorxiv` rung that does double duty: the supplementary-material page provides both the listing, with the author'''s own labels in place of the JATS listing, and the bytes.

## How it decides a paper is a preprint

By lookup, not by prefix. `biorxiv_listing` asks the details API, and a DOI the server does not host returns no collection — that is the test. The same response yields the version number the content URL needs. This matters because preprint DOIs are no longer all under one prefix; the atlas paper here is `10.64898/...`, and prefix matching would have missed it. `fetch_preprint._biorxiv_metadata` was made public and reused rather than writing a second lookup.

## Transport

**Plain httpx is not sufficient, and it looks as though it is.** A first request returns 200; subsequent ones — page and media alike — come back as HTTP 429 Cloudflare challenges. The route uses `curl_cffi` with Chrome impersonation, the same approach and the same optional `[text-access]` extra that `fetch_preprint` already relies on. Anyone re-testing by hand should know the first probe is misleading.

No playwright fallback: curl_cffi answered every request in testing, and a second fallback for one host is complexity nobody has needed. Without curl_cffi installed the route records a note and the paper degrades to the existing manual gap rather than failing silently.

## Verification

- 12 new unit tests with both network boundaries monkeypatched: page parsing, version selection, end-to-end retrieval with no PMC record, an unreadable page falling back to the manual gap, a per-file download failure becoming a gap, the negative cache on a second run, and corrupt bytes not being left on disk. 453 unit tests pass overall.
- 6 live tests against the real server, no skips — if the API or the page shape changes they fail. All seven supplements of the atlas preprint are retrieved, verified, schema-valid, with zero gaps, and the workbooks outline cleanly.
- One existing test needed a monkeypatch so it no longer reaches the network, now that the no-PMC branch tries the preprint server.

`Retrieval.route` gains `biorxiv`; `docs/pipeline.md` updated alongside.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
