### PR TITLE
Choose cell types by finding the node, not by matching the name

### DIFF
--- a/.claude/agents/read-atlas-paper.md
+++ b/.claude/agents/read-atlas-paper.md
@@ -45,7 +45,7 @@ them and read what they report.
 **Where things are.**
 
 ```bash
-uv run python -m atlas_chat.cli_project --project <project>
+uv run python -m atlas_chat.cli_project paths --project <project>
 ```
 
 This gives you the project directory, its CAS+ document, the atlas DOI, the

--- a/.claude/skills/select-cell-types/SKILL.md
+++ b/.claude/skills/select-cell-types/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: select-cell-types
+description: Turn a request for reports — "all macrophages", "just the L3 ones", a single label — into the list of cell types to read for, by reading the atlas's annotation hierarchy rather than its annotations. Use when a user asks for reports and has not named exact labels.
+---
+
+# Skill: select cell types
+
+A request for reports names cell types the way a person would, and the atlas
+names them the way its authors did. Closing that gap is a judgement, and this
+is where it is made — before a long run rather than during one.
+
+## Do not load the annotations
+
+A CAS+ document is mostly `composition`: the breakdown of every descriptor over
+every cell. On a real atlas that is millions of tokens, and none of it says what
+a cell type is called or where it sits.
+
+Load the hierarchy instead:
+
+```bash
+uv run python -m atlas_chat.cli_project outline --project <project> [--synonyms]
+```
+
+One line per annotation — labelset, label, full name, parent, cell count — at
+roughly a two-hundredth of the size. Read it whole.
+
+## Which project
+
+```bash
+uv run python -m atlas_chat.cli_project paths --project <project>
+```
+
+Where `projects/` holds exactly one project, use it without asking. Where it
+holds several, list them and ask. A project filed in a subdirectory is named
+with it, `test_projects/<name>`: a bare name never reaches past `projects/`,
+because a test project standing in for a working atlas of the same name is not
+a mistake anyone would catch by reading the output.
+
+## Find the node, then take what is under it
+
+**Text matching alone is not enough, and fails quietly.** A cell type's label
+need not contain the word for what it is, and siblings' labels need not
+resemble each other. Asking for macrophages on one real atlas:
+
+| | |
+|---|---|
+| substring over the label alone | 1 of 7 |
+| substring over label, full name and synonyms | 7 |
+| the subtree under the population called `Macrophages` | its 6 children, exactly |
+
+Two of those six are named for where they are and what they contain, and say
+nothing about being macrophages. A match would drop them and return an answer
+that looks right.
+
+So: **find candidate roots by text, then take the subtree.** `--under <label>`
+does the second part. Fall back to a flat match only when nothing resolves to a
+node — and say that you have.
+
+For the same reason, **do not narrow before loading**. `--match` and
+`--labelset` are for an atlas too large to read whole; used routinely they hide
+the structure that makes the subtree visible.
+
+## Say what you decided, and check
+
+The request is vague on purpose, so answering it means making calls the user did
+not make. State them:
+
+- whether a parent is included as well as its children — "all macrophages" may
+  mean the six subtypes, or those plus the population they belong to;
+- anything left out as a cell state rather than a cell type;
+- anything included on a resemblance you are not sure of.
+
+**Then show the selection — labels and cell counts — and wait.** A count is
+often what tells someone they did not mean to include something, and a
+selection governs everything downstream: getting it wrong is discovered when
+the reports come back.
+
+Record the request and what it resolved to alongside the run, so the judgement
+can be reviewed later rather than reconstructed.
+
+## Then
+
+Hand the labels to the reading step. It takes a project and a list of cell
+types and assembles everything else itself.

--- a/docs/pipeline.md
+++ b/docs/pipeline.md
@@ -143,6 +143,20 @@ Prompt: `agents/supplementary_scanner.prompt.yaml`. Output:
 `schemas/supplementary_findings.schema.json`. Declares its output schema in
 front-matter, but no validator hook is registered for it.
 
+## 5a. Choosing which cell types to report on
+
+A request names cell types the way a person would; the atlas names them the way
+its authors did. The `select-cell-types` skill closes that gap in the
+orchestrator's own context, because it is a judgement that has to be put to the
+user rather than guessed at.
+
+It reads `cli_project outline` — the annotation hierarchy, at roughly a
+two-hundredth of the size of the CAS+ document, whose bulk is composition — and
+resolves a request by finding a node and taking its subtree. Text matching alone
+is not sufficient and fails quietly: on the reference project, asking for
+macrophages by label alone finds one of seven, because two of the six subtypes
+are named for where they are and say nothing about being macrophages.
+
 ## 6a. Reading a paper whole
 
 `read-atlas-paper` (opus) is given a project name and the cell types to read
@@ -316,7 +330,7 @@ Everything reusable is callable without a Claude Code session:
 
 | Command | What it does |
 | --- | --- |
-| `python -m atlas_chat.cli_project` | a project's paths, from its name under `projects/` |
+| `python -m atlas_chat.cli_project` | `paths`: a project's locations, from its name under `projects/`. `outline`: its annotation hierarchy |
 | `python -m atlas_chat.cli_paper_ingest` | a paper plus its indexed supplementary prose, assembled for reading |
 | `python -m atlas_chat.cli_subject_block` | what a reader is told about a cell set, from CAS+ |
 | `python -m atlas_chat.cli_supplement_prose` | supplementary prose: units, record, cas-uptake |

--- a/src/atlas_chat/atlas_chat/services/project_paths.py
+++ b/src/atlas_chat/atlas_chat/services/project_paths.py
@@ -169,27 +169,149 @@ def resolve(
     return paths
 
 
+# ------------------------------------------------------------------
+# The annotation hierarchy, small enough to read
+# ------------------------------------------------------------------
+
+#: Columns of the outline, in order.
+OUTLINE_COLUMNS = ("labelset", "label", "full name", "parent", "cells", "synonyms")
+
+
+def _searchable(annotation: dict[str, Any]) -> str:
+    parts = [annotation.get("cell_label", ""), annotation.get("cell_fullname") or ""]
+    parts.extend(annotation.get("synonyms") or [])
+    return " ".join(parts).lower()
+
+
+def _descendants(root: str, by_parent: dict[str, list[dict[str, Any]]]) -> list[dict[str, Any]]:
+    out: list[dict[str, Any]] = []
+    stack = list(by_parent.get(root, []))
+    while stack:
+        node = stack.pop()
+        out.append(node)
+        stack.extend(by_parent.get(node.get("cell_set_accession") or "", []))
+    return out
+
+
+def outline(
+    cas: dict[str, Any],
+    *,
+    labelset: str | None = None,
+    match: str | None = None,
+    under: str | None = None,
+    synonyms: bool = False,
+) -> str:
+    """The annotation hierarchy as lines, without the composition that dwarfs it.
+
+    A CAS+ document is mostly the breakdown of every descriptor over every cell,
+    which says nothing about what a cell type is called or where it sits. What is
+    left is small enough to read, and reading it is what lets a vague request —
+    all the macrophages, only the ones at this level — be answered by judgement
+    rather than by pattern.
+
+    The parent is here because matching on text alone is not enough: a cell type's
+    label need not contain the word for what it is, and its siblings' labels need
+    not resemble each other. Finding a node by name and taking what sits under it
+    catches those; a substring does not.
+
+    Args:
+        cas: the CAS+ document.
+        labelset: keep only this level.
+        match: keep annotations whose label, full name or synonyms contain this.
+        under: keep everything beneath the annotation with this label.
+        synonyms: include them in the output.
+
+    Returns:
+        A header line and one line per annotation, tab-separated, in document
+        order. Empty where a field is absent, so the columns stay aligned.
+    """
+    annotations = cas.get("annotations") or []
+    by_accession = {
+        a.get("cell_set_accession"): a for a in annotations if a.get("cell_set_accession")
+    }
+    by_parent: dict[str, list[dict[str, Any]]] = {}
+    for a in annotations:
+        by_parent.setdefault(a.get("parent_cell_set_accession") or "", []).append(a)
+
+    kept = list(annotations)
+    if under:
+        roots = [a for a in annotations if a.get("cell_label") == under]
+        wanted = {
+            id(a)
+            for root in roots
+            for a in _descendants(root.get("cell_set_accession") or "", by_parent)
+        }
+        kept = [a for a in kept if id(a) in wanted]
+    if labelset:
+        kept = [a for a in kept if a.get("labelset") == labelset]
+    if match:
+        needle = match.lower()
+        kept = [a for a in kept if needle in _searchable(a)]
+
+    columns = OUTLINE_COLUMNS if synonyms else OUTLINE_COLUMNS[:-1]
+    lines = ["\t".join(columns)]
+    for a in kept:
+        parent = by_accession.get(a.get("parent_cell_set_accession") or "")
+        fullname = a.get("cell_fullname") or ""
+        row = [
+            a.get("labelset", ""),
+            a.get("cell_label", ""),
+            "" if fullname == a.get("cell_label") else fullname,
+            parent.get("cell_label", "") if parent else "",
+            str(a.get("n_cells", "")),
+        ]
+        if synonyms:
+            row.append(";".join(a.get("synonyms") or []))
+        lines.append("\t".join(row))
+    return "\n".join(lines)
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="python -m atlas_chat.cli_project",
-        description="Resolve a project's paths from its name.",
+        description="A project's paths, and its annotation hierarchy.",
     )
-    parser.add_argument(
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    common = argparse.ArgumentParser(add_help=False)
+    common.add_argument(
         "--project",
         required=True,
         help="project directory under projects/, e.g. test_projects/<name>, or a path",
     )
-    parser.add_argument("--repo-root", help="checkout to look in; default the working directory")
-    parser.add_argument("--corpus-root", help=f"default {CORPUS_ENV}")
+    common.add_argument("--repo-root", help="checkout to look in; default the working directory")
+
+    paths = sub.add_parser("paths", parents=[common], help="where the project's things are")
+    paths.add_argument("--corpus-root", help=f"default {CORPUS_ENV}")
+
+    out = sub.add_parser("outline", parents=[common], help="the annotation hierarchy")
+    out.add_argument("--labelset", help="keep only this level")
+    out.add_argument("--match", help="keep annotations whose label, full name or synonyms match")
+    out.add_argument("--under", help="keep everything beneath this annotation")
+    out.add_argument("--synonyms", action="store_true", help="include synonyms")
     return parser
 
 
 def main(argv: list[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
+    root = Path(args.repo_root) if args.repo_root else None
     try:
+        if args.command == "outline":
+            project_dir = find_project(args.project, root or Path.cwd())
+            cas = json.loads((project_dir / "cas.json").read_text(encoding="utf-8"))
+            print(
+                outline(
+                    cas,
+                    labelset=args.labelset,
+                    match=args.match,
+                    under=args.under,
+                    synonyms=args.synonyms,
+                )
+            )
+            return 0
         paths = resolve(
             args.project,
-            repo_root=Path(args.repo_root) if args.repo_root else None,
+            repo_root=root,
             corpus_root=Path(args.corpus_root) if args.corpus_root else None,
         )
     except ProjectNotFound as exc:

--- a/tests/unit/test_project_paths.py
+++ b/tests/unit/test_project_paths.py
@@ -139,12 +139,122 @@ def test_the_traversal_directory_is_created(tmp_path):
 def test_cli_prints_the_paths(tmp_path, capsys):
     d = _project(tmp_path, "a")
     _paper(d)
-    assert main(["--project", "a", "--repo-root", str(tmp_path)]) == 0
+    assert main(["paths", "--project", "a", "--repo-root", str(tmp_path)]) == 0
     out = json.loads(capsys.readouterr().out)
     assert out["doi"] == DOI
     assert out["paper_text"].endswith("paper.jats.xml")
 
 
 def test_cli_exits_nonzero_for_an_unknown_project(tmp_path, capsys):
-    assert main(["--project", "nope", "--repo-root", str(tmp_path)]) == 2
+    assert main(["paths", "--project", "nope", "--repo-root", str(tmp_path)]) == 2
     assert "no cas.json" in capsys.readouterr().out
+
+
+# --- the annotation hierarchy ------------------------------------------------
+
+
+def _hierarchy(tmp_path: Path) -> dict:
+    """A parent with two children, one of which does not say what it is."""
+    return {
+        "source": {"doi": DOI},
+        "annotations": [
+            {
+                "labelset": "L3",
+                "cell_label": "Macrophages",
+                "cell_set_accession": "M",
+                "n_cells": 100,
+                "synonyms": ["Mac"],
+            },
+            {
+                "labelset": "L4",
+                "cell_label": "Immune_Mac_LYVE1hi",
+                "cell_fullname": "Macrophages LYVE1+",
+                "cell_set_accession": "A",
+                "parent_cell_set_accession": "M",
+                "n_cells": 60,
+            },
+            {
+                "labelset": "L4",
+                "cell_label": "Immune_oLAM",
+                "cell_fullname": "Ovarian lipid-associated macrophages",
+                "cell_set_accession": "B",
+                "parent_cell_set_accession": "M",
+                "n_cells": 40,
+            },
+        ],
+    }
+
+
+def _labels(text: str) -> list[str]:
+    return [line.split("\t")[1] for line in text.splitlines()[1:]]
+
+
+def test_the_outline_has_a_line_per_annotation_and_a_header(tmp_path):
+    from atlas_chat.services.project_paths import outline
+
+    text = outline(_hierarchy(tmp_path))
+    assert text.splitlines()[0].startswith("labelset\tlabel")
+    assert _labels(text) == ["Macrophages", "Immune_Mac_LYVE1hi", "Immune_oLAM"]
+
+
+def test_a_full_name_identical_to_the_label_is_left_blank(tmp_path):
+    from atlas_chat.services.project_paths import outline
+
+    row = outline(_hierarchy(tmp_path)).splitlines()[1].split("\t")
+    assert row[1] == "Macrophages"
+    assert row[2] == ""
+
+
+def test_the_parent_is_named_so_a_subtree_is_visible(tmp_path):
+    from atlas_chat.services.project_paths import outline
+
+    rows = [line.split("\t") for line in outline(_hierarchy(tmp_path)).splitlines()[1:]]
+    assert {r[3] for r in rows if r[1].startswith("Immune")} == {"Macrophages"}
+
+
+def test_matching_the_label_alone_would_miss_most_of_them(tmp_path):
+    """The reason selection resolves to a subtree rather than a match: a cell
+    type's label need not contain the word for what it is."""
+    from atlas_chat.services.project_paths import outline
+
+    by_label = [
+        a["cell_label"]
+        for a in _hierarchy(tmp_path)["annotations"]
+        if "macrophage" in a["cell_label"].lower()
+    ]
+    assert by_label == ["Macrophages"]
+    assert _labels(outline(_hierarchy(tmp_path), under="Macrophages")) == [
+        "Immune_Mac_LYVE1hi",
+        "Immune_oLAM",
+    ]
+
+
+def test_match_covers_the_full_name_and_synonyms(tmp_path):
+    from atlas_chat.services.project_paths import outline
+
+    assert len(_labels(outline(_hierarchy(tmp_path), match="macrophage"))) == 3
+    assert _labels(outline(_hierarchy(tmp_path), match="mac")) == [
+        "Macrophages",
+        "Immune_Mac_LYVE1hi",
+        "Immune_oLAM",
+    ]
+
+
+def test_a_labelset_narrows_to_one_level(tmp_path):
+    from atlas_chat.services.project_paths import outline
+
+    assert _labels(outline(_hierarchy(tmp_path), labelset="L3")) == ["Macrophages"]
+
+
+def test_synonyms_are_left_out_unless_asked_for(tmp_path):
+    from atlas_chat.services.project_paths import outline
+
+    assert "synonyms" not in outline(_hierarchy(tmp_path)).splitlines()[0]
+    assert "Mac" in outline(_hierarchy(tmp_path), synonyms=True).splitlines()[1]
+
+
+def test_cli_outline_prints_the_hierarchy(tmp_path, capsys):
+    d = _project(tmp_path, "a")
+    (d / "cas.json").write_text(json.dumps(_hierarchy(tmp_path)))
+    assert main(["outline", "--project", "a", "--repo-root", str(tmp_path)]) == 0
+    assert "Immune_oLAM" in capsys.readouterr().out


### PR DESCRIPTION
Implements the near-term half of #64. **Stacked on #63** — `cli_project` arrives there, so review that first and this diff will shrink once it merges.

A request for reports says "all the macrophages". The atlas says `Immune_uftLAM`. Something has to close that gap, and until now it was closed by hand.

## Read the hierarchy, not the annotations

A CAS+ document is mostly `composition` — every descriptor over every cell — which says nothing about what a cell type is called or where it sits. On the reference project:

| | |
|---|---|
| `cas.json` | ~1.5M tokens |
| the hierarchy alone | **~5,600 tokens** |

`cli_project` gains `outline`: one line per annotation — labelset, label, full name, parent, cell count, synonyms on request.

## The parent is the point

Matching on text alone fails, and fails quietly. Asking for macrophages on the reference project:

| method | finds |
|---|---|
| substring over the **label** | **1 of 7** |
| substring over label, full name and synonyms | 7 |
| the **subtree** under `Macrophages` | its 6 children, exactly |

`Immune_uftLAM` and `Immune_oLAM` are macrophages named for where they are and what they contain; their labels never say what they are. A match drops them and returns something that looks right — worse than returning nothing. Two of the five cell types in the first planned run are in that pair.

So the method is **find a node by name, then take its subtree** (`--under`), falling back to a flat match only where nothing resolves to a node, and saying so. For the same reason the outline is read **whole**: `--match` and `--labelset` are for an atlas too large to hold, and used routinely they hide the structure that makes the subtree visible.

## A skill, in the orchestrator's context

`.claude/skills/select-cell-types/`. Not a subagent, and the reason is not context cost — the request is vague *on purpose*, so answering it means making calls the user did not make: whether a parent belongs alongside its children, whether a cycling subpopulation is a type or a state. Those go to the user, and a subagent cannot ask.

It shows the labels with their cell counts and waits. A count is usually what tells someone they did not mean to include something.

`CLAUDE.md` on the #61 branch gains the trigger, separately pushed there.

## Verification

- 551 unit tests, 8 new, including one pinning the failure this is built around: label-only matching finds one of three in a fixture where two children are named for their tissue.
- ruff clean, `docs/pipeline.md` updated with a new step 5a and the CLI table.
- Tried against the real project: `outline --match macrophage --synonyms` returns the six subtypes and their parent, with counts from 321 to 47,280.

## Not here

The composition half of #64 — restricting on "in adult tissue" — is #66 and deliberately deferred. `cli_project paths` gained a subcommand, so the invocation in `read-atlas-paper` is updated from `--project X` to `paths --project X`.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
